### PR TITLE
docs: fix slowfiltering example

### DIFF
--- a/docs/_examples/config-dnstap-slowfiltering.yml
+++ b/docs/_examples/config-dnstap-slowfiltering.yml
@@ -27,8 +27,8 @@ pipelines:
       matching:
         include:
           dnstap.operation: "CLIENT_RESPONSE"
-          dnstap.latency:
-            greater-than: 0.2
+          dnstap.latency_ms:
+            greater-than: 200
     routing-policy:
       forward: [outputfile-slowresponses]
 


### PR DESCRIPTION
The example uses greater-than to compare the latency threshold. But as per documentation greater-than compares int, while dnstap.latency is a float. Changed example to use latency_ms and adjusted the value accordingly.