### PR TITLE
feat: Decode RCode to the real RCode in case of Extended Errors

### DIFF
--- a/dnsutils/dns_parser.go
+++ b/dnsutils/dns_parser.go
@@ -345,6 +345,10 @@ func DecodePayload(dm *DNSMessage, header *DNSHeader, config *pkgconfig.Config) 
 		edns, _, err := DecodeEDNS(header.Arcount, payloadOffset, dm.DNS.Payload)
 		if err == nil { // nolint
 			dm.EDNS = edns
+			// Update the RCode to the "real" rcode
+			if header.Qr == 1 {
+				dm.DNS.Rcode = RcodeToString(edns.ExtendedRcode + header.Rcode)
+			}
 		} else if dm.DNS.Flags.TC && (errors.Is(err, ErrDecodeDNSAnswerTooShort) ||
 			errors.Is(err, ErrDecodeDNSAnswerRdataTooShort) ||
 			errors.Is(err, ErrDecodeDNSLabelTooShort) ||


### PR DESCRIPTION
This PR updates the DNS decoding to use the "real" RCode. I noticed that a BADCOOKIE response (RCode 23) was sent as `dns.rcode = XYRRSET` (7) and `edns.rcode = 16` and 16 + 7 = 23. With this change, `dns.rcode` is now set to `BADCOOKIE`.

Discussion:

* Is `dns.rcode` the right place? If not, would something like `dns.effective-rcode` need to be created?
* What to do with `edns.rcode`?
  * Should this remain a number?
  * Should this contain the "effective" RCode when there is an extended RCode?
* Should the effective RCode be done by a transformer and not the parser?

To Do:
* [x] Discuss if this the right approach
* [x] Add tests
