### PR TITLE
Added experimental HTTP enrichment

### DIFF
--- a/dnsutils/dnsmessage.go
+++ b/dnsutils/dnsmessage.go
@@ -189,6 +189,11 @@ type TransformATags struct {
 	Tags []string `json:"tags"`
 }
 
+type TransformRest struct {
+	Failed   bool   `json:"failed"`
+	Response string `json:"response"`
+}
+
 type RelabelingRule struct {
 	Regex       *regexp.Regexp
 	Replacement string
@@ -214,6 +219,7 @@ type DNSMessage struct {
 	MachineLearning *TransformML           `json:"ml,omitempty"`
 	Filtering       *TransformFiltering    `json:"filtering,omitempty"`
 	ATags           *TransformATags        `json:"atags,omitempty"`
+	Rest            *TransformRest         `json:"rest,omitempty"`
 	Relabeling      *TransformRelabeling   `json:"-"`
 }
 
@@ -263,6 +269,7 @@ func (dm *DNSMessage) Init() {
 func (dm *DNSMessage) InitTransforms() {
 	// init transforms
 	dm.ATags = &TransformATags{}
+	dm.Rest = &TransformRest{}
 	dm.Filtering = &TransformFiltering{}
 	dm.MachineLearning = &TransformML{}
 	dm.Reducer = &TransformReducer{}

--- a/docs/collectors/collector_webhook.md
+++ b/docs/collectors/collector_webhook.md
@@ -1,0 +1,62 @@
+# Collector: HTTP Webhook
+
+Special middleware-type collector to be used as part of pipeline.
+
+Performs HTTP POST to 3rd party system with JSON-encoded DNS message as payload.
+Returned HTTP body is added to DNS message.
+HTTP basic auth is optional.
+
+If num-threads is increased from default 1 then DNS message order from input to output is **not** guaranteed as lookups are performed by parallel HTTP lookup threads.
+
+Options:
+
+* `enable` (bool)
+  > enable webhook
+
+* `url` (string)
+  > HTTP URL
+
+* `timeout` (int)
+  > HTTP timeout
+
+* `basic-auth-enable` (bool)
+  > perform HTTP basic auth with provided credentials
+
+* `basic-auth-login` (string)
+  > HTTP basic auth username
+
+* `basic-auth-pwd` (string)
+  > HTTP basic auth password
+
+* `num-threads` (int)
+  > Number of parallel HTTP lookup threads
+
+```yaml
+- name: webhook
+  webhook:
+    enable: true
+    url: http://localhost:8000
+    timeout: 1
+    basic-auth-enable: true
+    basic-auth-login: username
+    basic-auth-pwd: password
+    num-threads: 10
+  routing-policy:
+    forward: [ to-logger ]
+```
+
+When the feature is enabled, the following JSON structure is populated in your DNS message:
+
+```json
+{
+  "rest": {
+    "failed": false,
+    "response": "HTTP return body"
+  }
+},
+```
+
+Specific directives added:
+
+* `failed`: Indicates if HTTP request was successful
+* `response`: HTTP return body from performed HTTP POST

--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -54,6 +54,7 @@ Transformers execute in a specific sequence to ensure data consistency and optim
 |-------------|------------------------|------------------|
 | [GeoIP Metadata](transformers/transform_geoip.md) | • **Country Identification**: Client geolocation<br/>• **City-Level Data**: Detailed location information<br/>• **ASN Mapping**: Internet service provider data<br/>• **IP Intelligence**: Threat reputation scoring | • Geographic traffic analysis<br/>• Compliance monitoring<br/>• Threat intelligence correlation<br/>• Content delivery optimization |
 | [Data Extractor](transformers/transform_dataextractor.md) | • **Base64 Encoding**: Full DNS payload preservation<br/>• **Binary Data Handling**: Raw packet analysis<br/>• **Metadata Extraction**: Protocol-level details<br/>• **Custom Field Addition**: Flexible data enhancement | • Deep packet inspection<br/>• Forensic analysis<br/>• Custom analytics<br/>• Advanced research |
+| [REST Lookup](transformers/transform_rest.md) | • **Custom Data Addition**: Flexible data enhancement | • Business intelligence integration |
 
 ### Data Transformation & Formatting
 

--- a/docs/transformers/transform_rest.md
+++ b/docs/transformers/transform_rest.md
@@ -1,0 +1,54 @@
+# Transformer: REST Lookup
+
+Performs HTTP POST to 3rd party system with JSON-encoded DNS message as payload.
+Returned HTTP body is added to DNS message.
+HTTP basic auth is optional.
+
+HTTP lookups have high overhead, see [Webhook collector](../collectors/collector_webhook.md) for increased-performance version of similar functionality.
+
+Options:
+
+* `enable` (bool)
+  > enable transformer
+
+* `url` (string)
+  > HTTP URL
+
+* `timeout` (int)
+  > HTTP timeout
+
+* `basic-auth-enable` (bool)
+  > perform HTTP basic auth with provided credentials
+
+* `basic-auth-login` (string)
+  > HTTP basic auth username
+
+* `basic-auth-pwd` (string)
+  > HTTP basic auth password
+
+```yaml
+transforms:
+  rest:
+    enable: true
+    url: http://localhost:8000
+    timeout: 1
+    basic-auth-enable: true
+    basic-auth-login: username
+    basic-auth-pwd: password
+```
+
+When the feature is enabled, the following JSON structure is populated in your DNS message:
+
+```json
+{
+  "rest": {
+    "failed": false,
+    "response": "HTTP return body"
+  }
+},
+```
+
+Specific directives added:
+
+* `failed`: Indicates if HTTP request was successful
+* `response`: HTTP return body from performed HTTP POST

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -29,6 +29,7 @@ Collectors are responsible for gathering DNS data from different sources. They a
 | Collector | Description |
 |-----------|-------------|
 | [DNS Message](collectors/collector_dnsmessage.md) | Filters and matches specific DNS messages |
+| [HTTP Webhook](collectors/collector_webhook.md) | Adds custom data using HTTP webhooks |
 
 ## Supported Loggers
 

--- a/pkgconfig/collectors.go
+++ b/pkgconfig/collectors.go
@@ -92,6 +92,16 @@ type ConfigCollectors struct {
 		ListenPort        int    `yaml:"listen-port" default:"10000"`
 		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
 	} `yaml:"tzsp"`
+	Webhook struct {
+		Enable            bool   `yaml:"enable" default:"false"`
+		URL               string `yaml:"url" default:"http://127.0.0.1:8088"`
+		Timeout           int    `yaml:"timeout" default:"1"`
+		BasicAuthEnabled  bool   `yaml:"basic-auth-enable" default:"false"`
+		BasicAuthLogin    string `yaml:"basic-auth-login" default:""`
+		BasicAuthPwd      string `yaml:"basic-auth-pwd" default:""`
+		NumThreads        int    `yaml:"num-threads" default:"1"`
+		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
+	} `yaml:"webhook"`
 }
 
 func (c *ConfigCollectors) SetDefault() {

--- a/pkgconfig/transformers.go
+++ b/pkgconfig/transformers.go
@@ -87,6 +87,14 @@ type ConfigTransformers struct {
 		Enable  bool     `yaml:"enable" default:"false"`
 		AddTags []string `yaml:"add-tags,flow" default:"[]"`
 	} `yaml:"atags"`
+	Rest struct {
+		Enable           bool   `yaml:"enable" default:"false"`
+		URL              string `yaml:"url" default:"http://127.0.0.1:8088"`
+		Timeout          int    `yaml:"timeout" default:"1"`
+		BasicAuthEnabled bool   `yaml:"basic-auth-enable" default:"false"`
+		BasicAuthLogin   string `yaml:"basic-auth-login" default:""`
+		BasicAuthPwd     string `yaml:"basic-auth-pwd" default:""`
+	} `yaml:"rest"`
 	Relabeling struct {
 		Enable bool               `yaml:"enable" default:"false"`
 		Rename []RelabelingConfig `yaml:"rename,flow"`

--- a/pkginit/pipelines.go
+++ b/pkginit/pipelines.go
@@ -241,6 +241,10 @@ func CreateStanza(stanzaName string, config *pkgconfig.Config, mapCollectors map
 		mapCollectors[stanzaName] = workers.NewTZSP(nil, config, logger, stanzaName)
 		mapCollectors[stanzaName].SetMetrics(metrics)
 	}
+	if config.Collectors.Webhook.Enable {
+		mapCollectors[stanzaName] = workers.NewWebhook(nil, config, logger, stanzaName)
+		mapCollectors[stanzaName].SetMetrics(metrics)
+	}
 }
 
 func InitPipelines(mapLoggers map[string]workers.Worker, mapCollectors map[string]workers.Worker, config *pkgconfig.Config, logger *logger.Logger, telemetry *telemetry.PrometheusCollector) error {

--- a/transformers/rest.go
+++ b/transformers/rest.go
@@ -1,0 +1,84 @@
+package transformers
+
+import (
+	"time"
+	"io"
+	"net/http"
+	"bytes"
+	"encoding/json"
+
+	"github.com/dmachard/go-dnscollector/dnsutils"
+	"github.com/dmachard/go-dnscollector/pkgconfig"
+	"github.com/dmachard/go-logger"
+)
+
+type RestTransform struct {
+	GenericTransformer
+	httpclient *http.Client
+}
+
+func NewRestTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan dnsutils.DNSMessage) *RestTransform {
+	t := &RestTransform{GenericTransformer: NewTransformer(config, logger, "rest", name, instance, nextWorkers)}
+	return t
+}
+
+func (t *RestTransform) GetTransforms() ([]Subtransform, error) {
+	subtransforms := []Subtransform{}
+	if t.config.Rest.Enable {
+		t.Setup()
+		subtransforms = append(subtransforms, Subtransform{name: "rest:request", processFunc: t.Request})
+	}
+	return subtransforms, nil
+}
+
+func (t *RestTransform) Setup() () {
+	tr := &http.Transport{
+		MaxIdleConns: 10,
+		MaxIdleConnsPerHost: 10,
+		IdleConnTimeout: 30 * time.Second,
+	}
+
+	t.httpclient = &http.Client{
+		Timeout: time.Duration(t.config.Rest.Timeout) * time.Second,
+		Transport: tr,
+	}
+}
+
+func (t *RestTransform) Request(dm *dnsutils.DNSMessage) (int, error) {
+	if dm.Rest == nil {
+		dm.Rest = &dnsutils.TransformRest{Failed: true, Response: ""}
+	}
+
+	payload, err := json.Marshal(dm)
+
+	post, err := http.NewRequest("POST", t.config.Rest.URL, bytes.NewBuffer(payload))
+
+	post.Header.Set("Content-Type", "application/json")
+
+	if t.config.Rest.BasicAuthEnabled {
+		post.SetBasicAuth(t.config.Rest.BasicAuthLogin, t.config.Rest.BasicAuthPwd)
+	}
+
+	resp, err := t.httpclient.Do(post)
+	if err != nil {
+		t.LogError("HTTP request failed: %s", err)
+		return ReturnKeep, nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.LogError("invalid HTTP status code: %d", resp.StatusCode)
+		return ReturnKeep, nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.LogError("HTTP body read failed: %s", err)
+		return ReturnKeep, nil
+	}
+
+	dm.Rest.Failed = false
+	dm.Rest.Response = string(body)
+
+	return ReturnKeep, nil
+}

--- a/transformers/rest.go
+++ b/transformers/rest.go
@@ -1,11 +1,11 @@
 package transformers
 
 import (
-	"time"
-	"io"
-	"net/http"
 	"bytes"
 	"encoding/json"
+	"io"
+	"net/http"
+	"time"
 
 	"github.com/dmachard/go-dnscollector/dnsutils"
 	"github.com/dmachard/go-dnscollector/pkgconfig"
@@ -31,15 +31,15 @@ func (t *RestTransform) GetTransforms() ([]Subtransform, error) {
 	return subtransforms, nil
 }
 
-func (t *RestTransform) Setup() () {
+func (t *RestTransform) Setup() {
 	tr := &http.Transport{
-		MaxIdleConns: 10,
+		MaxIdleConns:        10,
 		MaxIdleConnsPerHost: 10,
-		IdleConnTimeout: 30 * time.Second,
+		IdleConnTimeout:     30 * time.Second,
 	}
 
 	t.httpclient = &http.Client{
-		Timeout: time.Duration(t.config.Rest.Timeout) * time.Second,
+		Timeout:   time.Duration(t.config.Rest.Timeout) * time.Second,
 		Transport: tr,
 	}
 }
@@ -50,8 +50,16 @@ func (t *RestTransform) Request(dm *dnsutils.DNSMessage) (int, error) {
 	}
 
 	payload, err := json.Marshal(dm)
+	if err != nil {
+		t.LogError("JSON marshal failed: %s", err)
+		return ReturnKeep, nil
+	}
 
 	post, err := http.NewRequest("POST", t.config.Rest.URL, bytes.NewBuffer(payload))
+	if err != nil {
+		t.LogError("HTTP error: %s", err)
+		return ReturnKeep, nil
+	}
 
 	post.Header.Set("Content-Type", "application/json")
 

--- a/transformers/rest_test.go
+++ b/transformers/rest_test.go
@@ -1,0 +1,58 @@
+package transformers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmachard/go-dnscollector/dnsutils"
+	"github.com/dmachard/go-dnscollector/pkgconfig"
+	"github.com/dmachard/go-logger"
+)
+
+func TestRest_Request(t *testing.T) {
+	// Create a test HTTP server to simulate remote API
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		if username != "testuser" || password != "testpass" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		fmt.Fprintf(w, "testbody")
+	}))
+	defer server.Close()
+
+	// enable feature
+	config := pkgconfig.GetFakeConfigTransformers()
+	config.Rest.Enable = true
+	config.Rest.URL = server.URL
+	config.Rest.BasicAuthEnabled = true
+	config.Rest.BasicAuthLogin = "testuser"
+	config.Rest.BasicAuthPwd = "testpass"
+
+	// init the processor
+	outChans := []chan dnsutils.DNSMessage{}
+	rest := NewRestTransform(config, logger.New(false), "test", 0, outChans)
+	rest.GetTransforms()
+
+	// send message
+	dm := dnsutils.GetFakeDNSMessage()
+	rest.Request(&dm)
+
+	// check results
+	if dm.Rest.Failed != false {
+		t.Errorf("REST request failed")
+	}
+
+	if dm.Rest.Response != "testbody" {
+		t.Errorf("REST body mismatch, want: testbody got: %s", dm.Rest.Response)
+	}
+}

--- a/transformers/rest_test.go
+++ b/transformers/rest_test.go
@@ -21,12 +21,12 @@ func TestRest_Request(t *testing.T) {
 			return
 		}
 
-		if username != "testuser" || password != "testpass" {
+		if username != "restuser" || password != "restpass" {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
 
-		fmt.Fprintf(w, "testbody")
+		fmt.Fprintf(w, "restbody")
 	}))
 	defer server.Close()
 
@@ -35,8 +35,8 @@ func TestRest_Request(t *testing.T) {
 	config.Rest.Enable = true
 	config.Rest.URL = server.URL
 	config.Rest.BasicAuthEnabled = true
-	config.Rest.BasicAuthLogin = "testuser"
-	config.Rest.BasicAuthPwd = "testpass"
+	config.Rest.BasicAuthLogin = "restuser"
+	config.Rest.BasicAuthPwd = "restpass"
 
 	// init the processor
 	outChans := []chan dnsutils.DNSMessage{}
@@ -52,7 +52,7 @@ func TestRest_Request(t *testing.T) {
 		t.Errorf("REST request failed")
 	}
 
-	if dm.Rest.Response != "testbody" {
-		t.Errorf("REST body mismatch, want: testbody got: %s", dm.Rest.Response)
+	if dm.Rest.Response != "restbody" {
+		t.Errorf("REST body mismatch, want: restbody got: %s", dm.Rest.Response)
 	}
 }

--- a/transformers/transformers.go
+++ b/transformers/transformers.go
@@ -78,6 +78,7 @@ func NewTransforms(config *pkgconfig.ConfigTransformers, logger *logger.Logger, 
 	d.availableTransforms = append(d.availableTransforms, TransformEntry{NewFilteringTransform(config, logger, name, instance, nextWorkers)})
 	d.availableTransforms = append(d.availableTransforms, TransformEntry{NewReducerTransform(config, logger, name, instance, nextWorkers)})
 	d.availableTransforms = append(d.availableTransforms, TransformEntry{NewATagsTransform(config, logger, name, instance, nextWorkers)})
+	d.availableTransforms = append(d.availableTransforms, TransformEntry{NewRestTransform(config, logger, name, instance, nextWorkers)})
 	d.availableTransforms = append(d.availableTransforms, TransformEntry{NewRelabelTransform(config, logger, name, instance, nextWorkers)})
 	d.availableTransforms = append(d.availableTransforms, TransformEntry{NewUserPrivacyTransform(config, logger, name, instance, nextWorkers)})
 	d.availableTransforms = append(d.availableTransforms, TransformEntry{NewExtractTransform(config, logger, name, instance, nextWorkers)})

--- a/workers/webhook.go
+++ b/workers/webhook.go
@@ -1,0 +1,173 @@
+package workers
+
+import (
+	"context"
+	"net/http"
+	"time"
+	"io"
+	"bytes"
+	"encoding/json"
+
+	"github.com/dmachard/go-dnscollector/dnsutils"
+	"github.com/dmachard/go-dnscollector/pkgconfig"
+	"github.com/dmachard/go-dnscollector/transformers"
+	"github.com/dmachard/go-logger"
+)
+
+type Webhook struct {
+	*GenericWorker
+	httpclient       *http.Client
+	URL              string
+	BasicAuthEnabled bool
+	BasicAuthLogin   string
+	BasicAuthPwd     string
+}
+
+func NewWebhook(next []Worker, config *pkgconfig.Config, logger *logger.Logger, name string) *Webhook {
+	bufSize := config.Global.Worker.ChannelBufferSize
+	if config.Collectors.Webhook.ChannelBufferSize > 0 {
+		bufSize = config.Collectors.Webhook.ChannelBufferSize
+	}
+	w := &Webhook{GenericWorker: NewGenericWorker(config, logger, name, "webhook", bufSize, pkgconfig.DefaultMonitor)}
+	w.SetDefaultRoutes(next)
+	w.ReadConfig()
+	return w
+}
+
+func (w *Webhook) ReadConfig() {
+	w.URL = w.GetConfig().Collectors.Webhook.URL
+	w.BasicAuthEnabled = w.GetConfig().Collectors.Webhook.BasicAuthEnabled
+	w.BasicAuthLogin = w.GetConfig().Collectors.Webhook.BasicAuthLogin
+	w.BasicAuthPwd = w.GetConfig().Collectors.Webhook.BasicAuthPwd
+
+	tr := &http.Transport{
+		MaxIdleConns: 10,
+		MaxIdleConnsPerHost: 10,
+		IdleConnTimeout: 30 * time.Second,
+	}
+
+	w.httpclient = &http.Client{
+		Timeout: time.Duration(w.GetConfig().Collectors.Webhook.Timeout) * time.Second,
+		Transport: tr,
+	}
+}
+
+func (w *Webhook) StartCollect() {
+	w.LogInfo("starting data collection")
+	defer w.CollectDone()
+
+	// prepare next channels for dropped messages, forwarding is done in logger
+	droppedRoutes, droppedNames := GetRoutes(w.GetDroppedRoutes())
+
+	// prepare transforms
+	subprocessors := transformers.NewTransforms(&w.GetConfig().OutgoingTransformers, w.GetLogger(), w.GetName(), w.GetOutputChannelAsList(), 0)
+
+	// goroutines to process and forward transformed dns messages
+	ctx, cancel := context.WithCancel(context.Background())
+	for n := 1; n <= w.GetConfig().Collectors.Webhook.NumThreads; n++ {
+		go w.StartLogging(n, ctx)
+	}
+
+	// read incoming dns message
+	w.LogInfo("waiting dns message to process...")
+	for {
+		select {
+		case <-w.OnStop():
+			subprocessors.Reset()
+			cancel()
+			return
+
+		// save the new config
+		case cfg := <-w.NewConfig():
+			w.SetConfig(cfg)
+			w.ReadConfig()
+
+		case dm, opened := <-w.GetInputChannel():
+			if !opened {
+				w.LogInfo("channel closed, exit")
+				return
+			}
+			// count global messages
+			w.CountIngressTraffic()
+
+			// apply tranforms, init dns message with additionnals parts if necessary
+			transformResult, err := subprocessors.ProcessMessage(&dm)
+			if err != nil {
+				w.LogError(err.Error())
+			}
+			if transformResult == transformers.ReturnDrop {
+				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+				continue
+			}
+			// count output packets
+			w.CountEgressTraffic()
+
+			w.GetOutputChannel() <- dm
+		}
+	}
+}
+
+func (w *Webhook) StartLogging(threadnum int, ctx context.Context) {
+	w.LogInfo("logging thread %d has started", threadnum)
+	defer w.LoggingDone()
+
+	defaultRoutes, defaultNames := GetRoutes(w.GetDefaultRoutes())
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case dm, opened := <-w.GetOutputChannel():
+			if !opened {
+				w.LogInfo("output channel closed!")
+				return
+			}
+
+			// enrich dm with HTTP data
+			w.Request(&dm)
+
+			// send to next
+			w.SendForwardedTo(defaultRoutes, defaultNames, dm)
+		}
+	}
+}
+
+func (w *Webhook) Request(dm *dnsutils.DNSMessage) (error) {
+	if dm.Rest == nil {
+		dm.Rest = &dnsutils.TransformRest{Failed: true, Response: ""}
+	}
+
+	payload, err := json.Marshal(dm)
+
+	post, err := http.NewRequest("POST", w.URL, bytes.NewBuffer(payload))
+
+	post.Header.Set("Content-Type", "application/json")
+
+	if w.BasicAuthEnabled {
+		post.SetBasicAuth(w.BasicAuthLogin, w.BasicAuthPwd)
+	}
+
+	resp, err := w.httpclient.Do(post)
+	if err != nil {
+		w.LogError("HTTP request failed: %s", err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		w.LogError("invalid HTTP status code: %d", resp.StatusCode)
+		return err
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		w.LogError("HTTP body read failed: %s", err)
+		return err
+	}
+
+	dm.Rest.Failed = false
+	dm.Rest.Response = string(body)
+
+	return nil
+}

--- a/workers/webhook.go
+++ b/workers/webhook.go
@@ -1,12 +1,12 @@
 package workers
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"time"
-	"io"
-	"bytes"
-	"encoding/json"
 
 	"github.com/dmachard/go-dnscollector/dnsutils"
 	"github.com/dmachard/go-dnscollector/pkgconfig"
@@ -41,13 +41,13 @@ func (w *Webhook) ReadConfig() {
 	w.BasicAuthPwd = w.GetConfig().Collectors.Webhook.BasicAuthPwd
 
 	tr := &http.Transport{
-		MaxIdleConns: 10,
+		MaxIdleConns:        10,
 		MaxIdleConnsPerHost: 10,
-		IdleConnTimeout: 30 * time.Second,
+		IdleConnTimeout:     30 * time.Second,
 	}
 
 	w.httpclient = &http.Client{
-		Timeout: time.Duration(w.GetConfig().Collectors.Webhook.Timeout) * time.Second,
+		Timeout:   time.Duration(w.GetConfig().Collectors.Webhook.Timeout) * time.Second,
 		Transport: tr,
 	}
 }
@@ -85,6 +85,7 @@ func (w *Webhook) StartCollect() {
 		case dm, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("channel closed, exit")
+				cancel()
 				return
 			}
 			// count global messages
@@ -133,14 +134,22 @@ func (w *Webhook) StartLogging(threadnum int, ctx context.Context) {
 	}
 }
 
-func (w *Webhook) Request(dm *dnsutils.DNSMessage) (error) {
+func (w *Webhook) Request(dm *dnsutils.DNSMessage) error {
 	if dm.Rest == nil {
 		dm.Rest = &dnsutils.TransformRest{Failed: true, Response: ""}
 	}
 
 	payload, err := json.Marshal(dm)
+	if err != nil {
+		w.LogError("JSON marshal failed: %s", err)
+		return err
+	}
 
 	post, err := http.NewRequest("POST", w.URL, bytes.NewBuffer(payload))
+	if err != nil {
+		w.LogError("HTTP error: %s", err)
+		return err
+	}
 
 	post.Header.Set("Content-Type", "application/json")
 

--- a/workers/webhook_test.go
+++ b/workers/webhook_test.go
@@ -1,0 +1,67 @@
+package workers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmachard/go-dnscollector/dnsutils"
+	"github.com/dmachard/go-dnscollector/pkgconfig"
+	"github.com/dmachard/go-logger"
+)
+
+func Test_Webhook(t *testing.T) {
+	// Create a test HTTP server to simulate remote API
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		if username != "testuser" || password != "testpass" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		fmt.Fprintf(w, "testbody")
+	}))
+	defer server.Close()
+
+	// simulate next workers
+	kept := GetWorkerForTest(pkgconfig.DefaultBufferSize)
+	dropped := GetWorkerForTest(pkgconfig.DefaultBufferSize)
+
+	// config for the collector
+	config := pkgconfig.GetDefaultConfig()
+	config.Collectors.Webhook.Enable = true
+	config.Collectors.Webhook.URL = server.URL
+	config.Collectors.Webhook.BasicAuthEnabled = true
+	config.Collectors.Webhook.BasicAuthLogin = "testuser"
+	config.Collectors.Webhook.BasicAuthPwd = "testpass"
+
+	// init collector
+	c := NewWebhook(nil, config, logger.New(false), "test")
+	c.SetDefaultRoutes([]Worker{kept})
+	c.SetDefaultDropped([]Worker{dropped})
+
+	// start to collect and send DNS messages on it
+	go c.StartCollect()
+
+	// send fake dns message to logger
+	dm := dnsutils.GetFakeDNSMessage()
+	c.GetInputChannel() <- dm
+
+	dmOut := <-kept.GetInputChannel()
+
+	// check results
+	if dmOut.Rest.Failed != false {
+		t.Errorf("REST request failed")
+	}
+
+	if dmOut.Rest.Response != "testbody" {
+		t.Errorf("REST body mismatch, want: testbody got: %s", dmOut.Rest.Response)
+	}
+}

--- a/workers/webhook_test.go
+++ b/workers/webhook_test.go
@@ -21,12 +21,12 @@ func Test_Webhook(t *testing.T) {
 			return
 		}
 
-		if username != "testuser" || password != "testpass" {
+		if username != "whuser" || password != "whpass" {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
 
-		fmt.Fprintf(w, "testbody")
+		fmt.Fprintf(w, "whbody")
 	}))
 	defer server.Close()
 
@@ -39,8 +39,8 @@ func Test_Webhook(t *testing.T) {
 	config.Collectors.Webhook.Enable = true
 	config.Collectors.Webhook.URL = server.URL
 	config.Collectors.Webhook.BasicAuthEnabled = true
-	config.Collectors.Webhook.BasicAuthLogin = "testuser"
-	config.Collectors.Webhook.BasicAuthPwd = "testpass"
+	config.Collectors.Webhook.BasicAuthLogin = "whuser"
+	config.Collectors.Webhook.BasicAuthPwd = "whpass"
 
 	// init collector
 	c := NewWebhook(nil, config, logger.New(false), "test")
@@ -61,7 +61,7 @@ func Test_Webhook(t *testing.T) {
 		t.Errorf("REST request failed")
 	}
 
-	if dmOut.Rest.Response != "testbody" {
-		t.Errorf("REST body mismatch, want: testbody got: %s", dmOut.Rest.Response)
+	if dmOut.Rest.Response != "whbody" {
+		t.Errorf("REST body mismatch, want: whbody got: %s", dmOut.Rest.Response)
 	}
 }


### PR DESCRIPTION
I've added two experimental ways to do HTTP lookups to 3rd party system and add HTTP response into dnsmessage to be processed further.

I first added REST transformer and while it works fine, it's not very performant as the messages are processed in single thread and HTTP lookups take quite a bit of time.

I then added webhook "middleware" (it's neither collector or logger, similar to dnsmessage) that can be used as part of pipeline. It can use >1 threads so performance is greatly improved. Obvious downside is that message order cannot be guaranteed and that is why default number of threads is 1.

Should I keep both or drop the transformer?

Does this look mergeable? If so I'll finish and add tests/documentation as well.