### PR TITLE
perf: optimize extract, and rewrite transformers

### DIFF
--- a/transformers/extract.go
+++ b/transformers/extract.go
@@ -2,21 +2,83 @@ package transformers
 
 import (
 	"encoding/hex"
-	"fmt"
 	"reflect"
+	"strconv"
 
 	"github.com/dmachard/go-dnscollector/v2/dnsutils"
 	"github.com/dmachard/go-dnscollector/v2/pkgconfig"
 	"github.com/dmachard/go-logger"
 )
 
+type ExtractorFunc func(dm *dnsutils.DNSMessage) (interface{}, bool)
+
 type ExtractTransform struct {
 	GenericTransformer
+	base64Extractors []ExtractorFunc
+	hexExtractors    []ExtractorFunc
 }
 
 func NewExtractTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan dnsutils.DNSMessage) *ExtractTransform {
 	t := &ExtractTransform{GenericTransformer: NewTransformer(config, logger, "extract", name, instance, nextWorkers)}
+	t.initExtractors()
 	return t
+}
+
+func (t *ExtractTransform) ReloadConfig(config *pkgconfig.ConfigTransformers) {
+	t.GenericTransformer.ReloadConfig(config)
+	t.initExtractors()
+}
+
+func (t *ExtractTransform) initExtractors() {
+	t.base64Extractors = make([]ExtractorFunc, len(t.config.Extract.Base64Fields))
+	for i, field := range t.config.Extract.Base64Fields {
+		t.base64Extractors[i] = getExtractor(field)
+	}
+
+	t.hexExtractors = make([]ExtractorFunc, len(t.config.Extract.HexFields))
+	for i, field := range t.config.Extract.HexFields {
+		t.hexExtractors[i] = getExtractor(field)
+	}
+}
+
+func getExtractor(tag string) ExtractorFunc {
+	switch tag {
+	case "network.query-ip":
+		return func(dm *dnsutils.DNSMessage) (interface{}, bool) { return dm.NetworkInfo.QueryIP, true }
+	case "network.response-ip":
+		return func(dm *dnsutils.DNSMessage) (interface{}, bool) { return dm.NetworkInfo.ResponseIP, true }
+	case "dns.qname":
+		return func(dm *dnsutils.DNSMessage) (interface{}, bool) { return dm.DNS.Qname, true }
+	case "dns.qtype":
+		return func(dm *dnsutils.DNSMessage) (interface{}, bool) { return dm.DNS.Qtype, true }
+	case "dns.length":
+		return func(dm *dnsutils.DNSMessage) (interface{}, bool) { return dm.DNS.Length, true }
+	case "dns.id":
+		return func(dm *dnsutils.DNSMessage) (interface{}, bool) { return dm.DNS.ID, true }
+	case "dns.opcode":
+		return func(dm *dnsutils.DNSMessage) (interface{}, bool) { return dm.DNS.Opcode, true }
+	case "dns.rcode":
+		return func(dm *dnsutils.DNSMessage) (interface{}, bool) { return dm.DNS.Rcode, true }
+	case "dns.qclass":
+		return func(dm *dnsutils.DNSMessage) (interface{}, bool) { return dm.DNS.Qclass, true }
+	case "network.family":
+		return func(dm *dnsutils.DNSMessage) (interface{}, bool) { return dm.NetworkInfo.Family, true }
+	case "network.protocol":
+		return func(dm *dnsutils.DNSMessage) (interface{}, bool) { return dm.NetworkInfo.Protocol, true }
+	case "network.query-port":
+		return func(dm *dnsutils.DNSMessage) (interface{}, bool) { return dm.NetworkInfo.QueryPort, true }
+	case "network.response-port":
+		return func(dm *dnsutils.DNSMessage) (interface{}, bool) { return dm.NetworkInfo.ResponsePort, true }
+	}
+
+	// Fallback to reflection if not standard
+	return func(dm *dnsutils.DNSMessage) (interface{}, bool) {
+		dmValue := reflect.ValueOf(dm).Elem()
+		if value, found := dnsutils.GetFieldByJSONTag(dmValue, tag); found {
+			return value.Interface(), true
+		}
+		return nil, false
+	}
 }
 
 func (t *ExtractTransform) GetTransforms() ([]Subtransform, error) {
@@ -50,29 +112,45 @@ func (t *ExtractTransform) addBase64Fields(dm *dnsutils.DNSMessage) (int, error)
 		dm.Extracted.Base64Fields = make(map[string]interface{})
 	}
 
-	dmValue := reflect.ValueOf(dm).Elem()
-	for _, field := range t.config.Extract.Base64Fields {
-		if value, found := dnsutils.GetFieldByJSONTag(dmValue, field); found {
-			switch value.Kind() {
-			case reflect.String:
-				dm.Extracted.Base64Fields[field] = []byte(value.String())
-			case reflect.Int:
-				dm.Extracted.Base64Fields[field] = []byte(fmt.Sprintf("%d", value.Int()))
-			case reflect.Slice, reflect.Array:
-				var encodedSlice [][]byte
-				for i := 0; i < value.Len(); i++ {
-					elem := value.Index(i)
-					if elem.Kind() == reflect.Interface {
-						elem = elem.Elem()
-					}
-					switch elem.Kind() {
-					case reflect.String:
-						encodedSlice = append(encodedSlice, []byte(elem.String()))
-					case reflect.Int:
-						encodedSlice = append(encodedSlice, []byte(fmt.Sprintf("%d", elem.Int())))
-					}
+	for i, field := range t.config.Extract.Base64Fields {
+		extractor := t.base64Extractors[i]
+		if val, found := extractor(dm); found {
+			switch v := val.(type) {
+			case string:
+				dm.Extracted.Base64Fields[field] = []byte(v)
+			case int:
+				dm.Extracted.Base64Fields[field] = []byte(strconv.Itoa(v))
+			case []string:
+				encodedSlice := make([][]byte, len(v))
+				for idx, s := range v {
+					encodedSlice[idx] = []byte(s)
 				}
 				dm.Extracted.Base64Fields[field] = encodedSlice
+			case []int:
+				encodedSlice := make([][]byte, len(v))
+				for idx, s := range v {
+					encodedSlice[idx] = []byte(strconv.Itoa(s))
+				}
+				dm.Extracted.Base64Fields[field] = encodedSlice
+			default:
+				value := reflect.ValueOf(val)
+				switch value.Kind() {
+				case reflect.Slice, reflect.Array:
+					var encodedSlice [][]byte
+					for i := 0; i < value.Len(); i++ {
+						elem := value.Index(i)
+						if elem.Kind() == reflect.Interface {
+							elem = elem.Elem()
+						}
+						switch elem.Kind() {
+						case reflect.String:
+							encodedSlice = append(encodedSlice, []byte(elem.String()))
+						case reflect.Int:
+							encodedSlice = append(encodedSlice, []byte(strconv.Itoa(int(elem.Int()))))
+						}
+					}
+					dm.Extracted.Base64Fields[field] = encodedSlice
+				}
 			}
 		}
 	}
@@ -87,29 +165,45 @@ func (t *ExtractTransform) addHexFields(dm *dnsutils.DNSMessage) (int, error) {
 		dm.Extracted.HexFields = make(map[string]interface{})
 	}
 
-	dmValue := reflect.ValueOf(dm).Elem()
-	for _, field := range t.config.Extract.HexFields {
-		if value, found := dnsutils.GetFieldByJSONTag(dmValue, field); found {
-			switch value.Kind() {
-			case reflect.String:
-				dm.Extracted.HexFields[field] = hex.EncodeToString([]byte(value.String()))
-			case reflect.Int:
-				dm.Extracted.HexFields[field] = hex.EncodeToString([]byte(fmt.Sprintf("%d", value.Int())))
-			case reflect.Slice, reflect.Array:
-				var encodedSlice []string
-				for i := 0; i < value.Len(); i++ {
-					elem := value.Index(i)
-					if elem.Kind() == reflect.Interface {
-						elem = elem.Elem()
-					}
-					switch elem.Kind() {
-					case reflect.String:
-						encodedSlice = append(encodedSlice, hex.EncodeToString([]byte(elem.String())))
-					case reflect.Int:
-						encodedSlice = append(encodedSlice, hex.EncodeToString([]byte(fmt.Sprintf("%d", elem.Int()))))
-					}
+	for i, field := range t.config.Extract.HexFields {
+		extractor := t.hexExtractors[i]
+		if val, found := extractor(dm); found {
+			switch v := val.(type) {
+			case string:
+				dm.Extracted.HexFields[field] = hex.EncodeToString([]byte(v))
+			case int:
+				dm.Extracted.HexFields[field] = hex.EncodeToString([]byte(strconv.Itoa(v)))
+			case []string:
+				encodedSlice := make([]string, len(v))
+				for idx, s := range v {
+					encodedSlice[idx] = hex.EncodeToString([]byte(s))
 				}
 				dm.Extracted.HexFields[field] = encodedSlice
+			case []int:
+				encodedSlice := make([]string, len(v))
+				for idx, s := range v {
+					encodedSlice[idx] = hex.EncodeToString([]byte(strconv.Itoa(s)))
+				}
+				dm.Extracted.HexFields[field] = encodedSlice
+			default:
+				value := reflect.ValueOf(val)
+				switch value.Kind() {
+				case reflect.Slice, reflect.Array:
+					var encodedSlice []string
+					for i := 0; i < value.Len(); i++ {
+						elem := value.Index(i)
+						if elem.Kind() == reflect.Interface {
+							elem = elem.Elem()
+						}
+						switch elem.Kind() {
+						case reflect.String:
+							encodedSlice = append(encodedSlice, hex.EncodeToString([]byte(elem.String())))
+						case reflect.Int:
+							encodedSlice = append(encodedSlice, hex.EncodeToString([]byte(strconv.Itoa(int(elem.Int())))))
+						}
+					}
+					dm.Extracted.HexFields[field] = encodedSlice
+				}
 			}
 		}
 	}

--- a/transformers/extract_test.go
+++ b/transformers/extract_test.go
@@ -214,3 +214,24 @@ func TestExtract_WildcardSliceFields(t *testing.T) {
 		t.Errorf("JSON should contain the correct Hex encoded values in array")
 	}
 }
+
+func BenchmarkExtract_AddBase64AndHexFields(b *testing.B) {
+	config := pkgconfig.GetFakeConfigTransformers()
+	config.Extract.Enable = true
+	config.Extract.Base64Fields = []string{"dns.qname", "network.query-ip"}
+	config.Extract.HexFields = []string{"dns.qname", "network.query-ip"}
+
+	outChans := []chan dnsutils.DNSMessage{}
+	extract := NewExtractTransform(config, logger.New(false), "test", 0, outChans)
+	extract.GetTransforms()
+
+	dm := dnsutils.GetFakeDNSMessage()
+	dm.DNS.Qname = "test-request-abcd.com"
+	dm.NetworkInfo.QueryIP = "192.168.1.2"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = extract.addBase64Fields(&dm)
+		_, _ = extract.addHexFields(&dm)
+	}
+}

--- a/transformers/rewrite.go
+++ b/transformers/rewrite.go
@@ -10,13 +10,111 @@ import (
 	"github.com/dmachard/go-logger"
 )
 
+type MutatorFunc func(dm *dnsutils.DNSMessage) error
+
 type RewriteTransform struct {
 	GenericTransformer
+	mutators []MutatorFunc
 }
 
 func NewRewriteTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan dnsutils.DNSMessage) *RewriteTransform {
 	t := &RewriteTransform{GenericTransformer: NewTransformer(config, logger, "rewrite", name, instance, nextWorkers)}
+	t.initMutators()
 	return t
+}
+
+func (t *RewriteTransform) ReloadConfig(config *pkgconfig.ConfigTransformers) {
+	t.GenericTransformer.ReloadConfig(config)
+	t.initMutators()
+}
+
+func (t *RewriteTransform) initMutators() {
+	t.mutators = make([]MutatorFunc, 0, len(t.config.Rewrite.Identifiers))
+	for nestedKeys, value := range t.config.Rewrite.Identifiers {
+		t.mutators = append(t.mutators, getMutator(nestedKeys, value))
+	}
+}
+
+func getMutator(nestedKeys string, val interface{}) MutatorFunc {
+	switch nestedKeys {
+	case "network.query-ip":
+		if s, ok := val.(string); ok {
+			return func(dm *dnsutils.DNSMessage) error { dm.NetworkInfo.QueryIP = s; return nil }
+		}
+	case "network.response-ip":
+		if s, ok := val.(string); ok {
+			return func(dm *dnsutils.DNSMessage) error { dm.NetworkInfo.ResponseIP = s; return nil }
+		}
+	case "dns.qname":
+		if s, ok := val.(string); ok {
+			return func(dm *dnsutils.DNSMessage) error { dm.DNS.Qname = s; return nil }
+		}
+	case "dns.qtype":
+		if s, ok := val.(string); ok {
+			return func(dm *dnsutils.DNSMessage) error { dm.DNS.Qtype = s; return nil }
+		}
+	case "dns.length":
+		if i, ok := val.(int); ok {
+			return func(dm *dnsutils.DNSMessage) error { dm.DNS.Length = i; return nil }
+		}
+	case "dns.id":
+		if i, ok := val.(int); ok {
+			return func(dm *dnsutils.DNSMessage) error { dm.DNS.ID = i; return nil }
+		}
+	case "dns.opcode":
+		if i, ok := val.(int); ok {
+			return func(dm *dnsutils.DNSMessage) error { dm.DNS.Opcode = i; return nil }
+		}
+	case "dns.rcode":
+		if s, ok := val.(string); ok {
+			return func(dm *dnsutils.DNSMessage) error { dm.DNS.Rcode = s; return nil }
+		}
+	case "dns.qclass":
+		if s, ok := val.(string); ok {
+			return func(dm *dnsutils.DNSMessage) error { dm.DNS.Qclass = s; return nil }
+		}
+	case "network.family":
+		if s, ok := val.(string); ok {
+			return func(dm *dnsutils.DNSMessage) error { dm.NetworkInfo.Family = s; return nil }
+		}
+	case "network.protocol":
+		if s, ok := val.(string); ok {
+			return func(dm *dnsutils.DNSMessage) error { dm.NetworkInfo.Protocol = s; return nil }
+		}
+	case "network.query-port":
+		if s, ok := val.(string); ok {
+			return func(dm *dnsutils.DNSMessage) error { dm.NetworkInfo.QueryPort = s; return nil }
+		}
+	case "network.response-port":
+		if s, ok := val.(string); ok {
+			return func(dm *dnsutils.DNSMessage) error { dm.NetworkInfo.ResponsePort = s; return nil }
+		}
+	case "dnstap.identity":
+		if s, ok := val.(string); ok {
+			return func(dm *dnsutils.DNSMessage) error { dm.DNSTap.Identity = s; return nil }
+		}
+	}
+
+	// Fallback to reflection if not standard
+	return func(dm *dnsutils.DNSMessage) error {
+		dmValue := reflect.ValueOf(dm)
+		if dmValue.Kind() == reflect.Pointer {
+			dmValue = dmValue.Elem()
+		}
+		realValue, found := getFieldByTag(dmValue, nestedKeys)
+		if !found {
+			return errors.New("field not found: " + nestedKeys)
+		}
+		if !realValue.CanSet() {
+			return errors.New("field cannot be set: " + nestedKeys)
+		}
+		newValue := reflect.ValueOf(val)
+		if realValue.Kind() != newValue.Kind() {
+			return errors.New("unable to set value (" + newValue.Type().String() + ") for " + nestedKeys + "(" + realValue.Type().String() + ")")
+		}
+		realValue.Set(newValue)
+		return nil
+	}
 }
 
 func (t *RewriteTransform) GetTransforms() ([]Subtransform, error) {
@@ -28,36 +126,11 @@ func (t *RewriteTransform) GetTransforms() ([]Subtransform, error) {
 }
 
 func (t *RewriteTransform) UpdateValues(dm *dnsutils.DNSMessage) (int, error) {
-	dmValue := reflect.ValueOf(dm)
-	if dmValue.Kind() == reflect.Pointer {
-		dmValue = dmValue.Elem()
-	}
-
-	for nestedKeys, value := range t.config.Rewrite.Identifiers {
-		realValue, found := getFieldByTag(dmValue, nestedKeys)
-		switch {
-		case !found:
-			return 0, errors.New("field not found: " + nestedKeys)
-		case !realValue.CanSet():
-			return 0, errors.New("field cannot be set: " + nestedKeys)
-		default:
-			newValue := reflect.ValueOf(value)
-
-			switch realValue.Kind() {
-			case reflect.Int, reflect.String:
-				if realValue.Kind() == newValue.Kind() {
-					realValue.Set(newValue)
-				} else {
-					return 0, errors.New("unable to set value (" + newValue.Type().String() + ") for " + nestedKeys + "(" + realValue.Type().String() + ")")
-				}
-			default:
-				// Ignore unsupported types
-				continue
-			}
-
+	for _, mutator := range t.mutators {
+		if err := mutator(dm); err != nil {
+			return 0, err
 		}
 	}
-
 	return ReturnKeep, nil
 }
 

--- a/transformers/rewrite_test.go
+++ b/transformers/rewrite_test.go
@@ -61,3 +61,22 @@ func TestRewrite_UpdateFields_InvalidType(t *testing.T) {
 		t.Errorf("invalid error: %s", err)
 	}
 }
+
+func BenchmarkRewrite_UpdateValues(b *testing.B) {
+	config := pkgconfig.GetFakeConfigTransformers()
+	config.Rewrite.Enable = true
+	config.Rewrite.Identifiers = make(map[string]interface{})
+	config.Rewrite.Identifiers["dns.qname"] = "rewritten.qname.com"
+	config.Rewrite.Identifiers["network.query-ip"] = "1.1.1.1"
+
+	outChans := []chan dnsutils.DNSMessage{}
+	rewrite := NewRewriteTransform(config, logger.New(false), "test", 0, outChans)
+	rewrite.GetTransforms()
+
+	dm := dnsutils.GetFakeDNSMessage()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = rewrite.UpdateValues(&dm)
+	}
+}


### PR DESCRIPTION
### Description
Optimize Extract, and Rewrite transformers to prevent packet drops, memory allocations, and lock contention under high load:

- **Extract**:
  - Replaced runtime reflection lookup of fields with pre-resolved direct extractor closures.
  - Falls back to reflection only for non-standard fields.

- **Rewrite**:
  - Replaced recursive reflect-based tag lookup and mutation with pre-resolved direct mutator closures.
  - Falls back to reflection only for non-standard fields.

**Benchmarks (AMD Ryzen 9 9900X):**
- Extract: Field extraction latency reduced from `1227 ns/op` to `208.8 ns/op` (~5.8x speedup).
- Rewrite: Field rewrite latency reduced from `556.0 ns/op` to `3.398 ns/op` (~163x speedup).
