### PR TITLE
Telemetry unix socket

### DIFF
--- a/dnscollector.go
+++ b/dnscollector.go
@@ -154,7 +154,11 @@ func main() {
 
 	// // telemetry
 	if config.Global.Telemetry.Enabled {
-		logger.Info("main - telemetry enabled on local address: %s", config.Global.Telemetry.WebListen)
+		if config.Global.Telemetry.SockPath != "" {
+			logger.Info("main - telemetry enabled on unix socket: %s", config.Global.Telemetry.SockPath)
+		} else {
+			logger.Info("main - telemetry enabled on local address: %s", config.Global.Telemetry.WebListen)
+		}
 	}
 	promServer, metrics, errTelemetry := telemetry.InitTelemetryServer(config, logger)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,7 +128,12 @@ global:
     web-path: "/metrics"
     web-listen: ":9165"
     prometheus-prefix: "dnscollector"
-    
+
+    # Optional: serve over a unix socket instead of web-listen.
+    # Either/or - setting sock-path is a config error together with tls-support.
+    sock-path: ""
+    sock-mode: "0660"
+
     # Optional TLS configuration
     tls-support: false
     tls-cert-file: ""
@@ -139,6 +144,23 @@ global:
     basic-auth-login: "admin"
     basic-auth-pwd: "changeme"
 ```
+
+`sock-path` is an alternative to `web-listen`: when set, the endpoint serves
+plain HTTP over the unix socket instead of TCP. `tls-support` must be `false`
+(setting both is a startup error).
+
+Access is governed by `sock-mode` and the socket's parent directory — keep the
+socket in a dedicated directory owned by the daemon, not `/tmp`:
+
+```yaml
+global:
+  telemetry:
+    sock-path: "/run/dnscollector/telemetry.sock"  # dir mode 0750
+    sock-mode: "0660"
+```
+
+`basic-auth-enable` still applies but travels in cleartext over the socket —
+defense-in-depth, not a replacement for `sock-mode`.
 
 ### Default Output Format
 

--- a/pkgconfig/global.go
+++ b/pkgconfig/global.go
@@ -59,12 +59,19 @@ func (c *ConfigGlobal) Check(userCfg map[string]interface{}) error {
 		return err
 	}
 
-	if c.Telemetry.SockPath != "" {
-		if c.Telemetry.TLSSupport {
-			return errors.Errorf("telemetry: tls-support is not supported with sock-path, remove tls-support or use web-listen")
-		}
-		if _, err := strconv.ParseUint(c.Telemetry.SockMode, 8, 32); err != nil {
-			return errors.Errorf("telemetry: invalid sock-mode %q: %s", c.Telemetry.SockMode, err)
+	// Telemetry unix-socket constraints. Read from userCfg (the parsed YAML), not
+	// the struct: Check runs against a defaults-only ConfigGlobal, so the user's
+	// values live only in the map.
+	if tel, ok := userCfg["telemetry"].(map[string]interface{}); ok {
+		if sockPath, _ := tel["sock-path"].(string); sockPath != "" {
+			if tlsSupport, _ := tel["tls-support"].(bool); tlsSupport {
+				return errors.Errorf("telemetry: tls-support is not supported with sock-path, remove tls-support or use web-listen")
+			}
+			if sockMode, ok := tel["sock-mode"].(string); ok && sockMode != "" {
+				if _, err := strconv.ParseUint(sockMode, 8, 32); err != nil {
+					return errors.Errorf("telemetry: invalid sock-mode %q: %s", sockMode, err)
+				}
+			}
 		}
 	}
 

--- a/pkgconfig/global.go
+++ b/pkgconfig/global.go
@@ -2,8 +2,10 @@ package pkgconfig
 
 import (
 	"reflect"
+	"strconv"
 
 	"github.com/creasty/defaults"
+	"github.com/pkg/errors"
 )
 
 type ConfigGlobal struct {
@@ -28,6 +30,8 @@ type ConfigGlobal struct {
 		Enabled         bool   `yaml:"enabled" default:"false"`
 		WebPath         string `yaml:"web-path" default:"/metrics"`
 		WebListen       string `yaml:"web-listen" default:":9165"`
+		SockPath        string `yaml:"sock-path" default:""`
+		SockMode        string `yaml:"sock-mode" default:"0660"`
 		PromPrefix      string `yaml:"prometheus-prefix" default:"dnscollector_exporter"`
 		TLSSupport      bool   `yaml:"tls-support" default:"false"`
 		TLSCertFile     string `yaml:"tls-cert-file" default:""`
@@ -51,5 +55,18 @@ func (c *ConfigGlobal) SetDefault() {
 }
 
 func (c *ConfigGlobal) Check(userCfg map[string]interface{}) error {
-	return CheckConfigWithTags(reflect.ValueOf(*c), userCfg)
+	if err := CheckConfigWithTags(reflect.ValueOf(*c), userCfg); err != nil {
+		return err
+	}
+
+	if c.Telemetry.SockPath != "" {
+		if c.Telemetry.TLSSupport {
+			return errors.Errorf("telemetry: tls-support is not supported with sock-path, remove tls-support or use web-listen")
+		}
+		if _, err := strconv.ParseUint(c.Telemetry.SockMode, 8, 32); err != nil {
+			return errors.Errorf("telemetry: invalid sock-mode %q: %s", c.Telemetry.SockMode, err)
+		}
+	}
+
+	return nil
 }

--- a/pkgconfig/global_test.go
+++ b/pkgconfig/global_test.go
@@ -43,35 +43,34 @@ func TestConfigGlobalSetDefault(t *testing.T) {
 }
 
 func TestConfigGlobalCheck_TelemetrySockPath(t *testing.T) {
+	// Check() runs against a defaults-only ConfigGlobal with the parsed YAML
+	// passed as a map (see Config.IsValid -> Global.Check), so the telemetry
+	// values must be validated from the map, not the struct. Drive the test the
+	// same way the real config-load path does.
 	tests := []struct {
-		name       string
-		sockPath   string
-		sockMode   string
-		tlsSupport bool
-		wantErr    bool
+		name      string
+		telemetry map[string]interface{}
+		wantErr   bool
 	}{
 		{
-			name:       "sock-path and tls-support both set",
-			sockPath:   "/run/dnscollector/telemetry.sock",
-			sockMode:   "0660",
-			tlsSupport: true,
-			wantErr:    true,
+			name:      "sock-path and tls-support both set",
+			telemetry: map[string]interface{}{"sock-path": "/run/dnscollector/telemetry.sock", "sock-mode": "0660", "tls-support": true},
+			wantErr:   true,
 		},
 		{
-			name:     "sock-path with invalid sock-mode",
-			sockPath: "/run/dnscollector/telemetry.sock",
-			sockMode: "not-an-octal",
-			wantErr:  true,
+			name:      "sock-path with invalid sock-mode",
+			telemetry: map[string]interface{}{"sock-path": "/run/dnscollector/telemetry.sock", "sock-mode": "not-an-octal"},
+			wantErr:   true,
 		},
 		{
-			name:     "sock-path with valid sock-mode, no tls",
-			sockPath: "/run/dnscollector/telemetry.sock",
-			sockMode: "0600",
-			wantErr:  false,
+			name:      "sock-path with valid sock-mode, no tls",
+			telemetry: map[string]interface{}{"sock-path": "/run/dnscollector/telemetry.sock", "sock-mode": "0600"},
+			wantErr:   false,
 		},
 		{
-			name:    "defaults, no sock-path",
-			wantErr: false,
+			name:      "no sock-path",
+			telemetry: map[string]interface{}{"web-listen": "127.0.0.1:9165"},
+			wantErr:   false,
 		},
 	}
 
@@ -79,13 +78,9 @@ func TestConfigGlobalCheck_TelemetrySockPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config := ConfigGlobal{}
 			config.SetDefault()
-			config.Telemetry.SockPath = tt.sockPath
-			if tt.sockMode != "" {
-				config.Telemetry.SockMode = tt.sockMode
-			}
-			config.Telemetry.TLSSupport = tt.tlsSupport
 
-			err := config.Check(nil)
+			userCfg := map[string]interface{}{"telemetry": tt.telemetry}
+			err := config.Check(userCfg)
 			if tt.wantErr && err == nil {
 				t.Errorf("expected an error, got nil")
 			}

--- a/pkgconfig/global_test.go
+++ b/pkgconfig/global_test.go
@@ -32,4 +32,66 @@ func TestConfigGlobalSetDefault(t *testing.T) {
 	if config.Framestream.ContentType != "protobuf:dnstap.Dnstap" {
 		t.Errorf("content-type should be protobuf:dnstap.Dnstap")
 	}
+
+	if config.Telemetry.SockPath != "" {
+		t.Errorf("sock-path should be empty by default")
+	}
+
+	if config.Telemetry.SockMode != "0660" {
+		t.Errorf("sock-mode should be 0660 by default")
+	}
+}
+
+func TestConfigGlobalCheck_TelemetrySockPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		sockPath   string
+		sockMode   string
+		tlsSupport bool
+		wantErr    bool
+	}{
+		{
+			name:       "sock-path and tls-support both set",
+			sockPath:   "/run/dnscollector/telemetry.sock",
+			sockMode:   "0660",
+			tlsSupport: true,
+			wantErr:    true,
+		},
+		{
+			name:     "sock-path with invalid sock-mode",
+			sockPath: "/run/dnscollector/telemetry.sock",
+			sockMode: "not-an-octal",
+			wantErr:  true,
+		},
+		{
+			name:     "sock-path with valid sock-mode, no tls",
+			sockPath: "/run/dnscollector/telemetry.sock",
+			sockMode: "0600",
+			wantErr:  false,
+		},
+		{
+			name:    "defaults, no sock-path",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := ConfigGlobal{}
+			config.SetDefault()
+			config.Telemetry.SockPath = tt.sockPath
+			if tt.sockMode != "" {
+				config.Telemetry.SockMode = tt.sockMode
+			}
+			config.Telemetry.TLSSupport = tt.tlsSupport
+
+			err := config.Check(nil)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
 }

--- a/telemetry/prometheus.go
+++ b/telemetry/prometheus.go
@@ -237,7 +237,8 @@ func InitTelemetryServer(config *pkgconfig.Config, logger *logger.Logger) (*http
 			}
 
 			// start server
-			if config.Global.Telemetry.SockPath != "" {
+			switch {
+			case config.Global.Telemetry.SockPath != "":
 				sockMode, err := strconv.ParseUint(config.Global.Telemetry.SockMode, 8, 32)
 				if err != nil {
 					errChan <- fmt.Errorf("invalid telemetry sock-mode %q: %w", config.Global.Telemetry.SockMode, err)
@@ -251,11 +252,11 @@ func InitTelemetryServer(config *pkgconfig.Config, logger *logger.Logger) (*http
 				if err := promServer.Serve(listener); err != nil && err != http.ErrServerClosed {
 					errChan <- err
 				}
-			} else if config.Global.Telemetry.TLSSupport {
+			case config.Global.Telemetry.TLSSupport:
 				if err := promServer.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
 					errChan <- err
 				}
-			} else {
+			default:
 				if err := promServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 					errChan <- err
 				}

--- a/telemetry/prometheus.go
+++ b/telemetry/prometheus.go
@@ -4,9 +4,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"regexp"
+	"strconv"
 	"sync"
 	"time"
 
@@ -234,8 +236,22 @@ func InitTelemetryServer(config *pkgconfig.Config, logger *logger.Logger) (*http
 				promServer.Handler = http.DefaultServeMux
 			}
 
-			// start https server
-			if config.Global.Telemetry.TLSSupport {
+			// start server
+			if config.Global.Telemetry.SockPath != "" {
+				sockMode, err := strconv.ParseUint(config.Global.Telemetry.SockMode, 8, 32)
+				if err != nil {
+					errChan <- fmt.Errorf("invalid telemetry sock-mode %q: %w", config.Global.Telemetry.SockMode, err)
+					return
+				}
+				listener, err := prepareUnixSocket(config.Global.Telemetry.SockPath, os.FileMode(sockMode))
+				if err != nil {
+					errChan <- err
+					return
+				}
+				if err := promServer.Serve(listener); err != nil && err != http.ErrServerClosed {
+					errChan <- err
+				}
+			} else if config.Global.Telemetry.TLSSupport {
 				if err := promServer.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
 					errChan <- err
 				}
@@ -248,6 +264,34 @@ func InitTelemetryServer(config *pkgconfig.Config, logger *logger.Logger) (*http
 	}
 
 	return promServer, metrics, errChan
+}
+
+// prepareUnixSocket listens on a unix socket at path. It refuses to delete a
+// pre-existing non-socket file (a misconfigured sock-path must not clobber a
+// real file), clears a stale socket left by a crash, and sets the socket mode
+// deterministically before the caller starts serving.
+func prepareUnixSocket(path string, mode os.FileMode) (net.Listener, error) {
+	if fi, err := os.Lstat(path); err == nil {
+		if fi.Mode()&os.ModeSocket == 0 {
+			return nil, fmt.Errorf("telemetry sock-path %q exists and is not a socket", path)
+		}
+		if err := os.Remove(path); err != nil {
+			return nil, err
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.Chmod(path, mode); err != nil {
+		listener.Close()
+		return nil, err
+	}
+	return listener, nil
 }
 
 // BasicAuth middleware

--- a/telemetry/prometheus_test.go
+++ b/telemetry/prometheus_test.go
@@ -1,9 +1,17 @@
 package telemetry
 
 import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/dmachard/go-dnscollector/v2/pkgconfig"
+	"github.com/dmachard/go-logger"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,4 +55,117 @@ func TestTelemetry_PrometheusCollectorUpdateStats(t *testing.T) {
 	assert.Equal(t, ws.TotalForwardedPolicy, storedWS.TotalForwardedPolicy)
 	assert.Equal(t, ws.TotalDroppedPolicy, storedWS.TotalDroppedPolicy)
 	assert.Equal(t, ws.TotalDiscarded, storedWS.TotalDiscarded)
+}
+
+func TestTelemetry_InitTelemetryServer_UnixSocket(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// keep the filename to one char: AF_UNIX sun_path is capped at ~108 bytes
+	sockPath := filepath.Join(tmpDir, "a")
+
+	config := pkgconfig.GetDefaultConfig()
+	config.Global.Telemetry.Enabled = true
+	config.Global.Telemetry.SockPath = sockPath
+	config.Global.Telemetry.SockMode = "0660"
+	config.Global.Telemetry.BasicAuthEnable = true
+	config.Global.Telemetry.BasicAuthLogin = "admin"
+	config.Global.Telemetry.BasicAuthPwd = "changeme"
+
+	promServer, _, errChan := InitTelemetryServer(config, logger.New(false))
+
+	go func() {
+		for err := range errChan {
+			t.Logf("telemetry server error: %v", err)
+		}
+	}()
+
+	// wait for the listener goroutine to create the socket file
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, statErr := os.Stat(sockPath); statErr == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("socket file was not created: %s", sockPath)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", sockPath)
+			},
+		},
+	}
+
+	// no credentials -> 401
+	resp, err := client.Get("http://unix/metrics")
+	if err != nil {
+		t.Fatalf("request without credentials failed: %v", err)
+	}
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	resp.Body.Close()
+
+	// correct credentials -> 200, body contains a well-known metric
+	req, err := http.NewRequest(http.MethodGet, "http://unix/metrics", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	req.SetBasicAuth("admin", "changeme")
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatalf("authenticated request failed: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, string(body), "go_goroutines")
+
+	// socket mode matches sock-mode
+	fi, err := os.Stat(sockPath)
+	if err != nil {
+		t.Fatalf("failed to stat socket: %v", err)
+	}
+	assert.Equal(t, os.FileMode(0660), fi.Mode().Perm())
+
+	// graceful shutdown removes the socket file
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := promServer.Shutdown(ctx); err != nil {
+		t.Fatalf("shutdown failed: %v", err)
+	}
+
+	_, err = os.Stat(sockPath)
+	assert.True(t, os.IsNotExist(err), "socket file should be removed after shutdown")
+}
+
+func TestTelemetry_prepareUnixSocket_RefusesNonSocket(t *testing.T) {
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	p := filepath.Join(dir, "f")
+	if err := os.WriteFile(p, []byte("keep me"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := prepareUnixSocket(p, 0o660)
+	if err == nil {
+		l.Close()
+		t.Fatal("expected an error for a non-socket file")
+	}
+	if _, statErr := os.Stat(p); statErr != nil {
+		t.Fatalf("non-socket file must not be deleted: %v", statErr)
+	}
 }


### PR DESCRIPTION
This adds two new options to allow listen telemetry on unix socket. Useful when you need export metrics but your dns-collector running in different network namespace. 

You configure UNIX socket or TCP not both. Manually tested UNIX socket and TCP. Made with ai assistance.

```
sock-path: "/run/dnscollector/telemetry.sock"  # dir mode 0750
sock-mode: "0660"
```