### PR TITLE
feat: log all answers IP in text format log

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
   <img src="https://goreportcard.com/badge/github.com/dmachard/go-dns-collector" alt="Go Report"/>
   <img src="https://img.shields.io/badge/go%20version-min%201.23-green" alt="Go version"/>
-  <img src="https://img.shields.io/badge/go%20tests-531-green" alt="Go tests"/>
+  <img src="https://img.shields.io/badge/go%20tests-532-green" alt="Go tests"/>
   <img src="https://img.shields.io/badge/go%20bench-21-green" alt="Go bench"/>
-  <img src="https://img.shields.io/badge/go%20lines-33484-green" alt="Go lines"/>
+  <img src="https://img.shields.io/badge/go%20lines-33681-green" alt="Go lines"/>
 </p>
 
 <p align="center">

--- a/dnsutils/dnsmessage_text.go
+++ b/dnsutils/dnsmessage_text.go
@@ -579,6 +579,19 @@ func (dm *DNSMessage) ToTextLine(format []string, fieldDelimiter string, fieldBo
 				s.WriteByte('-')
 			}
 
+		case directive == "answer-ips":
+			var ips []string
+			for _, answer := range an {
+				if answer.Rdatatype == "A" || answer.Rdatatype == Rdatatypes[28] {
+					ips = append(ips, answer.Rdata)
+				}
+			}
+			if len(ips) > 0 {
+				QuoteStringAndWrite(&s, strings.Join(ips, ";"), fieldDelimiter, fieldBoundary)
+			} else {
+				s.WriteByte('-')
+			}
+
 		case directive == "questionscount" || directive == "qdcount":
 			s.WriteString(strconv.Itoa(dm.DNS.QdCount))
 		case directive == "answercount" || directive == "ancount":

--- a/dnsutils/dnsmessage_text_test.go
+++ b/dnsutils/dnsmessage_text_test.go
@@ -280,6 +280,30 @@ func TestDnsMessage_TextFormat_DefaultDirectives(t *testing.T) {
 			},
 			expected: "::1",
 		},
+		{
+			format: "answer-ips",
+			dm: DNSMessage{
+				DNS: DNS{
+					DNSRRs: DNSRRs{
+						Answers: []DNSAnswer{
+							{
+								Name:      "dnscollector.fr",
+								Rdatatype: "A",
+								Class:     "IN",
+								Rdata:     "127.0.0.1",
+							},
+							{
+								Name:      "dnscollector.fr",
+								Rdatatype: "A",
+								Class:     "IN",
+								Rdata:     "127.0.0.2",
+							},
+						},
+					},
+				},
+			},
+			expected: "127.0.0.1;127.0.0.2",
+		},
 	}
 
 	for _, tc := range testcases {

--- a/docs/dnsconversions.md
+++ b/docs/dnsconversions.md
@@ -52,9 +52,10 @@ The text format can be customized using the following directives.
 - `nscount`: the number of nameserver
 - `ttl`: answer ttl, only the first one
 - `answer`: rdata answer, only the first one, prefer to use the JSON format if you want all answers
-- `answer-ip`: get A or AAAA answer
-- `answer-a`: get A answer
-- `answer-aaaa`: get AAAA answer
+- `answer-ip`: Returns the first answer of type A (IPv4) or AAAA (IPv6).
+- `answer-ips`: Returns all answers of type A and AAAA, separated by commas (,) Example output: 192.0.2.1,192.0.2.2
+- `answer-a`: Returns the first answer of type A (IPv4).
+- `answer-aaaa`: Returns the first answer of type AAAA (IPv6).
 - `malformed`: malformed dns packet, integer value 1/0
 - `qr`: Query or reply flag, indicating the type of message. Possible values: `Q` (query) or `R` (reply).
 - `tc`: Truncated response flag, indicates whether the response was truncated. Value is `TC` for enabled, `-` for disabled.


### PR DESCRIPTION
fix #960 

new text directive added: `anwer-ips`
