### PR TITLE
fix(#975): rename buffer-size to batch-size in Kafka logger config

### DIFF
--- a/docs/_integration/kafka/config.yml
+++ b/docs/_integration/kafka/config.yml
@@ -8,7 +8,6 @@ pipelines:
     dnstap:
       listen-ip: 0.0.0.0
       listen-port: 6000
-      chan-buffer-size: 4096
     routing-policy:
       forward: [ kafka ]
       dropped: []
@@ -27,8 +26,7 @@ pipelines:
       sasl-username: false
       sasl-password: false
       mode: flat-json
-      buffer-size: 100
+      batch-size: 100
       topic: "dnscollector"
       partition: null
-      chan-buffer-size: 4096
       compression: none

--- a/docs/loggers/logger_kafka.md
+++ b/docs/loggers/logger_kafka.md
@@ -59,8 +59,8 @@ Options:
 * `text-format` (string)
   > output text format, please refer to the default text format to see all available [text directives](../dnsconversions.md#text-format-inline), use this parameter if you want a specific format
 
-* `buffer-size` (integer)
-  > Specifies the size of the bulk for DNS messages before they are sent to Kafka.
+* `batch-size` (integer)
+  > Specifies the size of the batch for DNS messages before they are sent to Kafka.
 
 * `topic` (integer)
   > Specifies the Kafka topic to which messages will be forwarded.
@@ -69,7 +69,7 @@ Options:
   > Specifies the Kafka partition to which messages will be sent.
   > If partition parameter is null, then use `round-robin` partitioner for kafka (default behavior)
 
-* `chan-buffer-size` (int)
+* `chan-buffer-size` (int) - advanced setting, will be remove in future version
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -94,7 +94,7 @@ kafkaproducer:
   sasl-password: false
   mode: flat-json
   text-format: ""
-  buffer-size: 100
+  batch-size: 100
   topic: "dnscollector"
   partition: null
   chan-buffer-size: 0

--- a/pkgconfig/loggers.go
+++ b/pkgconfig/loggers.go
@@ -301,7 +301,7 @@ type ConfigLoggers struct {
 		SaslMechanism     string `yaml:"sasl-mechanism" default:"PLAIN"`
 		Mode              string `yaml:"mode" default:"flat-json"`
 		TextFormat        string `yaml:"text-format" default:""`
-		BufferSize        int    `yaml:"buffer-size" default:"100"`
+		BatchSize         int    `yaml:"batch-size" default:"100"`
 		FlushInterval     int    `yaml:"flush-interval" default:"10"`
 		ConnectTimeout    int    `yaml:"connect-timeout" default:"5"`
 		Topic             string `yaml:"topic" default:"dnscollector"`

--- a/workers/kafkaproducer.go
+++ b/workers/kafkaproducer.go
@@ -389,7 +389,7 @@ func (w *KafkaProducer) StartLogging() {
 			bufferDm = append(bufferDm, dm)
 
 			// buffer is full ?
-			if len(bufferDm) >= w.GetConfig().Loggers.KafkaProducer.BufferSize {
+			if len(bufferDm) >= w.GetConfig().Loggers.KafkaProducer.BatchSize {
 				w.FlushBuffer(&bufferDm)
 			}
 

--- a/workers/kafkaproducer_test.go
+++ b/workers/kafkaproducer_test.go
@@ -49,7 +49,7 @@ func Test_KafkaProducer(t *testing.T) {
 
 			// init logger
 			cfg := pkgconfig.GetDefaultConfig()
-			cfg.Loggers.KafkaProducer.BufferSize = 0
+			cfg.Loggers.KafkaProducer.BatchSize = 0
 			cfg.Loggers.KafkaProducer.RemotePort = 9092
 			cfg.Loggers.KafkaProducer.Topic = tc.topic
 			cfg.Loggers.KafkaProducer.Compression = tc.compress


### PR DESCRIPTION
fixes #975 