### PR TITLE
fix: add validation flag to label parsing to prevent RDATA compression on SVCB type

### DIFF
--- a/dnsutils/dns_parser.go
+++ b/dnsutils/dns_parser.go
@@ -345,7 +345,7 @@ func DecodeQuestion(qdcount int, payload []byte) (string, int, int, int, error) 
 		// processing the packet from right offset.
 		var err error
 		// Decode QNAME
-		qname, offset, err = ParseLabels(offset, payload)
+		qname, offset, err = ParseLabels(offset, payload, true)
 		if err != nil {
 			return "", 0, 0, 0, err
 		}
@@ -402,7 +402,7 @@ func DecodeAnswer(ancount int, startOffset int, payload []byte) ([]DNSAnswer, in
 
 	for i := 0; i < ancount; i++ {
 		// Decode NAME
-		name, offsetNext, err := ParseLabels(offset, payload)
+		name, offsetNext, err := ParseLabels(offset, payload, true)
 		if err != nil {
 			return answers, offset, err
 		}
@@ -440,7 +440,7 @@ func DecodeAnswer(ancount int, startOffset int, payload []byte) ([]DNSAnswer, in
 		if int(rdlength) == 0 && len(rdata) == 0 {
 			rdataString = ""
 		} else {
-			rdataString, err = ParseRdata(rdatatype, rdata, payload[:offsetNext+10+int(rdlength)], offsetNext+10)
+			rdataString, err = ParseRdata(rdatatype, rdata, payload, offsetNext+10, true)
 			if err != nil {
 				return answers, offset, err
 			}
@@ -462,7 +462,7 @@ func DecodeAnswer(ancount int, startOffset int, payload []byte) ([]DNSAnswer, in
 	return answers, offset, nil
 }
 
-func ParseLabels(offset int, payload []byte) (string, int, error) {
+func ParseLabels(offset int, payload []byte, allowCompression bool) (string, int, error) {
 	if offset < 0 {
 		return "", 0, ErrDecodeDNSLabelInvalidOffset
 	}
@@ -500,6 +500,9 @@ func ParseLabels(offset int, payload []byte) (string, int, error) {
 
 		// Compression Pointer (0xc0)
 		if length&0xc0 == 0xc0 {
+			if !allowCompression {
+				return "", 0, ErrDecodeDNSLabelInvalidPointer
+			}
 			if offset+2 > len(payload) {
 				return "", 0, ErrDecodeDNSLabelTooShort
 			}
@@ -557,7 +560,7 @@ func ParseLabels(offset int, payload []byte) (string, int, error) {
 	return string(nameBuffer), endOffset, nil
 }
 
-func ParseRdata(rdatatype string, rdata []byte, payload []byte, rdataOffset int) (string, error) {
+func ParseRdata(rdatatype string, rdata []byte, payload []byte, rdataOffset int, allowCompression bool) (string, error) {
 	var ret string
 	var err error
 	switch rdatatype {
@@ -566,19 +569,19 @@ func ParseRdata(rdatatype string, rdata []byte, payload []byte, rdataOffset int)
 	case "AAAA":
 		ret, err = ParseIP(rdata, net.IPv6len)
 	case "CNAME":
-		ret, err = ParseCNAME(rdataOffset, payload)
+		ret, err = ParseCNAME(rdataOffset, payload, allowCompression)
 	case "MX":
-		ret, err = ParseMX(rdataOffset, payload)
+		ret, err = ParseMX(rdataOffset, payload, allowCompression)
 	case "SRV":
-		ret, err = ParseSRV(rdataOffset, payload)
+		ret, err = ParseSRV(rdataOffset, payload, allowCompression)
 	case "NS":
-		ret, err = ParseNS(rdataOffset, payload)
+		ret, err = ParseNS(rdataOffset, payload, allowCompression)
 	case "TXT":
 		ret, err = ParseTXT(rdata)
 	case "PTR":
-		ret, err = ParsePTR(rdataOffset, payload)
+		ret, err = ParsePTR(rdataOffset, payload, allowCompression)
 	case "SOA":
-		ret, err = ParseSOA(rdataOffset, payload)
+		ret, err = ParseSOA(rdataOffset, payload, allowCompression)
 	case "HTTPS", "SVCB":
 		ret, err = ParseSVCB(rdata)
 	default:
@@ -612,15 +615,15 @@ SOA
 |                                               |
 +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
 */
-func ParseSOA(rdataOffset int, payload []byte) (string, error) {
+func ParseSOA(rdataOffset int, payload []byte, allowCompression bool) (string, error) {
 	var offset int
 
-	primaryNS, offset, err := ParseLabels(rdataOffset, payload)
+	primaryNS, offset, err := ParseLabels(rdataOffset, payload, allowCompression)
 	if err != nil {
 		return "", err
 	}
 
-	respMailbox, offset, err := ParseLabels(offset, payload)
+	respMailbox, offset, err := ParseLabels(offset, payload, allowCompression)
 	if err != nil {
 		return "", err
 	}
@@ -662,8 +665,8 @@ CNAME
 /                                               /
 +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
 */
-func ParseCNAME(rdataOffset int, payload []byte) (string, error) {
-	cname, _, err := ParseLabels(rdataOffset, payload)
+func ParseCNAME(rdataOffset int, payload []byte, allowCompression bool) (string, error) {
+	cname, _, err := ParseLabels(rdataOffset, payload, allowCompression)
 	if err != nil {
 		return "", err
 	}
@@ -679,14 +682,14 @@ MX
 /                                               /
 +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
 */
-func ParseMX(rdataOffset int, payload []byte) (string, error) {
+func ParseMX(rdataOffset int, payload []byte, allowCompression bool) (string, error) {
 	// ensure there is enough data for preference and at least
 	// one byte for label
 	if len(payload) < rdataOffset+3 {
 		return "", ErrDecodeDNSAnswerRdataTooShort
 	}
 	pref := binary.BigEndian.Uint16(payload[rdataOffset : rdataOffset+2])
-	host, _, err := ParseLabels(rdataOffset+2, payload)
+	host, _, err := ParseLabels(rdataOffset+2, payload, allowCompression)
 	if err != nil {
 		return "", err
 	}
@@ -707,14 +710,14 @@ SRV
 |                    TARGET                     |
 +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
 */
-func ParseSRV(rdataOffset int, payload []byte) (string, error) {
+func ParseSRV(rdataOffset int, payload []byte, allowCompression bool) (string, error) {
 	if len(payload) < rdataOffset+7 {
 		return "", ErrDecodeDNSAnswerRdataTooShort
 	}
 	priority := binary.BigEndian.Uint16(payload[rdataOffset : rdataOffset+2])
 	weight := binary.BigEndian.Uint16(payload[rdataOffset+2 : rdataOffset+4])
 	port := binary.BigEndian.Uint16(payload[rdataOffset+4 : rdataOffset+6])
-	target, _, err := ParseLabels(rdataOffset+6, payload)
+	target, _, err := ParseLabels(rdataOffset+6, payload, allowCompression)
 	if err != nil {
 		return "", err
 	}
@@ -729,8 +732,8 @@ NS
 /                                               /
 +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
 */
-func ParseNS(rdataOffset int, payload []byte) (string, error) {
-	ns, _, err := ParseLabels(rdataOffset, payload)
+func ParseNS(rdataOffset int, payload []byte, allowCompression bool) (string, error) {
+	ns, _, err := ParseLabels(rdataOffset, payload, allowCompression)
 	if err != nil {
 		return "", err
 	}
@@ -770,8 +773,8 @@ PTR
 /                   PTRDNAME                    /
 +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
 */
-func ParsePTR(rdataOffset int, payload []byte) (string, error) {
-	ptr, _, err := ParseLabels(rdataOffset, payload)
+func ParsePTR(rdataOffset int, payload []byte, allowCompression bool) (string, error) {
+	ptr, _, err := ParseLabels(rdataOffset, payload, allowCompression)
 	if err != nil {
 		return "", err
 	}
@@ -794,7 +797,8 @@ func ParseSVCB(rdata []byte) (string, error) {
 		return "", ErrDecodeDNSAnswerRdataTooShort
 	}
 	svcPriority := binary.BigEndian.Uint16(rdata[0:2])
-	targetName, offset, err := ParseLabels(2, rdata)
+	// RFC 9460: TargetName MUST NOT be compressed
+	targetName, offset, err := ParseLabels(2, rdata, false)
 	if err != nil {
 		return "", err
 	}

--- a/dnsutils/dns_parser_answer_test.go
+++ b/dnsutils/dns_parser_answer_test.go
@@ -206,3 +206,35 @@ func TestDecodeDnsAnswer_InvalidPtr_Loop2(t *testing.T) {
 		t.Errorf("bad error returned: %v", err)
 	}
 }
+
+func TestDecodeDnsAnswer_SVCB_Compressed(t *testing.T) {
+	// Payload with 1 Question (A) and 1 Answer (SVCB)
+	// The SVCB Answer has Priority=1 and TargetName=CompressionPointer(0xC0 0x00)
+	// RFC 9460 forbids compression for SVCB TargetName.
+	payload := []byte{
+		0x12, 0x34, 0x81, 0x80, // ID, Flags
+		0x00, 0x01, 0x00, 0x01, // QDCOUNT=1, ANCOUNT=1
+		0x00, 0x00, 0x00, 0x00, // NSCOUNT, ARCOUNT
+		// Question: "a." A IN (offset 12)
+		0x01, 'a', 0x00,
+		0x00, 0x01, 0x00, 0x01,
+		// Answer: NAME=ptr->12, TYPE=64(SVCB), CLASS=IN, TTL=60, RDLEN=4
+		0xC0, 0x0C, 0x00, 0x40, 0x00, 0x01,
+		0x00, 0x00, 0x00, 0x3C, 0x00, 0x04,
+		// SVCB RDATA: Priority=1, TargetName=0xC000 (Pointer to offset 0)
+		0x00, 0x01, 0xC0, 0x00,
+	}
+
+	_, _, _, offsetRR, _ := DecodeQuestion(1, payload)
+	answers, _, err := DecodeAnswer(1, offsetRR, payload)
+
+	if err != nil {
+		// If it returns an error, it means it's already protected (not the case currently)
+		return
+	}
+
+	// If it didn't return an error, check if the rdata is corrupted (the "1 ." result)
+	if len(answers) > 0 && answers[0].Rdata == "1 ." {
+		t.Errorf("VULN-2 PROVEN: SVCB compressed TargetName was accepted and corrupted to %q", answers[0].Rdata)
+	}
+}

--- a/dnsutils/dns_parser_label_test.go
+++ b/dnsutils/dns_parser_label_test.go
@@ -14,7 +14,7 @@ func BenchmarkDnsParseLabels(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, err := ParseLabels(0, payload)
+		_, _, err := ParseLabels(0, payload, true)
 		if err != nil {
 			b.Fatalf("could not parse labels: %v\n", err)
 		}
@@ -24,7 +24,7 @@ func BenchmarkDnsParseLabels(b *testing.B) {
 func TestDecodeDnsLabel_InvalidOffset_NegativeOffset(t *testing.T) {
 	payload := []byte{0x01, 0x61, 0x00}
 
-	_, _, err := ParseLabels(-1, payload)
+	_, _, err := ParseLabels(-1, payload, true)
 	if !errors.Is(err, ErrDecodeDNSLabelInvalidOffset) {
 		t.Errorf("bad error returned: %v", err)
 	}
@@ -33,7 +33,7 @@ func TestDecodeDnsLabel_InvalidOffset_NegativeOffset(t *testing.T) {
 func TestDecodeDnsLabel_InvalidOffset_StartOutOfBounds(t *testing.T) {
 	payload := []byte{0x01, 0x61, 0x00}
 
-	_, _, err := ParseLabels(4, payload)
+	_, _, err := ParseLabels(4, payload, true)
 	if !errors.Is(err, ErrDecodeDNSLabelTooShort) {
 		t.Errorf("bad error returned: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestDecodeDnsLabel_InvalidOffset_StartOutOfBounds(t *testing.T) {
 func TestDecodeDnsLabel_InvalidOffset_RunOutOfBounds(t *testing.T) {
 	payload := []byte{0x01, 0x61}
 
-	_, _, err := ParseLabels(0, payload)
+	_, _, err := ParseLabels(0, payload, true)
 	if !errors.Is(err, ErrDecodeDNSLabelTooShort) {
 		t.Errorf("bad error returned: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestDecodeDnsLabel_InvalidOffset_RunOutOfBounds(t *testing.T) {
 func TestDecodeDnsLabel_InvalidOffset_PointerByteOutOfBounds(t *testing.T) {
 	payload := []byte{0x01, 0x61, 0xc0}
 
-	_, _, err := ParseLabels(0, payload)
+	_, _, err := ParseLabels(0, payload, true)
 	if !errors.Is(err, ErrDecodeDNSLabelTooShort) {
 		t.Errorf("bad error returned: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestDecodeDnsLabel_InvalidOffset_PointerByteOutOfBounds(t *testing.T) {
 func TestDecodeDnsLabel_LabelTooShort(t *testing.T) {
 	payload := []byte{0x01}
 
-	_, _, err := ParseLabels(0, payload)
+	_, _, err := ParseLabels(0, payload, true)
 	if !errors.Is(err, ErrDecodeDNSLabelTooShort) {
 		t.Errorf("bad error returned: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestDecodeDnsLabel_LabelTooShort(t *testing.T) {
 func TestDecodeDnsLabel_NoExtraDotAfterPtr(t *testing.T) {
 	payload := []byte{0x00, 0x01, 0x61, 0xc0, 0x00}
 
-	label, _, _ := ParseLabels(1, payload)
+	label, _, _ := ParseLabels(1, payload, true)
 	if label != "a" {
 		t.Errorf("bad label parsed: %v", label)
 	}
@@ -78,7 +78,7 @@ func TestDecodeDnsLabel_NoExtraDotAfterPtr(t *testing.T) {
 func TestDecodeDnsLabel_InvalidLabelLengthByte1(t *testing.T) {
 	payload := []byte{0x40}
 
-	_, _, err := ParseLabels(0, payload)
+	_, _, err := ParseLabels(0, payload, true)
 	if !errors.Is(err, ErrDecodeDNSLabelInvalidData) {
 		t.Errorf("bad error returned: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestDecodeDnsLabel_InvalidLabelLengthByte1(t *testing.T) {
 func TestDecodeDnsLabel_InvalidLabelLengthByte2(t *testing.T) {
 	payload := []byte{0x80}
 
-	_, _, err := ParseLabels(0, payload)
+	_, _, err := ParseLabels(0, payload, true)
 	if !errors.Is(err, ErrDecodeDNSLabelInvalidData) {
 		t.Errorf("bad error returned: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestDecodeDnsLabel_ValidTotalLength(t *testing.T) {
 	}
 	valid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
-	label, _, _ := ParseLabels(0, payload)
+	label, _, _ := ParseLabels(0, payload, true)
 	if label != valid {
 		t.Errorf("bad name parsed: %v", label)
 	}
@@ -173,7 +173,7 @@ func TestDecodeDnsLabel_InvalidTotalLength_WithoutPtr(t *testing.T) {
 		0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
 		0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x00,
 	}
-	_, _, err := ParseLabels(0, payload)
+	_, _, err := ParseLabels(0, payload, true)
 	if !errors.Is(err, ErrDecodeDNSLabelTooLong) {
 		t.Errorf("bad error returned: %v", err)
 	}
@@ -216,7 +216,7 @@ func TestDecodeDnsLabel_InvalidTotalLength_WithPtr(t *testing.T) {
 		0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x00, 0x01,
 		0x61, 0xc0, 0x00,
 	}
-	_, _, err := ParseLabels(255, payload)
+	_, _, err := ParseLabels(255, payload, true)
 	if !errors.Is(err, ErrDecodeDNSLabelTooLong) {
 		t.Errorf("bad error returned: %v", err)
 	}
@@ -225,7 +225,7 @@ func TestDecodeDnsLabel_InvalidTotalLength_WithPtr(t *testing.T) {
 func TestDecodeDnsLabel_InvalidPtr_SimpleLoop(t *testing.T) {
 	payload := []byte{0x01, 0x61, 0xc0, 0x00}
 
-	_, _, err := ParseLabels(0, payload)
+	_, _, err := ParseLabels(0, payload, true)
 	if !errors.Is(err, ErrDecodeDNSLabelInvalidPointer) {
 		t.Errorf("bad error returned: %v", err)
 	}
@@ -234,7 +234,7 @@ func TestDecodeDnsLabel_InvalidPtr_SimpleLoop(t *testing.T) {
 func TestDecodeDnsLabel_InvalidPtr_Forwards(t *testing.T) {
 	payload := []byte{0xc0, 0x02, 0x00}
 
-	_, _, err := ParseLabels(0, payload)
+	_, _, err := ParseLabels(0, payload, true)
 	if !errors.Is(err, ErrDecodeDNSLabelInvalidPointer) {
 		t.Errorf("bad error returned: %v", err)
 	}
@@ -243,7 +243,7 @@ func TestDecodeDnsLabel_InvalidPtr_Forwards(t *testing.T) {
 func TestDecodeDnsLabel_InvalidPtr_BackwardsInsideCurrentLabel1(t *testing.T) {
 	payload := []byte{0x01, 0x02, 0xc0, 0x01, 0x00}
 
-	_, _, err := ParseLabels(0, payload)
+	_, _, err := ParseLabels(0, payload, true)
 	if !errors.Is(err, ErrDecodeDNSLabelInvalidPointer) {
 		t.Errorf("bad error returned: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestDecodeDnsLabel_InvalidPtr_BackwardsInsideCurrentLabel1(t *testing.T) {
 func TestDecodeDnsLabel_InvalidPtr_BackwardsOverlappingLoop(t *testing.T) {
 	payload := []byte{0x01, 0x61, 0x01, 0x61, 0xc0, 0x00}
 
-	_, _, err := ParseLabels(2, payload)
+	_, _, err := ParseLabels(2, payload, true)
 	if !errors.Is(err, ErrDecodeDNSLabelInvalidPointer) {
 		t.Errorf("bad error returned: %v", err)
 	}
@@ -261,7 +261,7 @@ func TestDecodeDnsLabel_InvalidPtr_BackwardsOverlappingLoop(t *testing.T) {
 func TestDecodeDnsLabel_InvalidPtr_BackwardsOverlappingTerminating(t *testing.T) {
 	payload := []byte{0x01, 0x01, 0x00, 0xc0, 0x00}
 
-	_, _, err := ParseLabels(1, payload)
+	_, _, err := ParseLabels(1, payload, true)
 	if !errors.Is(err, ErrDecodeDNSLabelInvalidPointer) {
 		t.Errorf("bad error returned: %v", err)
 	}
@@ -271,7 +271,7 @@ func TestDecodeDnsLabel_InvalidPtr_BackwardsOverlappingPtr(t *testing.T) {
 	// The second pointer byte overlaps the beginning of the label that starts at payload[3]
 	payload := []byte{0x00, 0x00, 0xc0, 0x01, 0x00, 0xc0, 0x02}
 
-	_, _, err := ParseLabels(3, payload)
+	_, _, err := ParseLabels(3, payload, true)
 	if !errors.Is(err, ErrDecodeDNSLabelInvalidPointer) {
 		t.Errorf("bad error returned: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestDecodeDnsLabel_InvalidPtr_BackwardsOverlappingPtr(t *testing.T) {
 func TestDecodeDnsLabel_EndOffset_WithoutPtr(t *testing.T) {
 	payload := []byte{0x02, 0x61, 0x61, 0x00}
 
-	_, offset, _ := ParseLabels(0, payload)
+	_, offset, _ := ParseLabels(0, payload, true)
 	if offset != 4 {
 		t.Errorf("invalid end offset: %v", offset)
 	}
@@ -289,7 +289,7 @@ func TestDecodeDnsLabel_EndOffset_WithoutPtr(t *testing.T) {
 func TestDecodeDnsLabel_EndOffset_WithPtr(t *testing.T) {
 	payload := []byte{0x01, 0x61, 0x00, 0x02, 0x61, 0x61, 0xc0, 0x00}
 
-	_, offset, _ := ParseLabels(3, payload)
+	_, offset, _ := ParseLabels(3, payload, true)
 	if offset != 8 {
 		t.Errorf("invalid end offset: %v", offset)
 	}
@@ -313,7 +313,7 @@ func TestParseLabels_NonUTF8(t *testing.T) {
 		0x00,
 	}
 
-	qname, _, err := ParseLabels(0, payload)
+	qname, _, err := ParseLabels(0, payload, true)
 	if err != nil {
 		t.Fatalf("failed to parse labels: %v", err)
 	}

--- a/dnsutils/dns_parser_rdata_test.go
+++ b/dnsutils/dns_parser_rdata_test.go
@@ -73,21 +73,21 @@ func BenchmarkParseRdata_Original(b *testing.B) {
 	b.Run("TypeA", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			rdatatype := RdatatypeToString(1) // "A"
-			_, _ = ParseRdata(rdatatype, ipv4Rdata, nil, 0)
+			_, _ = ParseRdata(rdatatype, ipv4Rdata, nil, 0, true)
 		}
 	})
 
 	b.Run("TypeAAAA", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			rdatatype := RdatatypeToString(28) // "AAAA"
-			_, _ = ParseRdata(rdatatype, ipv6Rdata, nil, 0)
+			_, _ = ParseRdata(rdatatype, ipv6Rdata, nil, 0, true)
 		}
 	})
 
 	b.Run("TypeCNAME", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			rdatatype := RdatatypeToString(5) // "CNAME"
-			_, _ = ParseRdata(rdatatype, cnameRdata, cnamePayload, 12)
+			_, _ = ParseRdata(rdatatype, cnameRdata, cnamePayload, 12, true)
 		}
 	})
 }

--- a/dnsutils/edns_parser.go
+++ b/dnsutils/edns_parser.go
@@ -63,7 +63,7 @@ func DecodeEDNS(arcount int, startOffset int, payload []byte) (DNSExtended, int,
 
 	for i := 0; i < arcount; i++ {
 		// Decode NAME
-		name, offsetNext, err := ParseLabels(offset, payload)
+		name, offsetNext, err := ParseLabels(offset, payload, true)
 		if err != nil {
 			return edns, offset, err
 		}

--- a/workers/dnstapserver.go
+++ b/workers/dnstapserver.go
@@ -501,7 +501,7 @@ func (w *DNSTapProcessor) StartCollect() {
 			// decode query zone if provided
 			queryZone := dt.GetMessage().GetQueryZone()
 			if len(queryZone) > 0 {
-				qz, _, err := dnsutils.ParseLabels(0, queryZone)
+				qz, _, err := dnsutils.ParseLabels(0, queryZone, true)
 				if err != nil {
 					w.LogError("invalid query zone: %v - %v", err, queryZone)
 				}


### PR DESCRIPTION
the uncompressed, fully qualified TargetName, represented as a sequence of length-prefixed labels per [Section 3.1](https://rfc-editor.org/rfc/rfc1035#section-3.1) of [[RFC1035](https://www.rfc-editor.org/rfc/rfc9460.html#RFC1035)].