### PR TITLE
feat: add OpenTelemetry data and EDNS version to PowerDNS collector

### DIFF
--- a/dnsutils/dnsmessage.go
+++ b/dnsutils/dnsmessage.go
@@ -118,6 +118,8 @@ type CollectorPowerDNS struct {
 	RequestorID           string            `json:"requestor-id"`
 	DeviceName            string            `json:"device-name"`
 	DeviceID              string            `json:"device-id"`
+	OpenTelemetryData     string            `json:"opentelemetry-data"`
+	EdnsVersion           string            `json:"edns-version"`
 }
 
 type LoggerOpenTelemetry struct {

--- a/dnsutils/dnsmessage_text.go
+++ b/dnsutils/dnsmessage_text.go
@@ -192,6 +192,18 @@ func (dm *DNSMessage) handlePdnsDirectives(directive string, s *strings.Builder)
 			} else {
 				s.WriteString("-")
 			}
+		case "powerdns-edns-version":
+			if len(dm.PowerDNS.EdnsVersion) > 0 {
+				s.WriteString(dm.PowerDNS.EdnsVersion)
+			} else {
+				s.WriteString("-")
+			}
+		case "powerdns-opentelemetry-data":
+			if len(dm.PowerDNS.OpenTelemetryData) > 0 {
+				s.WriteString(dm.PowerDNS.OpenTelemetryData)
+			} else {
+				s.WriteString("-")
+			}
 		default:
 			return errors.New(ErrorUnexpectedDirective + directive)
 		}

--- a/dnsutils/dnsmessage_text_test.go
+++ b/dnsutils/dnsmessage_text_test.go
@@ -596,6 +596,18 @@ func TestDnsMessage_TextFormat_Directives_Pdns(t *testing.T) {
 			dm:       DNSMessage{PowerDNS: &CollectorPowerDNS{DeviceID: "5e006236c8a74f7eafc6af126e6d0689", DeviceName: "test"}},
 			expected: "5e006236c8a74f7eafc6af126e6d0689 test",
 		},
+		{
+			name:     "ends_version",
+			format:   "powerdns-edns-version",
+			dm:       DNSMessage{PowerDNS: &CollectorPowerDNS{EdnsVersion: "1"}},
+			expected: "1",
+		},
+		{
+			name:     "opentelemetry_data",
+			format:   "powerdns-opentelemetry-data",
+			dm:       DNSMessage{PowerDNS: &CollectorPowerDNS{OpenTelemetryData: "5e006236c8a74f7eafc6af126e6d0689"}},
+			expected: "5e006236c8a74f7eafc6af126e6d0689",
+		},
 	}
 
 	for _, tc := range testcases {

--- a/docs/collectors/collector_powerdns.md
+++ b/docs/collectors/collector_powerdns.md
@@ -74,6 +74,8 @@ If you logs your DNS traffic in basic text format, you can use the specific dire
 * `powerdns-requestor-id`: requestor id
 * `powerdns-device-id`: device id
 * `powerdns-device-name`: device name
+* `powerdns-edns-version`: EDNS version
+* `powerdns-opentelemetry-data`: Open Telemetry data
 
 Configuration example:
 

--- a/workers/powerdns.go
+++ b/workers/powerdns.go
@@ -340,6 +340,14 @@ func (w *PdnsProcessor) StartCollect() {
 			}
 			pdns.Tags = tags
 
+			// get powerdns oepn telemetry data
+			opendata := pbdm.GetOpenTelemetryData()
+			pdns.OpenTelemetryData = hex.EncodeToString(opendata)
+
+			// get powerdns edns version
+			ednsVersion := pbdm.GetEdnsVersion()
+			pdns.EdnsVersion = strconv.Itoa(int(ednsVersion))
+
 			// get PowerDNS policy applied
 			pdns.AppliedPolicy = pbdm.GetResponse().GetAppliedPolicy()
 			pdns.AppliedPolicyHit = pbdm.GetResponse().GetAppliedPolicyHit()


### PR DESCRIPTION
fix #1072 

- [ ] update doc
- [ ] add tests

```

     dnsmessage_json_test.go:162: json format different from reference, Get=map[applied-policy:basicrpz applied-policy-hit:hit applied-policy-kind:kind applied-policy-trigger:trigger applied-policy-type:type device-id:ffffffffffffffffeaaeaeae device-name:foobar edns-version: http-version:http3 initial-requestor-id:5e006236c8a74f7eafc6af126e6d0689 message-id:27c3e94ad6284eec9a50cfc5bd7384d6 metadata:map[stream_id:collector] opentelemetry-data: original-request-subnet:subnet requestor-id:f7c3e94ad6284eec9a50cfc5bd7384d6 tags:[tag1]] Want=map[applied-policy:basicrpz applied-policy-hit:hit applied-policy-kind:kind applied-policy-trigger:trigger applied-policy-type:type device-id:ffffffffffffffffeaaeaeae device-name:foobar http-version:http3 initial-requestor-id:5e006236c8a74f7eafc6af126e6d0689 message-id:27c3e94ad6284eec9a50cfc5bd7384d6 metadata:map[stream_id:collector] original-request-subnet:subnet requestor-id:f7c3e94ad6284eec9a50cfc5bd7384d6 tags:[tag1]]
--- FAIL: TestDnsMessage_Json_Collectors_Reference (0.00s)
    --- FAIL: TestDnsMessage_Json_Collectors_Reference/powerdns (0.00s)
```