### PR TITLE
Add missing length check when reading label pointer

### DIFF
--- a/dnsutils/dns.go
+++ b/dnsutils/dns.go
@@ -342,6 +342,9 @@ func _ParseLabels(offset int, payload []byte, pointers map[uint16]int) (string, 
 		}
 		// label pointer support ?
 		if length>>6 == 3 {
+			if offset+1 >= len(payload) {
+				return "", 0, ErrDecodeDnsLabelTooShort
+			}
 			ptr := binary.BigEndian.Uint16(payload[offset:offset+2]) & 16383
 			_, exist := pointers[ptr]
 			if exist {

--- a/dnsutils/dns_test.go
+++ b/dnsutils/dns_test.go
@@ -360,6 +360,14 @@ func TestDecodeDnsQuestion_QtypeMissing(t *testing.T) {
 	}
 }
 
+func TestDecodeQuestion_InvalidPointer(t *testing.T) {
+	decoded := []byte{88, 27, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 202}
+	_, _, _, err := DecodeQuestion(decoded)
+	if !errors.Is(err, ErrDecodeDnsLabelTooShort) {
+		t.Errorf("bad error returned: %v", err)
+	}
+}
+
 func TestDecodeDnsAnswer_PacketTooShort(t *testing.T) {
 	payload := []byte{46, 172, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 15, 100, 110, 115, 116, 97, 112, 99, 111, 108, 108, 101, 99, 116,
 		111, 114, 4, 116, 101, 115, 116, 0, 0, 1, 0, 1, 15, 100, 110, 115, 116, 97, 112, 99, 111, 108, 108, 101, 99, 116,


### PR DESCRIPTION
Fixes slice bounds out of range panic when parsing invalid DNS packet containing only first byte of label pointer. 

Add unit test verifying that invalid label pointer is now detected and error is returned when it is being parsed. 
