### PR TITLE
docs(afpacket): fix IP-defrag option name 'enable-fragment-support' -> 'enable-defrag-ip'

### DIFF
--- a/docs/collectors/collector_afpacket.md
+++ b/docs/collectors/collector_afpacket.md
@@ -27,7 +27,7 @@ Options:
 * `enable-gre` (bool)
   > Enable GRE decoding protocol support
 
-* `enable-fragment-support` (bool)
+* `enable-defrag-ip` (bool)
   > Enable IP defrag support
 
 * `chan-buffer-size` (int)


### PR DESCRIPTION
## Summary

The afpacket collector docs listed the IP-defrag option as \`enable-fragment-support\`:

\`\`\`markdown
* \`enable-fragment-support\` (bool)
  > Enable IP defrag support
\`\`\`

But the YAML tag in \`pkgconfig/collectors.go:58\` is \`yaml:\"enable-defrag-ip\"\`, and the example config block on the same docs page (line 46) already uses \`enable-defrag-ip: true\`. A user copy-pasting the bullet name into their YAML would silently be ignored.

Closes #1202

## Testing

Docs-only change.