### PR TITLE
Fixing kafka worker get cancelled after 10 seconds of broker unreachability.

### DIFF
--- a/docs/loggers/logger_kafka.md
+++ b/docs/loggers/logger_kafka.md
@@ -21,6 +21,9 @@ Options:
 * `flush-interval` (integer)
   > Specifies the interval between buffer flushes.
 
+* `cancel-kafka` (boolean)
+  > Determines whether the Kafka worker should stop running if all configured brokers become unreachable after 10 seconds.
+
 * `tls-support` (boolean)
   > Enables or disables TLS (Transport Layer Security) support.
   > If set to true, TLS will be used for secure communication.

--- a/pkgconfig/loggers.go
+++ b/pkgconfig/loggers.go
@@ -304,6 +304,7 @@ type ConfigLoggers struct {
 		BatchSize         int    `yaml:"batch-size" default:"100"`
 		FlushInterval     int    `yaml:"flush-interval" default:"10"`
 		ConnectTimeout    int    `yaml:"connect-timeout" default:"5"`
+		CancelTimeout     bool   `yaml:"cancel-kafka" default:"true"`
 		Topic             string `yaml:"topic" default:"dnscollector"`
 		Partition         *int   `yaml:"partition" default:"nil"`
 		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`

--- a/pkgconfig/loggers.go
+++ b/pkgconfig/loggers.go
@@ -304,7 +304,7 @@ type ConfigLoggers struct {
 		BatchSize         int    `yaml:"batch-size" default:"100"`
 		FlushInterval     int    `yaml:"flush-interval" default:"10"`
 		ConnectTimeout    int    `yaml:"connect-timeout" default:"5"`
-		CancelTimeout     bool   `yaml:"cancel-kafka" default:"true"`
+		CancelKafka       bool   `yaml:"cancel-kafka" default:"false"`
 		Topic             string `yaml:"topic" default:"dnscollector"`
 		Partition         *int   `yaml:"partition" default:"nil"`
 		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`

--- a/workers/kafkaproducer.go
+++ b/workers/kafkaproducer.go
@@ -369,7 +369,10 @@ func (w *KafkaProducer) StartLogging() {
 
 		case <-readyTimer.C:
 			w.LogError("failed to established connection")
-			cancelKafka()
+			// Stop the kafka producer when the readyTimer is finished
+			if w.GetConfig().Loggers.KafkaProducer.CancelTimeout {
+				cancelKafka()
+			}
 
 		case <-w.kafkaReady:
 			w.LogInfo("producer connected with success to your kafka instance(s)")

--- a/workers/kafkaproducer.go
+++ b/workers/kafkaproducer.go
@@ -370,7 +370,7 @@ func (w *KafkaProducer) StartLogging() {
 		case <-readyTimer.C:
 			w.LogError("failed to established connection")
 			// Stop the kafka producer when the readyTimer is finished
-			if w.GetConfig().Loggers.KafkaProducer.CancelTimeout {
+			if w.GetConfig().Loggers.KafkaProducer.CancelKafka {
 				cancelKafka()
 			}
 


### PR DESCRIPTION
The readyTimer in the Kafka producer code was responsible for <a href="https://github.com/dmachard/DNS-collector/blob/5d254809173febecd4f84699e1b005c67a6b73e9/workers/kafkaproducer.go#L372">cancelling</a> Kafka after 10 seconds of unreachability to all the provided brokers. Therefore, I have added a new configuration parameter _cancel-kafka_ to the yaml configuration file