### PR TITLE
A bit of refactoring for DNS packet decoding

### DIFF
--- a/dnsutils/dns_test.go
+++ b/dnsutils/dns_test.go
@@ -54,7 +54,7 @@ func TestDecodeQuestion(t *testing.T) {
 	dm.SetQuestion(fqdn, dns.TypeA)
 	payload, _ := dm.Pack()
 
-	qname, qtype, offset_rr, _ := DecodeQuestion(payload)
+	qname, qtype, offset_rr, _ := DecodeQuestion(1, payload)
 	if qname+"." != fqdn {
 		t.Errorf("invalid qname: %s", qname)
 	}
@@ -83,7 +83,7 @@ func TestDecodeAnswer_Ns(t *testing.T) {
 	m.Ns = append(m.Ns, rrNs)
 
 	payload, _ := m.Pack()
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	_, offset_rrns, _ := DecodeAnswer(len(dm.Answer), offset_rr, payload)
 
 	nsAnswers, _, _ := DecodeAnswer(len(m.Ns), offset_rrns, payload)
@@ -104,7 +104,7 @@ func TestDecodeAnswer(t *testing.T) {
 
 	payload, _ := dm.Pack()
 
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	answer, _, _ := DecodeAnswer(len(dm.Answer), offset_rr, payload)
 
 	if len(answer) != len(dm.Answer) {
@@ -126,7 +126,7 @@ func TestDecodeAnswer_QnameMinimized(t *testing.T) {
 		0xc0, 0x7e, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x09, 0x00, 0x04, 0x34, 0x71, 0xc3,
 		0x84, 0x00, 0x00, 0x29, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	_, _, err := DecodeAnswer(4, offset_rr, payload)
 	if err != nil {
 		t.Errorf("failed to decode valid dns packet with minimization")
@@ -145,7 +145,7 @@ func TestDecodeRdataA(t *testing.T) {
 
 	payload, _ := dm.Pack()
 
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	answer, _, _ := DecodeAnswer(len(dm.Answer), offset_rr, payload)
 
 	if answer[0].Rdata != rdata {
@@ -176,7 +176,7 @@ func TestDecodeRdataA_Short(t *testing.T) {
 		// RDATA (1 byte too short for A record)
 		0x7f, 0x00, 0x00,
 	}
-	_, _, offsetrr, err := DecodeQuestion(payload)
+	_, _, offsetrr, err := DecodeQuestion(1, payload)
 	if err != nil {
 		t.Errorf("Unexpected error decoding question: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestDecodeRdataAAAA(t *testing.T) {
 
 	payload, _ := dm.Pack()
 
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	answer, _, _ := DecodeAnswer(len(dm.Answer), offset_rr, payload)
 
 	if answer[0].Rdata != rdata {
@@ -233,7 +233,7 @@ func TestDecodeRdataAAAA_Short(t *testing.T) {
 		0x00, 0x00, 0x00,
 	}
 
-	_, _, offsetset_rr, err := DecodeQuestion(payload)
+	_, _, offsetset_rr, err := DecodeQuestion(1, payload)
 	if err != nil {
 		t.Errorf("unexpected error while decoding question: %v", err)
 	}
@@ -255,7 +255,7 @@ func TestDecodeRdataCNAME(t *testing.T) {
 
 	payload, _ := dm.Pack()
 
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	answer, _, _ := DecodeAnswer(len(dm.Answer), offset_rr, payload)
 
 	if answer[0].Rdata != rdata {
@@ -275,7 +275,7 @@ func TestDecodeRdataMX(t *testing.T) {
 
 	payload, _ := dm.Pack()
 
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	answer, _, _ := DecodeAnswer(len(dm.Answer), offset_rr, payload)
 
 	if answer[0].Rdata != rdata {
@@ -307,7 +307,7 @@ func TestDecodeRdataMX_Short(t *testing.T) {
 		// RDATA
 		0x00,
 	}
-	_, _, offset_rr, err := DecodeQuestion(payload)
+	_, _, offset_rr, err := DecodeQuestion(1, payload)
 	if err != nil {
 		t.Errorf("unexpected error while decoding question: %v", err)
 	}
@@ -342,7 +342,7 @@ func TestDecodeRdataMX_Minimal(t *testing.T) {
 		// RDATA
 		0x00, 0x00, 0x00,
 	}
-	_, _, offset_rr, err := DecodeQuestion(payload)
+	_, _, offset_rr, err := DecodeQuestion(1, payload)
 	if err != nil {
 		t.Errorf("unexpected error while decoding question: %v", err)
 	}
@@ -368,7 +368,7 @@ func TestDecodeRdataSRV(t *testing.T) {
 
 	payload, _ := dm.Pack()
 
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	answer, _, _ := DecodeAnswer(len(dm.Answer), offset_rr, payload)
 
 	if answer[0].Rdata != rdata {
@@ -405,7 +405,7 @@ func TestDecodeRdataSRV_Short(t *testing.T) {
 		// missing port and target
 	}
 
-	_, _, offset_rr, err := DecodeQuestion(payload)
+	_, _, offset_rr, err := DecodeQuestion(1, payload)
 	if err != nil {
 		t.Errorf("unexpected error while decoding question: %v", err)
 	}
@@ -447,7 +447,7 @@ func TestDecodeRdataSRV_Minimal(t *testing.T) {
 		0x00,
 	}
 
-	_, _, offset_rr, err := DecodeQuestion(payload)
+	_, _, offset_rr, err := DecodeQuestion(1, payload)
 	if err != nil {
 		t.Errorf("unexpected error while decoding question: %v", err)
 	}
@@ -472,7 +472,7 @@ func TestDecodeRdataNS(t *testing.T) {
 
 	payload, _ := dm.Pack()
 
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	answer, _, _ := DecodeAnswer(len(dm.Answer), offset_rr, payload)
 
 	if answer[0].Rdata != rdata {
@@ -492,7 +492,7 @@ func TestDecodeRdataTXT(t *testing.T) {
 
 	payload, _ := dm.Pack()
 
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	answer, _, _ := DecodeAnswer(len(dm.Answer), offset_rr, payload)
 
 	if answer[0].Rdata != rdata {
@@ -524,7 +524,7 @@ func TestDecodeRdataTXT_Empty(t *testing.T) {
 		// no data
 	}
 
-	_, _, offset_rr, err := DecodeQuestion(payload)
+	_, _, offset_rr, err := DecodeQuestion(1, payload)
 	if err != nil {
 		t.Errorf("unexpected error while decoding question: %v", err)
 	}
@@ -564,7 +564,7 @@ func TestDecodeRdataTXT_Short(t *testing.T) {
 		// missing two bytes
 	}
 
-	_, _, offset_rr, err := DecodeQuestion(payload)
+	_, _, offset_rr, err := DecodeQuestion(1, payload)
 	if err != nil {
 		t.Errorf("unexpected error while decoding question: %v", err)
 	}
@@ -601,7 +601,7 @@ func TestDecodeRdataTXT_NoTxt(t *testing.T) {
 		// no txt-data
 	}
 
-	_, _, offset_rr, err := DecodeQuestion(payload)
+	_, _, offset_rr, err := DecodeQuestion(1, payload)
 	if err != nil {
 		t.Errorf("unexpected error while decoding question: %v", err)
 	}
@@ -628,7 +628,7 @@ func TestDecodeRdataPTR(t *testing.T) {
 
 	payload, _ := dm.Pack()
 
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	answer, _, _ := DecodeAnswer(len(dm.Answer), offset_rr, payload)
 
 	if answer[0].Rdata != rdata {
@@ -648,7 +648,7 @@ func TestDecodeRdataSOA(t *testing.T) {
 
 	payload, _ := dm.Pack()
 
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	answer, _, _ := DecodeAnswer(len(dm.Answer), offset_rr, payload)
 
 	if answer[0].Rdata != rdata {
@@ -698,7 +698,7 @@ func TestDecodeRdataSOA_Short(t *testing.T) {
 		// minimum -field missing from the RDATA
 	}
 
-	_, _, offsset_rr, err := DecodeQuestion(payload)
+	_, _, offsset_rr, err := DecodeQuestion(1, payload)
 	if err != nil {
 		t.Errorf("Unable to decode question: %v", err)
 	}
@@ -715,7 +715,7 @@ func TestDecodeRdataSOA_Minimization(t *testing.T) {
 		51, 3, 111, 118, 104, 3, 110, 101, 116, 0, 4, 116, 101, 99, 104, 192, 53,
 		120, 119, 219, 34, 0, 1, 81, 128, 0, 0, 14, 16, 0, 54, 238, 128, 0, 0, 0, 60}
 
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	_, _, err := DecodeAnswer(1, offset_rr, payload)
 	if err != nil {
 		t.Errorf(" error returned: %v", err)
@@ -757,7 +757,7 @@ func TestDecodeQuestion_SkipOpt(t *testing.T) {
 		// RDATA
 		0x7f, 0x00, 0x00, 0x01,
 	}
-	_, _, offsetrr, err := DecodeQuestion(payload)
+	_, _, offsetrr, err := DecodeQuestion(1, payload)
 	if err != nil {
 		t.Errorf("Unexpected error decoding question: %v", err)
 	}
@@ -784,7 +784,7 @@ func TestDecodeDns_HeaderTooShort(t *testing.T) {
 
 func TestDecodeDnsQuestion_InvalidOffset(t *testing.T) {
 	decoded := []byte{183, 59, 130, 217, 128, 16, 0, 51, 165, 67, 0, 0}
-	_, _, _, err := DecodeQuestion(decoded)
+	_, _, _, err := DecodeQuestion(1, decoded)
 	if !errors.Is(err, ErrDecodeDnsLabelTooShort) {
 		t.Errorf("bad error returned: %v", err)
 	}
@@ -792,7 +792,7 @@ func TestDecodeDnsQuestion_InvalidOffset(t *testing.T) {
 
 func TestDecodeDnsQuestion_PacketTooShort(t *testing.T) {
 	decoded := []byte{183, 59, 130, 217, 128, 16, 0, 51, 165, 67, 0, 0, 1, 1, 8, 10, 23}
-	_, _, _, err := DecodeQuestion(decoded)
+	_, _, _, err := DecodeQuestion(1, decoded)
 	if !errors.Is(err, ErrDecodeDnsLabelTooShort) {
 		t.Errorf("bad error returned: %v", err)
 	}
@@ -801,7 +801,7 @@ func TestDecodeDnsQuestion_PacketTooShort(t *testing.T) {
 func TestDecodeDnsQuestion_QtypeMissing(t *testing.T) {
 	decoded := []byte{88, 27, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 15, 100, 110, 115, 116, 97, 112,
 		99, 111, 108, 108, 101, 99, 116, 111, 114, 4, 116, 101, 115, 116, 0}
-	_, _, _, err := DecodeQuestion(decoded)
+	_, _, _, err := DecodeQuestion(1, decoded)
 	if !errors.Is(err, ErrDecodeQuestionQtypeTooShort) {
 		t.Errorf("bad error returned: %v", err)
 	}
@@ -809,7 +809,7 @@ func TestDecodeDnsQuestion_QtypeMissing(t *testing.T) {
 
 func TestDecodeQuestion_InvalidPointer(t *testing.T) {
 	decoded := []byte{88, 27, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 202}
-	_, _, _, err := DecodeQuestion(decoded)
+	_, _, _, err := DecodeQuestion(1, decoded)
 	if !errors.Is(err, ErrDecodeDnsLabelTooShort) {
 		t.Errorf("bad error returned: %v", err)
 	}
@@ -820,7 +820,7 @@ func TestDecodeDnsAnswer_PacketTooShort(t *testing.T) {
 		111, 114, 4, 116, 101, 115, 116, 0, 0, 1, 0, 1, 15, 100, 110, 115, 116, 97, 112, 99, 111, 108, 108, 101, 99, 116,
 		111, 114, 4, 116, 101, 115, 116, 0, 0, 1, 0, 1, 0, 0, 14, 16, 0}
 
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	_, _, err := DecodeAnswer(1, offset_rr, payload)
 	if !errors.Is(err, ErrDecodeDnsAnswerTooShort) {
 		t.Errorf("bad error returned: %v", err)
@@ -902,7 +902,7 @@ func TestDecodeDnsAnswer_RdataTooShort(t *testing.T) {
 		111, 114, 4, 116, 101, 115, 116, 0, 0, 1, 0, 1, 15, 100, 110, 115, 116, 97, 112, 99, 111, 108, 108, 101, 99, 116,
 		111, 114, 4, 116, 101, 115, 116, 0, 0, 1, 0, 1, 0, 0, 14, 16, 0, 4, 127, 0}
 
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	_, _, err := DecodeAnswer(1, offset_rr, payload)
 	if !errors.Is(err, ErrDecodeDnsAnswerRdataTooShort) {
 		t.Errorf("bad error returned: %v", err)
@@ -914,7 +914,7 @@ func TestDecodeDnsAnswer_InvalidPtr(t *testing.T) {
 		109, 99, 104, 100, 2, 109, 101, 0, 0, 1, 0, 1, 192, 254, 0, 1, 0, 1, 0, 0,
 		14, 16, 0, 4, 83, 112, 146, 176}
 
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	_, _, err := DecodeAnswer(1, offset_rr, payload)
 	if !errors.Is(err, ErrDecodeDnsLabelInvalidPointer) {
 		t.Errorf("bad error returned: %v", err)
@@ -927,7 +927,7 @@ func TestDecodeDnsAnswer_InvalidPtr_Loop1(t *testing.T) {
 		109, 99, 104, 100, 2, 109, 101, 0, 0, 1, 0, 1, 192, 31, 0, 1, 0, 1, 0, 0,
 		14, 16, 0, 4, 83, 112, 146, 176}
 
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	_, _, err := DecodeAnswer(1, offset_rr, payload)
 	if !errors.Is(err, ErrDecodeDnsLabelInvalidPointer) {
 		t.Errorf("bad error returned: %v", err)
@@ -941,7 +941,7 @@ func TestDecodeDnsAnswer_InvalidPtr_Loop2(t *testing.T) {
 		14, 16, 0, 4, 83, 112, 146, 176, 192, 31, 0, 1, 0, 1, 0, 0,
 		14, 16, 0, 4, 83, 112, 146, 176}
 
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	_, _, err := DecodeAnswer(1, offset_rr, payload)
 	if !errors.Is(err, ErrDecodeDnsLabelInvalidPointer) {
 		t.Errorf("bad error returned: %v", err)

--- a/dnsutils/edns_test.go
+++ b/dnsutils/edns_test.go
@@ -26,7 +26,7 @@ func TestDecodeQuery_EDNS(t *testing.T) {
 
 	payload, _ := dm.Pack()
 
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	_, _, err := DecodeEDNS(len(dm.Extra), offset_rr, payload)
 
 	if err != nil {
@@ -62,7 +62,7 @@ func TestDecodeReply_EDNS(t *testing.T) {
 	m.SetRcode(dm, 42) // 32(extended rcode) + 10(rcode)
 
 	payload, _ := m.Pack()
-	_, _, offset_rr, _ := DecodeQuestion(payload)
+	_, _, offset_rr, _ := DecodeQuestion(1, payload)
 	_, offset_rr, _ = DecodeAnswer(len(m.Answer), offset_rr, payload)
 
 	_, _, err := DecodeEDNS(len(m.Extra), offset_rr, payload)
@@ -108,7 +108,7 @@ func TestDecodeQuery_EdnsSubnet(t *testing.T) {
 		0xc0, 0xa8, 0x01,
 	}
 
-	_, _, offset, err := DecodeQuestion(payload)
+	_, _, offset, err := DecodeQuestion(1, payload)
 	if err != nil {
 		t.Errorf("unexpected error while decoding question: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestDecodeQuery_EdnsSubnetV6(t *testing.T) {
 		0xfe, 0x80, 0x01,
 	}
 
-	_, _, offset, err := DecodeQuestion(payload)
+	_, _, offset, err := DecodeQuestion(1, payload)
 	if err != nil {
 		t.Errorf("unexpected error while decoding question: %v", err)
 	}
@@ -249,7 +249,7 @@ func TestDecodeQuery_EdnsSubnet_invalidFam(t *testing.T) {
 		0xfe, 0x80, 0x01,
 	}
 
-	_, _, offset, err := DecodeQuestion(payload)
+	_, _, offset, err := DecodeQuestion(1, payload)
 	if err != nil {
 		t.Errorf("unexpected error while decoding question: %v", err)
 	}
@@ -307,7 +307,7 @@ func TestDecodeQuery_EdnsSubnet_Short(t *testing.T) {
 		// 0xfe, 0x80, 0x01,
 	}
 
-	_, _, offset, err := DecodeQuestion(payload)
+	_, _, offset, err := DecodeQuestion(1, payload)
 	if err != nil {
 		t.Errorf("unexpected error while decoding question: %v", err)
 	}
@@ -365,7 +365,7 @@ func TestDecodeQuery_EdnsSubnet_NoAddr(t *testing.T) {
 		// 0xfe, 0x80, 0x01,
 	}
 
-	_, _, offset, err := DecodeQuestion(payload)
+	_, _, offset, err := DecodeQuestion(1, payload)
 	if err != nil {
 		t.Errorf("unexpected error while decoding question: %v", err)
 	}
@@ -428,7 +428,7 @@ func TestDecodeAnswer_EdnsError(t *testing.T) {
 		0x00, 0x17,
 	}
 
-	_, _, offset, err := DecodeQuestion(payload)
+	_, _, offset, err := DecodeQuestion(1, payload)
 	if err != nil {
 		t.Errorf("unexpected error while decoding question: %v", err)
 	}
@@ -484,7 +484,7 @@ func TestDecodeAnswer_EdnsErrorText(t *testing.T) {
 		0x62, 0x30, 0x72, 0x6b, 0x65, 0x6e,
 	}
 
-	_, _, offset, err := DecodeQuestion(payload)
+	_, _, offset, err := DecodeQuestion(1, payload)
 	if err != nil {
 		t.Errorf("unexpected error while decoding question: %v", err)
 	}
@@ -539,7 +539,7 @@ func TestDecodeAnswer_EdnsErrorShort(t *testing.T) {
 		0x00,
 	}
 
-	_, _, offset, err := DecodeQuestion(payload)
+	_, _, offset, err := DecodeQuestion(1, payload)
 	if err != nil {
 		t.Errorf("unexpected error while decoding question: %v", err)
 	}

--- a/subprocessors/decoder.go
+++ b/subprocessors/decoder.go
@@ -70,7 +70,7 @@ func decodePayload(dm *dnsutils.DnsMessage, header *dnsutils.DnsHeader, qNamePri
 	var payload_offset int
 	// decode DNS question
 	if header.Qdcount > 0 {
-		dns_qname, dns_rrtype, offsetrr, err := dnsutils.DecodeQuestion(dm.DNS.Payload)
+		dns_qname, dns_rrtype, offsetrr, err := dnsutils.DecodeQuestion(header.Qdcount, dm.DNS.Payload)
 		if err != nil {
 			dm.DNS.MalformedPacket = 1
 			return &decodingError{part: "query", err: err}

--- a/subprocessors/decoder.go
+++ b/subprocessors/decoder.go
@@ -1,0 +1,136 @@
+package subprocessors
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dmachard/go-dnscollector/dnsutils"
+	"golang.org/x/net/publicsuffix"
+)
+
+// error returned if decoding of DNS packet payload fails.
+type decodingError struct {
+	part string
+	err  error
+}
+
+func (e *decodingError) Error() string {
+	return fmt.Sprintf("malformed %s in DNS packet: %v", e.part, e.err)
+}
+
+func (e *decodingError) Unwrap() error {
+	return e.err
+}
+
+// decodePayload can be used to decode raw payload data in dm.DNS.Payload
+// into relevant parts of dm.DNS struct. The payload is decoded according to
+// given DNS header.
+// qNamePrivacyEnabled should be set to true if query name privacy is enabled
+// in configuration.
+// If packet is marked as malformed already, this function returs with no
+// error, but does not process the packet.
+// Error is returned if packet can not be parsed. Returned error wraps the
+// original error returned by relevant decoding operation.
+func decodePayload(dm *dnsutils.DnsMessage, header *dnsutils.DnsHeader, qNamePrivacyEnabled bool, config *dnsutils.Config) error {
+
+	if dm.DNS.MalformedPacket == 1 {
+		// do not continue if packet is malformed, the header can not be
+		// trusted.
+		return nil
+	}
+
+	dm.DNS.Id = header.Id
+	dm.DNS.Rcode = dnsutils.RcodeToString(header.Rcode)
+	dm.DNS.Opcode = header.Opcode
+
+	// update dnstap operation if the opcode is equal to 5 (dns update)
+	if dm.DNS.Opcode == 5 && header.Qr == 1 {
+		dm.DnsTap.Operation = "UPDATE_QUERY"
+	}
+	if dm.DNS.Opcode == 5 && header.Qr == 0 {
+		dm.DnsTap.Operation = "UPDATE_RESPONSE"
+	}
+
+	if header.Qr == 1 {
+		dm.DNS.Flags.QR = true
+	}
+	if header.Tc == 1 {
+		dm.DNS.Flags.TC = true
+	}
+	if header.Aa == 1 {
+		dm.DNS.Flags.AA = true
+	}
+	if header.Ra == 1 {
+		dm.DNS.Flags.RA = true
+	}
+	if header.Ad == 1 {
+		dm.DNS.Flags.AD = true
+	}
+
+	var payload_offset int
+	// decode DNS question
+	if header.Qdcount > 0 {
+		dns_qname, dns_rrtype, offsetrr, err := dnsutils.DecodeQuestion(dm.DNS.Payload)
+		if err != nil {
+			dm.DNS.MalformedPacket = 1
+			return &decodingError{part: "query", err: err}
+		}
+		if config.Subprocessors.QnameLowerCase {
+			dm.DNS.Qname = strings.ToLower(dns_qname)
+		} else {
+			dm.DNS.Qname = dns_qname
+		}
+
+		// Public suffix
+		ps, _ := publicsuffix.PublicSuffix(dm.DNS.Qname)
+		dm.DNS.QnamePublicSuffix = ps
+
+		if !qNamePrivacyEnabled {
+			if etpo, err := publicsuffix.EffectiveTLDPlusOne(dm.DNS.Qname); err == nil {
+				dm.DNS.QnameEffectiveTLDPlusOne = etpo
+			}
+		}
+
+		dm.DNS.Qtype = dnsutils.RdatatypeToString(dns_rrtype)
+		payload_offset = offsetrr
+	}
+
+	// decode DNS answers
+	if header.Ancount > 0 {
+		if answers, offset, err := dnsutils.DecodeAnswer(header.Ancount, payload_offset, dm.DNS.Payload); err == nil {
+			dm.DNS.DnsRRs.Answers = answers
+			payload_offset = offset
+		} else {
+			dm.DNS.MalformedPacket = 1
+			return &decodingError{part: "answer records", err: err}
+		}
+	}
+
+	// decode authoritative answers
+	if header.Nscount > 0 {
+		if answers, offsetrr, err := dnsutils.DecodeAnswer(header.Nscount, payload_offset, dm.DNS.Payload); err == nil {
+			dm.DNS.DnsRRs.Nameservers = answers
+			payload_offset = offsetrr
+		} else {
+			dm.DNS.MalformedPacket = 1
+			return &decodingError{part: "authority records", err: err}
+		}
+	}
+	if header.Arcount > 0 {
+		// decode additional answers
+		if answers, _, err := dnsutils.DecodeAnswer(header.Arcount, payload_offset, dm.DNS.Payload); err == nil {
+			dm.DNS.DnsRRs.Records = answers
+		} else {
+			dm.DNS.MalformedPacket = 1
+			return &decodingError{part: "additional records", err: err}
+		}
+		// decode EDNS options, if there are any
+		if edns, _, err := dnsutils.DecodeEDNS(header.Arcount, payload_offset, dm.DNS.Payload); err == nil {
+			dm.EDNS = edns
+		} else {
+			dm.DNS.MalformedPacket = 1
+			return &decodingError{part: "edns options", err: err}
+		}
+	}
+	return nil
+}

--- a/subprocessors/decoder_test.go
+++ b/subprocessors/decoder_test.go
@@ -1,0 +1,671 @@
+package subprocessors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/dmachard/go-dnscollector/dnsutils"
+)
+
+func TestDecodePayload_QueryHappy(t *testing.T) {
+	payload := []byte{
+		//header
+		0x9e, 0x84, 0x01, 0x20, 0x00, 0x01, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+		// query section
+		// name
+		0x0b, 0x73, 0x65, 0x6e,
+		0x73, 0x6f, 0x72, 0x66, 0x6c, 0x65, 0x65, 0x74,
+		0x03, 0x63, 0x6f, 0x6d, 0x00,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// Additional records: EDNS OPT with no data, DO = 0, Z=0
+		0x00, 0x00, 0x29, 0x10, 0x00, 0x00, 0x00,
+		0x80, 0x00, 0x00, 0x00,
+	}
+
+	dm := dnsutils.DnsMessage{}
+	dm.DNS.Payload = payload
+	dm.DNS.Length = len(payload)
+
+	header, err := dnsutils.DecodeDns(payload)
+	if err != nil {
+		t.Errorf("unexpected error when decoding header: %v", err)
+	}
+
+	if err = decodePayload(&dm, &header, false, dnsutils.GetFakeConfig()); err != nil {
+		t.Errorf("Unexpected error while decoding payload: %v", err)
+	}
+	if dm.DNS.MalformedPacket != 0 {
+		t.Errorf("did not expect packet to be malformed")
+	}
+
+	if dm.DNS.Id != 0x9e84 ||
+		dm.DNS.Opcode != 0 ||
+		dm.DNS.Rcode != dnsutils.RcodeToString(0) ||
+		dm.DNS.Flags.QR ||
+		dm.DNS.Flags.TC ||
+		dm.DNS.Flags.AA ||
+		!dm.DNS.Flags.AD ||
+		dm.DNS.Flags.RA {
+		t.Error("Invalid DNS header data in message")
+	}
+
+	if dm.DNS.Qname != "sensorfleet.com" {
+		t.Errorf("Unexpected query name: %s", dm.DNS.Qname)
+	}
+	if dm.DNS.Qtype != "A" {
+		t.Errorf("Unexpected query type: %s", dm.DNS.Qtype)
+	}
+
+	if dm.EDNS.Do != 1 ||
+		dm.EDNS.UdpSize != 4096 ||
+		dm.EDNS.Z != 0 ||
+		dm.EDNS.Version != 0 ||
+		len(dm.EDNS.Options) != 0 {
+		t.Errorf("Unexpected EDNS data")
+	}
+
+	if len(dm.DNS.DnsRRs.Answers) != 0 ||
+		len(dm.DNS.DnsRRs.Nameservers) != 0 ||
+		len(dm.DNS.DnsRRs.Records) != 0 {
+		t.Errorf("Unexpected sections parsed")
+	}
+
+}
+func TestDecodePayload_QueryInvalid(t *testing.T) {
+	payload := []byte{
+		//header
+		0x9e, 0x84, 0x01, 0x20, 0x00, 0x01, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+		// query section
+		// name
+		0x0b, 0x73, 0x65, 0x6e,
+		0x73, 0x6f, 0x72, 0x66, 0x6c, 0x65, 0x65, 0x74,
+		0x83, 0x63, 0x6f, 0x6d, 0x00,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// Additional records: EDNS OPT with no data, DO = 1, Z=0
+		0x00, 0x00, 0x29, 0x10, 0x00, 0x00, 0x00,
+		0x80, 0x00, 0x00, 0x00,
+	}
+
+	dm := dnsutils.DnsMessage{}
+	dm.DNS.Payload = payload
+	dm.DNS.Length = len(payload)
+
+	header, err := dnsutils.DecodeDns(payload)
+	if err != nil {
+		t.Errorf("unexpected error when decoding header: %v", err)
+	}
+
+	if err = decodePayload(&dm, &header, false, dnsutils.GetFakeConfig()); err == nil {
+		t.Errorf("Expected error when parsing payload")
+	}
+	if dm.DNS.MalformedPacket != 1 {
+		t.Errorf("expected packet to be marked as malformed")
+	}
+
+	// returned error should wrap the original error
+	if !errors.Is(err, dnsutils.ErrDecodeDnsLabelInvalidData) {
+		t.Errorf("bad error returned: %v", err)
+	}
+}
+
+func TestDecodePayload_AnswerHappy(t *testing.T) {
+	payload := []byte{
+		0x9e, 0x84, 0x81, 0x80, 0x00, 0x01, 0x00, 0x04,
+		0x00, 0x00, 0x00, 0x01,
+		// Query section
+		0x0b, 0x73, 0x65, 0x6e,
+		0x73, 0x6f, 0x72, 0x66, 0x6c, 0x65, 0x65, 0x74,
+		0x03, 0x63, 0x6f, 0x6d, 0x00,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// Answer 1
+		0xc0, 0x0c, // pointer to name
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.1
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x01,
+		// Answer 2
+		0xc0, 0x0c,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.2
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x02,
+		// Answer 3
+		0xc0, 0x0c,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.3
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x03,
+		// Answer 4
+		0xc0, 0x0c,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.4
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x04,
+		// Additianl records, EDNS Option, 0 bytes DO=0, Z = 0
+		0x00, 0x00, 0x29, 0x04, 0xd0, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	}
+
+	dm := dnsutils.DnsMessage{}
+	dm.DNS.Payload = payload
+	dm.DNS.Length = len(payload)
+
+	header, err := dnsutils.DecodeDns(payload)
+	if err != nil {
+		t.Errorf("unexpected error when decoding header: %v", err)
+	}
+
+	if err = decodePayload(&dm, &header, false, dnsutils.GetFakeConfig()); err != nil {
+		t.Errorf("Unexpected error while decoding payload: %v", err)
+	}
+	if dm.DNS.MalformedPacket != 0 {
+		t.Errorf("did not expect packet to be malformed")
+	}
+
+	if dm.DNS.Id != 0x9e84 ||
+		dm.DNS.Opcode != 0 ||
+		dm.DNS.Rcode != dnsutils.RcodeToString(0) ||
+		!dm.DNS.Flags.QR ||
+		dm.DNS.Flags.TC ||
+		dm.DNS.Flags.AA ||
+		dm.DNS.Flags.AD ||
+		!dm.DNS.Flags.RA {
+		t.Error("Invalid DNS header data in message")
+	}
+
+	if dm.DNS.Qname != "sensorfleet.com" {
+		t.Errorf("Unexpected query name: %s", dm.DNS.Qname)
+	}
+	if dm.DNS.Qtype != "A" {
+		t.Errorf("Unexpected query type: %s", dm.DNS.Qtype)
+	}
+
+	if len(dm.DNS.DnsRRs.Answers) != 4 {
+		t.Errorf("expected 4 answers, got %d", len(dm.DNS.DnsRRs.Answers))
+	}
+
+	for i, ans := range dm.DNS.DnsRRs.Answers {
+		expected := dnsutils.DnsAnswer{
+			Name:      dm.DNS.Qname,
+			Rdatatype: dnsutils.RdatatypeToString(0x0001),
+			Class:     0x0001,
+			Ttl:       300,
+			Rdata:     fmt.Sprintf("10.10.1.%d", i+1),
+		}
+		if expected != ans {
+			t.Errorf("unexpected answer (%d). expected %v, got %v", i, expected, ans)
+		}
+	}
+
+	if dm.EDNS.Do != 0 ||
+		dm.EDNS.UdpSize != 1232 ||
+		dm.EDNS.Z != 0 ||
+		dm.EDNS.Version != 0 ||
+		len(dm.EDNS.Options) != 0 {
+		t.Errorf("Unexpected EDNS data")
+	}
+
+	if len(dm.DNS.DnsRRs.Nameservers) != 0 ||
+		len(dm.DNS.DnsRRs.Records) != 0 {
+		t.Errorf("Unexpected sections parsed")
+	}
+
+}
+func TestDecodePayload_AnswerInvalid(t *testing.T) {
+	payload := []byte{
+		0x9e, 0x84, 0x81, 0x80, 0x00, 0x01, 0x00, 0x04,
+		0x00, 0x00, 0x00, 0x01,
+		// Query section
+		0x0b, 0x73, 0x65, 0x6e,
+		0x73, 0x6f, 0x72, 0x66, 0x6c, 0x65, 0x65, 0x74,
+		0x03, 0x63, 0x6f, 0x6d, 0x00,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// Answer 1
+		0xc0, 0x0c, // pointer to name
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.1
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x01,
+		// Answer 2
+		0xc0, 0x0c,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.2
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x02,
+		// Answer 3
+		0xc0, 0xff,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.3
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x03,
+		// Answer 4
+		0xc0, 0x0c,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.4
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x04,
+		// Additianl records, EDNS Option, 0 bytes DO=0, Z = 0
+		0x00, 0x00, 0x29, 0x04, 0xd0, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	}
+
+	dm := dnsutils.DnsMessage{}
+	dm.DNS.Payload = payload
+	dm.DNS.Length = len(payload)
+
+	header, err := dnsutils.DecodeDns(payload)
+	if err != nil {
+		t.Errorf("unexpected error when decoding header: %v", err)
+	}
+
+	if err = decodePayload(&dm, &header, false, dnsutils.GetFakeConfig()); err == nil {
+		t.Error("expected decoding to fail")
+	}
+	// returned error should wrap the original error
+	if !errors.Is(err, dnsutils.ErrDecodeDnsLabelInvalidPointer) {
+		t.Errorf("bad error returned: %v", err)
+	}
+	if dm.DNS.MalformedPacket != 1 {
+		t.Errorf("expected packet to be malformed")
+	}
+}
+
+func TestDecodePayload_AnswerInvalidQuery(t *testing.T) {
+	payload := []byte{
+		0x9e, 0x84, 0x81, 0x80, 0x00, 0x01, 0x00, 0x04,
+		0x00, 0x00, 0x00, 0x01,
+		// Query section
+		0x0b, 0x73, 0x65, 0x6e,
+		0x73, 0x6f, 0x72, 0x66, 0x6c, 0x65, 0x65, 0x74,
+		0x83, 0x63, 0x6f, 0x6d, 0x00,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// Answer 1
+		0xc0, 0x0c, // pointer to name
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.1
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x01,
+		// Answer 2
+		0xc0, 0x0c,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.2
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x02,
+		// Answer 3
+		0xc0, 0x0c,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.3
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x03,
+		// Answer 4
+		0xc0, 0x0c,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.4
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x04,
+		// Additianl records, EDNS Option, 0 bytes DO=0, Z = 0
+		0x00, 0x00, 0x29, 0x04, 0xd0, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	}
+
+	dm := dnsutils.DnsMessage{}
+	dm.DNS.Payload = payload
+	dm.DNS.Length = len(payload)
+
+	header, err := dnsutils.DecodeDns(payload)
+	if err != nil {
+		t.Errorf("unexpected error when decoding header: %v", err)
+	}
+
+	if err = decodePayload(&dm, &header, false, dnsutils.GetFakeConfig()); err == nil {
+		t.Error("expected decoding to fail")
+	}
+	// returned error should wrap the original error
+	if !errors.Is(err, dnsutils.ErrDecodeDnsLabelInvalidData) {
+		t.Errorf("bad error returned: %v", err)
+	}
+	if dm.DNS.MalformedPacket != 1 {
+		t.Errorf("expected packet to be malformed")
+	}
+
+	// after error has been detected in the query part, we should not parse
+	// anything from answers
+	if len(dm.DNS.DnsRRs.Answers) != 0 {
+		t.Errorf("did not expect answers to be parsed, but there were %d parsed", len(dm.DNS.DnsRRs.Answers))
+	}
+}
+
+func TestDecodePayload_AnswerInvalidEdns(t *testing.T) {
+	payload := []byte{
+		0x9e, 0x84, 0x81, 0x80, 0x00, 0x01, 0x00, 0x04,
+		0x00, 0x00, 0x00, 0x01,
+		// Query section
+		0x0b, 0x73, 0x65, 0x6e,
+		0x73, 0x6f, 0x72, 0x66, 0x6c, 0x65, 0x65, 0x74,
+		0x03, 0x63, 0x6f, 0x6d, 0x00,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// Answer 1
+		0xc0, 0x0c, // pointer to name
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.1
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x01,
+		// Answer 2
+		0xc0, 0x0c,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.2
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x02,
+		// Answer 3
+		0xc0, 0x0c,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.3
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x03,
+		// Answer 4
+		0xc0, 0x0c,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.4
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x04,
+		// Additianl records, Invalid EDNS Option
+		0x00, 0x00, 0x29, 0x04, 0xd0, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x03, 0x00, 0x01, 0x01,
+	}
+
+	dm := dnsutils.DnsMessage{}
+	dm.DNS.Payload = payload
+	dm.DNS.Length = len(payload)
+
+	header, err := dnsutils.DecodeDns(payload)
+	if err != nil {
+		t.Errorf("unexpected error when decoding header: %v", err)
+	}
+
+	if err = decodePayload(&dm, &header, false, dnsutils.GetFakeConfig()); err == nil {
+		t.Error("expected decoding to fail")
+	}
+	// returned error should wrap the original error
+	if !errors.Is(err, dnsutils.ErrDecodeEdnsOptionTooShort) {
+		t.Errorf("bad error returned: %v", err)
+	}
+	if dm.DNS.MalformedPacket != 1 {
+		t.Errorf("expected packet to be malformed")
+	}
+}
+
+func TestDecodePayload_AnswerInvaliAdditional(t *testing.T) {
+	payload := []byte{
+		0x9e, 0x84, 0x81, 0x80, 0x00, 0x01, 0x00, 0x04,
+		0x00, 0x00, 0x00, 0x01,
+		// Query section
+		0x0b, 0x73, 0x65, 0x6e,
+		0x73, 0x6f, 0x72, 0x66, 0x6c, 0x65, 0x65, 0x74,
+		0x03, 0x63, 0x6f, 0x6d, 0x00,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// Answer 1
+		0xc0, 0x0c, // pointer to name
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.1
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x01,
+		// Answer 2
+		0xc0, 0x0c,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.2
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x02,
+		// Answer 3
+		0xc0, 0x0c,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.3
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x03,
+		// Answer 4
+		0xc0, 0x0c,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x01, 0x2c,
+		// 10.10.1.4
+		0x00, 0x04, 0x0a, 0x0a, 0x01, 0x04,
+		// Additianl records, Invalid RDLENGTH
+		0x00, 0x00, 0x29, 0x04, 0xd0, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+	}
+
+	dm := dnsutils.DnsMessage{}
+	dm.DNS.Payload = payload
+	dm.DNS.Length = len(payload)
+
+	header, err := dnsutils.DecodeDns(payload)
+	if err != nil {
+		t.Errorf("unexpected error when decoding header: %v", err)
+	}
+
+	if err = decodePayload(&dm, &header, false, dnsutils.GetFakeConfig()); err == nil {
+		t.Error("expected decoding to fail")
+	}
+	// returned error should wrap the original error
+	if !errors.Is(err, dnsutils.ErrDecodeDnsAnswerRdataTooShort) {
+		t.Errorf("bad error returned: %v", err)
+	}
+	if dm.DNS.MalformedPacket != 1 {
+		t.Errorf("expected packet to be malformed")
+	}
+}
+
+func TestDecodePayload_AnswerError(t *testing.T) {
+	payload := []byte{
+		// header
+		0xa8, 0x1a, 0x81, 0x83, 0x00, 0x01, 0x00, 0x00,
+		0x00, 0x01, 0x00, 0x01,
+		// query
+		0x03, 0x66, 0x6f, 0x6f,
+		0x06, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x03,
+		0x63, 0x6f, 0x6d, 0x00,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// Authority section
+		// name
+		0xc0, 0x10,
+		// type SOA, class IN
+		0x00, 0x06, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x00, 0x3c,
+		// RDLENGTH
+		0x00, 0x26,
+		// RDATA
+		// MNAME
+		0x03, 0x6e, 0x73, 0x31,
+		0xc0, 0x10,
+		// RNAME
+		0x09, 0x64, 0x6e, 0x73, 0x2d, 0x61,
+		0x64, 0x6d, 0x69, 0x6e, 0xc0, 0x10,
+		// serial
+		0x19, 0xa1, 0x4a, 0xb4,
+		// refresh
+		0x00, 0x00, 0x03, 0x84,
+		// retry
+		0x00, 0x00, 0x03, 0x84,
+		// expire
+		0x00, 0x00, 0x07, 0x08,
+		// minimum
+		0x00, 0x00, 0x00, 0x3c,
+		// Additianl records, EDNS Option, 0 bytes DO=1, Z = 0
+		0x00, 0x00, 0x29, 0x04, 0xd0, 0x00,
+		0x00, 0x80, 0x00, 0x00, 0x00,
+	}
+	dm := dnsutils.DnsMessage{}
+	dm.DNS.Payload = payload
+	dm.DNS.Length = len(payload)
+
+	header, err := dnsutils.DecodeDns(payload)
+	if err != nil {
+		t.Errorf("unexpected error when decoding header: %v", err)
+	}
+
+	if err = decodePayload(&dm, &header, false, dnsutils.GetFakeConfig()); err != nil {
+		t.Errorf("Unexpected error while decoding payload: %v", err)
+	}
+	if dm.DNS.MalformedPacket != 0 {
+		t.Errorf("did not expect packet to be malformed")
+	}
+
+	if dm.DNS.Id != 0xa81a ||
+		dm.DNS.Opcode != 0 ||
+		dm.DNS.Rcode != dnsutils.RcodeToString(3) ||
+		!dm.DNS.Flags.QR ||
+		dm.DNS.Flags.TC ||
+		dm.DNS.Flags.AA ||
+		dm.DNS.Flags.AD ||
+		!dm.DNS.Flags.RA {
+		t.Error("Invalid DNS header data in message")
+	}
+
+	if dm.DNS.Qname != "foo.google.com" {
+		t.Errorf("Unexpected query name: %s", dm.DNS.Qname)
+	}
+	if dm.DNS.Qtype != "A" {
+		t.Errorf("Unexpected query type: %s", dm.DNS.Qtype)
+	}
+
+	if len(dm.DNS.DnsRRs.Answers) != 0 {
+		t.Errorf("did not expect any answers, got %d", len(dm.DNS.DnsRRs.Answers))
+	}
+
+	if len(dm.DNS.DnsRRs.Nameservers) != 1 {
+		t.Errorf("expected 1 authority RR, got %d", len(dm.DNS.DnsRRs.Nameservers))
+	}
+	expected := dnsutils.DnsAnswer{
+		Name:      "google.com",
+		Rdatatype: dnsutils.RdatatypeToString(0x0006),
+		Class:     0x0001,
+		Ttl:       60,
+		Rdata:     "ns1.google.com dns-admin.google.com 430000820 900 900 1800 60",
+	}
+
+	if dm.DNS.DnsRRs.Nameservers[0] != expected {
+		t.Errorf("unexpected SOA record parsed, expected %v, git %v", expected, dm.DNS.DnsRRs.Nameservers[0])
+	}
+
+	if dm.EDNS.Do != 1 ||
+		dm.EDNS.UdpSize != 1232 ||
+		dm.EDNS.Z != 0 ||
+		dm.EDNS.Version != 0 ||
+		len(dm.EDNS.Options) != 0 {
+		t.Errorf("Unexpected EDNS data")
+	}
+
+}
+
+func TestDecodePayload_AnswerError_Invalid(t *testing.T) {
+	payload := []byte{
+		// header
+		0xa8, 0x1a, 0x81, 0x83, 0x00, 0x01, 0x00, 0x00,
+		0x00, 0x01, 0x00, 0x01,
+		// query
+		0x03, 0x66, 0x6f, 0x6f,
+		0x06, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x03,
+		0x63, 0x6f, 0x6d, 0x00,
+		// type A, class IN
+		0x00, 0x01, 0x00, 0x01,
+		// Authority section
+		// name
+		0xc0, 0x10,
+		// type SOA, class IN
+		0x00, 0x06, 0x00, 0x01,
+		// TTL
+		0x00, 0x00, 0x00, 0x3c,
+		// RDLENGTH
+		0x00, 0x26,
+		// RDATA
+		// MNAME, invalid offset in pointer
+		0x03, 0x6e, 0x73, 0x31,
+		0xc0, 0xff,
+		// RNAME
+		0x09, 0x64, 0x6e, 0x73, 0x2d, 0x61,
+		0x64, 0x6d, 0x69, 0x6e, 0xc0, 0x10,
+		// serial
+		0x19, 0xa1, 0x4a, 0xb4,
+		// refresh
+		0x00, 0x00, 0x03, 0x84,
+		// retry
+		0x00, 0x00, 0x03, 0x84,
+		// expire
+		0x00, 0x00, 0x07, 0x08,
+		// minimum
+		0x00, 0x00, 0x00, 0x3c,
+		// Additianl records, EDNS Option, 0 bytes DO=1, Z = 0
+		0x00, 0x00, 0x29, 0x04, 0xd0, 0x00,
+		0x00, 0x80, 0x00, 0x00, 0x00,
+	}
+	dm := dnsutils.DnsMessage{}
+	dm.DNS.Payload = payload
+	dm.DNS.Length = len(payload)
+
+	header, err := dnsutils.DecodeDns(payload)
+	if err != nil {
+		t.Errorf("unexpected error when decoding header: %v", err)
+	}
+
+	if err = decodePayload(&dm, &header, false, dnsutils.GetFakeConfig()); err == nil {
+		t.Error("expected decoding to fail")
+	}
+	// returned error should wrap the original error
+	if !errors.Is(err, dnsutils.ErrDecodeDnsLabelInvalidPointer) {
+		t.Errorf("bad error returned: %v", err)
+	}
+	if dm.DNS.MalformedPacket != 1 {
+		t.Errorf("expected packet to be malformed")
+	}
+
+}

--- a/subprocessors/dnstapreader.go
+++ b/subprocessors/dnstapreader.go
@@ -11,7 +11,6 @@ import (
 	"github.com/dmachard/go-dnscollector/dnsutils"
 	"github.com/dmachard/go-dnstap-protobuf"
 	"github.com/dmachard/go-logger"
-	"golang.org/x/net/publicsuffix"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -214,102 +213,8 @@ func (d *DnstapProcessor) Run(sendTo []chan dnsutils.DnsMessage) {
 			d.LogInfo("dns parser malformed packet: %s", err)
 		}
 
-		dm.DNS.Id = dnsHeader.Id
-		dm.DNS.Rcode = dnsutils.RcodeToString(dnsHeader.Rcode)
-		dm.DNS.Opcode = dnsHeader.Opcode
-
-		// update dnstap operation if the opcode is equal to 5 (dns update)
-		if dm.DNS.Opcode == 5 && op%2 == 1 {
-			dm.DnsTap.Operation = "UPDATE_QUERY"
-		}
-		if dm.DNS.Opcode == 5 && op%2 == 1 {
-			dm.DnsTap.Operation = "UPDATE_RESPONSE"
-		}
-
-		// set dns flags
-		if dnsHeader.Qr == 1 {
-			dm.DNS.Flags.QR = true
-		}
-		if dnsHeader.Tc == 1 {
-			dm.DNS.Flags.TC = true
-		}
-		if dnsHeader.Aa == 1 {
-			dm.DNS.Flags.AA = true
-		}
-		if dnsHeader.Ra == 1 {
-			dm.DNS.Flags.RA = true
-		}
-		if dnsHeader.Ad == 1 {
-			dm.DNS.Flags.AD = true
-		}
-
-		// continue to decode the dns payload to extract the qname and rrtype
-		var dns_offsetrr int
-		if dnsHeader.Qdcount > 0 && dm.DNS.MalformedPacket == 0 {
-			dns_qname, dns_rrtype, offsetrr, err := dnsutils.DecodeQuestion(dm.DNS.Payload)
-			if err != nil {
-				dm.DNS.MalformedPacket = 1
-				d.LogError("dns parser malformed question: %s", err)
-				//continue
-			}
-			if d.config.Subprocessors.QnameLowerCase {
-				dm.DNS.Qname = strings.ToLower(dns_qname)
-			} else {
-				dm.DNS.Qname = dns_qname
-			}
-
-			// Public suffix
-			ps, _ := publicsuffix.PublicSuffix(dm.DNS.Qname)
-			dm.DNS.QnamePublicSuffix = ps
-
-			if !qnamePrivacy.IsEnabled() {
-				if etpo, err := publicsuffix.EffectiveTLDPlusOne(dm.DNS.Qname); err == nil {
-					dm.DNS.QnameEffectiveTLDPlusOne = etpo
-				}
-			}
-
-			dm.DNS.Qtype = dnsutils.RdatatypeToString(dns_rrtype)
-			dns_offsetrr = offsetrr
-		}
-
-		//  decode answers except if the packet is malformed
-		if dnsHeader.Ancount > 0 && dm.DNS.MalformedPacket == 0 {
-			var offsetrr int
-			dm.DNS.DnsRRs.Answers, offsetrr, err = dnsutils.DecodeAnswer(dnsHeader.Ancount, dns_offsetrr, dm.DNS.Payload)
-			if err != nil {
-				dm.DNS.MalformedPacket = 1
-				d.LogError("dns parser malformed answers: %s", err)
-			}
-			dns_offsetrr = offsetrr
-		}
-
-		//  decode authoritative answers except if the packet is malformed
-		if dnsHeader.Nscount > 0 && dm.DNS.MalformedPacket == 0 {
-			var offsetrr int
-			dm.DNS.DnsRRs.Nameservers, offsetrr, err = dnsutils.DecodeAnswer(dnsHeader.Nscount, dns_offsetrr, dm.DNS.Payload)
-			if err != nil {
-				dm.DNS.MalformedPacket = 1
-				d.LogError("dns parser malformed nameservers answers: %s", err)
-			}
-			dns_offsetrr = offsetrr
-		}
-
-		//  decode additional answers ?
-		if dnsHeader.Arcount > 0 && dm.DNS.MalformedPacket == 0 {
-			dm.DNS.DnsRRs.Records, _, err = dnsutils.DecodeAnswer(dnsHeader.Arcount, dns_offsetrr, dm.DNS.Payload)
-			if err != nil {
-				dm.DNS.MalformedPacket = 1
-				d.LogError("dns parser malformed additional answers: %s", err)
-			}
-		}
-
-		// decode edns options ?
-		if dnsHeader.Arcount > 0 && dm.DNS.MalformedPacket == 0 {
-			dm.EDNS, _, err = dnsutils.DecodeEDNS(dnsHeader.Arcount, dns_offsetrr, dm.DNS.Payload)
-			if err != nil {
-				dm.DNS.MalformedPacket = 1
-				d.LogError("dns parser malformed edns: %s", err)
-			}
+		if err = decodePayload(&dm, &dnsHeader, qnamePrivacy.IsEnabled(), d.config); err != nil {
+			d.LogError("%v - %v", err, dm)
 		}
 
 		if dm.DNS.MalformedPacket == 1 {


### PR DESCRIPTION

 * Move common part of DNS packet decoding from `dnsreader` and `dnstapreader` into new `decodePayload()` function which can be used by both readers. 
 * Add unit tests for payload decoding.
 * Change `decodeQuestion()` to take the number of questions on packet as parameter and handle multiple questions on single DNS packet.
   * Multiple queries in single packet are supported by the specification, but in practise DNS servers rarely support them (see, for example [this answer from stack overflow](https://stackoverflow.com/questions/4082081/requesting-a-and-aaaa-records-in-single-dns-query/4083071#4083071l)) and thus we should not see them in wire. 
   * Changed the `decodeQuestion()` to handle multiple questions by just returning `qname` and `qtype` from the last question. This obviously does not change output on single question case, but allows us to properly parse rest of the payload after multiple queries.
   * Other option would have been to change the `Dns` struct to include a list of questions instead of simple one question information. I did not want to change the output since there really is no use for multiple queries. 
   *  Yet another option would have been to return `error` if multiple queries are encountered, but since they are technically allowed by the specification, I did not want to do that either. 
   * If any of these other options are better than the one in this PR, I am happy to implement those as well.   