### PR TITLE
perf(dnsutils): optimize JSON serialization and DNS decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/go%20version-min%201.26-green" alt="Go version"/>
   <img src="https://img.shields.io/badge/go%20tests-571-green" alt="Go tests"/>
-  <img src="https://img.shields.io/badge/go%20coverage-66%8-green" alt="Go coverage"/>
+  <img src="https://img.shields.io/badge/go%20coverage-66-green" alt="Go coverage"/>
   <img src="https://img.shields.io/badge/go%20bench-38-green" alt="Go bench"/>
   <img src="https://img.shields.io/badge/go%20fuzz-1-green" alt="Go Fuzz"/>
   <img src="https://img.shields.io/badge/go%20lines-16673-green" alt="Go lines"/>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 <p align="center">
-  <img src="https://goreportcard.com/badge/github.com/dmachard/DNS-collector" alt="Go Report"/>
   <img src="https://img.shields.io/badge/go%20version-min%201.26-green" alt="Go version"/>
-  <img src="https://img.shields.io/badge/go%20tests-547-green" alt="Go tests"/>
-  <img src="https://img.shields.io/badge/go%20coverage-70%25-green" alt="Go coverage"/>
+  <img src="https://img.shields.io/badge/go%20tests-571-green" alt="Go tests"/>
+  <img src="https://img.shields.io/badge/go%20coverage-66%8-green" alt="Go coverage"/>
   <img src="https://img.shields.io/badge/go%20bench-38-green" alt="Go bench"/>
   <img src="https://img.shields.io/badge/go%20fuzz-1-green" alt="Go Fuzz"/>
-  <img src="https://img.shields.io/badge/go%20lines-15905-green" alt="Go lines"/>
+  <img src="https://img.shields.io/badge/go%20lines-16673-green" alt="Go lines"/>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/go%20version-min%201.26-green" alt="Go version"/>
   <img src="https://img.shields.io/badge/go%20tests-571-green" alt="Go tests"/>
-  <img src="https://img.shields.io/badge/go%20coverage-66-green" alt="Go coverage"/>
+  <img src="https://img.shields.io/badge/go%20coverage-66%25-green" alt="Go coverage"/>
   <img src="https://img.shields.io/badge/go%20bench-38-green" alt="Go bench"/>
   <img src="https://img.shields.io/badge/go%20fuzz-1-green" alt="Go Fuzz"/>
   <img src="https://img.shields.io/badge/go%20lines-16673-green" alt="Go lines"/>

--- a/dnsutils/dns_parser.go
+++ b/dnsutils/dns_parser.go
@@ -218,7 +218,7 @@ func DecodePayload(dm *DNSMessage, header *DNSHeader, config *pkgconfig.Config) 
 
 	// decode DNS answers
 	if header.Ancount > 0 {
-		answers, offset, err := DecodeAnswer(header.Ancount, payloadOffset, dm.DNS.Payload)
+		answers, offset, err := DecodeAnswerInto(dm.DNS.DNSRRs.Answers, header.Ancount, payloadOffset, dm.DNS.Payload)
 		if err == nil { // nolint
 			dm.DNS.DNSRRs.Answers = answers
 			payloadOffset = offset
@@ -234,7 +234,7 @@ func DecodePayload(dm *DNSMessage, header *DNSHeader, config *pkgconfig.Config) 
 
 	// decode authoritative answers
 	if header.Nscount > 0 {
-		answers, offsetrr, err := DecodeAnswer(header.Nscount, payloadOffset, dm.DNS.Payload)
+		answers, offsetrr, err := DecodeAnswerInto(dm.DNS.DNSRRs.Nameservers, header.Nscount, payloadOffset, dm.DNS.Payload)
 		if err == nil { // nolint
 			dm.DNS.DNSRRs.Nameservers = answers
 			payloadOffset = offsetrr
@@ -250,7 +250,7 @@ func DecodePayload(dm *DNSMessage, header *DNSHeader, config *pkgconfig.Config) 
 
 	// decode additional answers
 	if header.Arcount > 0 {
-		answers, _, err := DecodeAnswer(header.Arcount, payloadOffset, dm.DNS.Payload)
+		answers, _, err := DecodeAnswerInto(dm.DNS.DNSRRs.Records, header.Arcount, payloadOffset, dm.DNS.Payload)
 		if err == nil { // nolint
 			dm.DNS.DNSRRs.Records = answers
 		} else if dm.DNS.Flags.TC && (errors.Is(err, ErrDecodeDNSAnswerTooShort) || errors.Is(err, ErrDecodeDNSAnswerRdataTooShort) || errors.Is(err, ErrDecodeDNSLabelTooShort)) {
@@ -260,6 +260,7 @@ func DecodePayload(dm *DNSMessage, header *DNSHeader, config *pkgconfig.Config) 
 			dm.DNS.MalformedPacket = true
 			return &decodingError{part: "additional records", err: err}
 		}
+
 		// decode EDNS options, if there are any
 		edns, _, err := DecodeEDNS(header.Arcount, payloadOffset, dm.DNS.Payload)
 		if err == nil { // nolint
@@ -360,8 +361,17 @@ PTR can be used on NAME for compression
 +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
 */
 func DecodeAnswer(ancount int, startOffset int, payload []byte) ([]DNSAnswer, int, error) {
+	return DecodeAnswerInto(nil, ancount, startOffset, payload)
+}
+
+func DecodeAnswerInto(buf []DNSAnswer, ancount int, startOffset int, payload []byte) ([]DNSAnswer, int, error) {
 	offset := startOffset
-	answers := make([]DNSAnswer, 0, ancount)
+	var answers []DNSAnswer
+	if cap(buf) >= ancount {
+		answers = buf[:0]
+	} else {
+		answers = make([]DNSAnswer, 0, ancount)
+	}
 	var rdataString string
 
 	for i := 0; i < ancount; i++ {

--- a/dnsutils/dns_parser.go
+++ b/dnsutils/dns_parser.go
@@ -404,7 +404,7 @@ func DecodeAnswer(ancount int, startOffset int, payload []byte) ([]DNSAnswer, in
 		if int(rdlength) == 0 && len(rdata) == 0 {
 			rdataString = ""
 		} else {
-			rdataString, err = ParseRdata(rdatatype, rdata, payload, offsetNext+10, true)
+			rdataString, err = ParseRdata(int(t), rdata, payload, offsetNext+10, true)
 			if err != nil {
 				return answers, offset, err
 			}
@@ -525,29 +525,29 @@ func ParseLabels(offset int, payload []byte, allowCompression bool) (string, int
 	return string(nameBuffer), endOffset, nil
 }
 
-func ParseRdata(rdatatype string, rdata []byte, payload []byte, rdataOffset int, allowCompression bool) (string, error) {
+func ParseRdata(rrtype int, rdata []byte, payload []byte, rdataOffset int, allowCompression bool) (string, error) {
 	var ret string
 	var err error
-	switch rdatatype {
-	case "A":
+	switch rrtype {
+	case 1: // A
 		ret, err = ParseIP(rdata, net.IPv4len)
-	case "AAAA":
+	case 28: // AAAA
 		ret, err = ParseIP(rdata, net.IPv6len)
-	case "CNAME":
+	case 5: // CNAME
 		ret, err = ParseCNAME(rdataOffset, payload, allowCompression)
-	case "MX":
+	case 15: // MX
 		ret, err = ParseMX(rdataOffset, payload, allowCompression)
-	case "SRV":
+	case 33: // SRV
 		ret, err = ParseSRV(rdataOffset, payload, allowCompression)
-	case "NS":
+	case 2: // NS
 		ret, err = ParseNS(rdataOffset, payload, allowCompression)
-	case "TXT":
+	case 16: // TXT
 		ret, err = ParseTXT(rdata)
-	case "PTR":
+	case 12: // PTR
 		ret, err = ParsePTR(rdataOffset, payload, allowCompression)
-	case "SOA":
+	case 6: // SOA
 		ret, err = ParseSOA(rdataOffset, payload, allowCompression)
-	case "HTTPS", "SVCB":
+	case 64, 65: // SVCB, HTTPS
 		ret, err = ParseSVCB(rdata)
 	default:
 		ret = "-"

--- a/dnsutils/dns_parser.go
+++ b/dnsutils/dns_parser.go
@@ -620,6 +620,70 @@ func ParseIP(r []byte, size int) (string, error) {
 	if len(r) < size {
 		return "", ErrDecodeDNSAnswerRdataTooShort
 	}
+	if size == 4 {
+		b0, b1, b2, b3 := r[0], r[1], r[2], r[3]
+		var buf [15]byte
+		n := 0
+		if b0 >= 100 {
+			buf[n] = b0/100 + '0'
+			n++
+			b0 %= 100
+			buf[n] = b0/10 + '0'
+			n++
+		} else if b0 >= 10 {
+			buf[n] = b0/10 + '0'
+			n++
+		}
+		buf[n] = b0%10 + '0'
+		n++
+		buf[n] = '.'
+		n++
+
+		if b1 >= 100 {
+			buf[n] = b1/100 + '0'
+			n++
+			b1 %= 100
+			buf[n] = b1/10 + '0'
+			n++
+		} else if b1 >= 10 {
+			buf[n] = b1/10 + '0'
+			n++
+		}
+		buf[n] = b1%10 + '0'
+		n++
+		buf[n] = '.'
+		n++
+
+		if b2 >= 100 {
+			buf[n] = b2/100 + '0'
+			n++
+			b2 %= 100
+			buf[n] = b2/10 + '0'
+			n++
+		} else if b2 >= 10 {
+			buf[n] = b2/10 + '0'
+			n++
+		}
+		buf[n] = b2%10 + '0'
+		n++
+		buf[n] = '.'
+		n++
+
+		if b3 >= 100 {
+			buf[n] = b3/100 + '0'
+			n++
+			b3 %= 100
+			buf[n] = b3/10 + '0'
+			n++
+		} else if b3 >= 10 {
+			buf[n] = b3/10 + '0'
+			n++
+		}
+		buf[n] = b3%10 + '0'
+		n++
+
+		return string(buf[:n]), nil
+	}
 	return net.IP(r[:size]).String(), nil
 }
 

--- a/dnsutils/dns_parser_bench_test.go
+++ b/dnsutils/dns_parser_bench_test.go
@@ -68,7 +68,7 @@ func BenchmarkParseRdata_TypeA(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_, _ = ParseRdata("A", rdata, nil, 0, false)
+		_, _ = ParseRdata(1, rdata, nil, 0, false)
 	}
 }
 
@@ -77,7 +77,7 @@ func BenchmarkParseRdata_TypeAAAA(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_, _ = ParseRdata("AAAA", rdata, nil, 0, false)
+		_, _ = ParseRdata(28, rdata, nil, 0, false)
 	}
 }
 

--- a/dnsutils/dns_parser_bench_test.go
+++ b/dnsutils/dns_parser_bench_test.go
@@ -81,34 +81,37 @@ func BenchmarkParseRdata_TypeAAAA(b *testing.B) {
 	}
 }
 
-var exampleDNSPacket = []byte{
-	0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
-	// Question: example.com
-	0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 0x03, 'c', 'o', 'm', 0x00,
-	0x00, 0x01, 0x00, 0x01,
-	// Answer: example.com (pointer) -> A -> 60s -> 4 bytes
-	0xc0, 0x0c, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x3c, 0x00, 0x04, 0x5d, 0xb8, 0xd8, 0x22,
-}
 var resultMsg *DNSMessage
 
 func BenchmarkCustomDecodeDNS(b *testing.B) {
+	pkt, err := GetDNSResponsePacket()
+	if err != nil {
+		b.Fatalf("failed to pack DNS response: %v", err)
+	}
 	config := &pkgconfig.Config{}
 	dm := &DNSMessage{}
-	dm.DNS.Payload = exampleDNSPacket
+	dm.DNS.Payload = pkt
 
 	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		header, _ := DecodeDNS(exampleDNSPacket)
+		header, _ := DecodeDNS(pkt)
 		_ = DecodePayload(dm, &header, config)
 		resultMsg = dm
 	}
 }
 
 func BenchmarkMiekgDecodeDNS(b *testing.B) {
+	pkt, err := GetDNSResponsePacket()
+	if err != nil {
+		b.Fatalf("failed to pack DNS response: %v", err)
+	}
 	msg := new(dns.Msg)
+
 	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		if err := msg.Unpack(exampleDNSPacket); err != nil {
+		if err := msg.Unpack(pkt); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/dnsutils/dns_parser_bench_test.go
+++ b/dnsutils/dns_parser_bench_test.go
@@ -1,0 +1,115 @@
+package dnsutils
+
+import (
+	"net"
+	"testing"
+
+	"github.com/dmachard/go-dnscollector/v2/pkgconfig"
+	"github.com/miekg/dns"
+)
+
+func BenchmarkLookupRdatatypeToString(b *testing.B) {
+	// Simulate A, NS, CNAME, SOA, AAAA
+	input := []int{1, 2, 5, 6, 28}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = RdatatypeToString(input[i%len(input)])
+	}
+}
+
+func BenchmarkLookupRcodeToString(b *testing.B) {
+	// The NOERROR rcode (0) represents 99% of traffic
+	input := 0
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = RcodeToString(input)
+	}
+}
+
+func BenchmarkLookupClassToString(b *testing.B) {
+	// The IN class (1) represents 99% of traffic
+	input := 1
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ClassToString(input)
+	}
+}
+
+func BenchmarkParseIP_v4(b *testing.B) {
+	// simulate IPv4 rdata (4 octets)
+	input := []byte{192, 168, 1, 1}
+	size := net.IPv4len
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := ParseIP(input, size)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkParseIP_v6(b *testing.B) {
+	// simulate IPv6 rdata (16 octets)
+	input := []byte{0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+	size := net.IPv6len
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := ParseIP(input, size)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkParseRdata_TypeA(b *testing.B) {
+	rdata := []byte{192, 168, 1, 1}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = ParseRdata("A", rdata, nil, 0, false)
+	}
+}
+
+func BenchmarkParseRdata_TypeAAAA(b *testing.B) {
+	rdata := []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = ParseRdata("AAAA", rdata, nil, 0, false)
+	}
+}
+
+var exampleDNSPacket = []byte{
+	0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+	// Question: example.com
+	0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 0x03, 'c', 'o', 'm', 0x00,
+	0x00, 0x01, 0x00, 0x01,
+	// Answer: example.com (pointer) -> A -> 60s -> 4 bytes
+	0xc0, 0x0c, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x3c, 0x00, 0x04, 0x5d, 0xb8, 0xd8, 0x22,
+}
+var resultMsg *DNSMessage
+
+func BenchmarkCustomDecodeDNS(b *testing.B) {
+	config := &pkgconfig.Config{}
+	dm := &DNSMessage{}
+	dm.DNS.Payload = exampleDNSPacket
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		header, _ := DecodeDNS(exampleDNSPacket)
+		_ = DecodePayload(dm, &header, config)
+		resultMsg = dm
+	}
+}
+
+func BenchmarkMiekgDecodeDNS(b *testing.B) {
+	msg := new(dns.Msg)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := msg.Unpack(exampleDNSPacket); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/dnsutils/dns_parser_bench_test.go
+++ b/dnsutils/dns_parser_bench_test.go
@@ -35,6 +35,15 @@ func BenchmarkLookupClassToString(b *testing.B) {
 	}
 }
 
+func BenchmarkOptCodeToString(b *testing.B) {
+	// Simulate EDNS Cookie (10) or CSUBNET (8)
+	input := 10
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = OptCodeToString(input)
+	}
+}
+
 func BenchmarkParseIP_v4(b *testing.B) {
 	// simulate IPv4 rdata (4 octets)
 	input := []byte{192, 168, 1, 1}

--- a/dnsutils/dns_parser_rdata_test.go
+++ b/dnsutils/dns_parser_rdata_test.go
@@ -72,22 +72,19 @@ func BenchmarkParseRdata_Original(b *testing.B) {
 
 	b.Run("TypeA", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			rdatatype := RdatatypeToString(1) // "A"
-			_, _ = ParseRdata(rdatatype, ipv4Rdata, nil, 0, true)
+			_, _ = ParseRdata(1, ipv4Rdata, nil, 0, true)
 		}
 	})
 
 	b.Run("TypeAAAA", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			rdatatype := RdatatypeToString(28) // "AAAA"
-			_, _ = ParseRdata(rdatatype, ipv6Rdata, nil, 0, true)
+			_, _ = ParseRdata(28, ipv6Rdata, nil, 0, true)
 		}
 	})
 
 	b.Run("TypeCNAME", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			rdatatype := RdatatypeToString(5) // "CNAME"
-			_, _ = ParseRdata(rdatatype, cnameRdata, cnamePayload, 12, true)
+			_, _ = ParseRdata(5, cnameRdata, cnamePayload, 12, true)
 		}
 	})
 }

--- a/dnsutils/dns_parser_test.go
+++ b/dnsutils/dns_parser_test.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"testing"
 
-	"github.com/dmachard/go-dnscollector/v2/pkgconfig"
 	"github.com/miekg/dns"
 )
 
@@ -20,6 +19,67 @@ func TestRcodeInvalid(t *testing.T) {
 	rcode := RcodeToString(100000)
 	if rcode != "UNKNOWN" {
 		t.Errorf("invalid rcode - expected: %s", rcode)
+	}
+}
+
+func TestParseIP_IPv4(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected string
+	}{
+		{"Localhost", []byte{127, 0, 0, 1}, "127.0.0.1"},
+		{"Zero", []byte{0, 0, 0, 0}, "0.0.0.0"},
+		{"Broadcast", []byte{255, 255, 255, 255}, "255.255.255.255"},
+		{"Private A", []byte{10, 255, 0, 42}, "10.255.0.42"},
+		{"Private C", []byte{192, 168, 1, 100}, "192.168.1.100"},
+		{"Public DNS 1", []byte{8, 8, 8, 8}, "8.8.8.8"},
+		{"Public DNS 2", []byte{1, 1, 1, 1}, "1.1.1.1"},
+		{"Mixed digits", []byte{100, 200, 150, 99}, "100.200.150.99"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseIP(tt.input, net.IPv4len)
+			if err != nil {
+				t.Fatalf("unexpected error for %s: %v", tt.name, err)
+			}
+			if got != tt.expected {
+				t.Errorf("ParseIP(%v) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseIP_IPv6(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected string
+	}{
+		{"Loopback", net.ParseIP("::1").To16(), "::1"},
+		{"Google Public DNS", net.ParseIP("2001:4860:4860::8888").To16(), "2001:4860:4860::8888"},
+		{"Link local", net.ParseIP("fe80::1").To16(), "fe80::1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseIP(tt.input, net.IPv6len)
+			if err != nil {
+				t.Fatalf("unexpected error for %s: %v", tt.name, err)
+			}
+			if got != tt.expected {
+				t.Errorf("ParseIP(%v) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseIP_TooShort(t *testing.T) {
+	tooShort := []byte{192, 168, 1}
+	_, err := ParseIP(tooShort, net.IPv4len)
+	if !errors.Is(err, ErrDecodeDNSAnswerRdataTooShort) {
+		t.Errorf("expected ErrDecodeDNSAnswerRdataTooShort, got: %v", err)
 	}
 }
 
@@ -39,93 +99,5 @@ func TestDecodeDns_HeaderTooShort(t *testing.T) {
 	_, err := DecodeDNS(decoded)
 	if !errors.Is(err, ErrDecodeDNSHeaderTooShort) {
 		t.Errorf("bad error returned: %v", err)
-	}
-}
-
-func BenchmarkLookupRdatatypeToString(b *testing.B) {
-	// Simulate A, NS, CNAME, SOA, AAAA
-	input := []int{1, 2, 5, 6, 28}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = RdatatypeToString(input[i%len(input)])
-	}
-}
-
-func BenchmarkLookupRcodeToString(b *testing.B) {
-	// Simulate: NOERROR, SERVFAIL, NXDOMAIN
-	input := []int{0, 2, 3}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = RcodeToString(input[i%len(input)])
-	}
-}
-
-func BenchmarkLookupClassToString(b *testing.B) {
-	// The IN class (1) represents 99% of traffic
-	input := 1
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = ClassToString(input)
-	}
-}
-
-func BenchmarkParseIP_v4(b *testing.B) {
-	// simulate IPv4 rdata (4 octets)
-	input := []byte{192, 168, 1, 1}
-	size := net.IPv4len
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, err := ParseIP(input, size)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func BenchmarkParseIP_v6(b *testing.B) {
-	// simulate IPv6 rdata (16 octets)
-	input := []byte{0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
-	size := net.IPv6len
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, err := ParseIP(input, size)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-var exampleDNSPacket = []byte{
-	0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
-	// Question: example.com
-	0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 0x03, 'c', 'o', 'm', 0x00,
-	0x00, 0x01, 0x00, 0x01,
-	// Answer: example.com (pointer) -> A -> 60s -> 4 bytes
-	0xc0, 0x0c, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x3c, 0x00, 0x04, 0x5d, 0xb8, 0xd8, 0x22,
-}
-var resultMsg *DNSMessage
-
-func BenchmarkCustomDecodeDNS(b *testing.B) {
-	config := &pkgconfig.Config{}
-	dm := &DNSMessage{}
-	dm.DNS.Payload = exampleDNSPacket
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		header, _ := DecodeDNS(exampleDNSPacket)
-		_ = DecodePayload(dm, &header, config)
-		resultMsg = dm
-	}
-}
-
-func BenchmarkMiekgDecodeDNS(b *testing.B) {
-	msg := new(dns.Msg)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		if err := msg.Unpack(exampleDNSPacket); err != nil {
-			b.Fatal(err)
-		}
 	}
 }

--- a/dnsutils/dnsmessage_bench_test.go
+++ b/dnsutils/dnsmessage_bench_test.go
@@ -1,8 +1,16 @@
 package dnsutils
 
 import (
+	"bytes"
+	"sync"
 	"testing"
 )
+
+var textBufferPool = sync.Pool{
+	New: func() interface{} {
+		return bytes.NewBuffer(make([]byte, 0, 512))
+	},
+}
 
 func Benchmark_DNSMessage_ToJSON(b *testing.B) {
 	dm := DNSMessage{}
@@ -21,5 +29,31 @@ func Benchmark_DNSMessage_ToFlatJSON(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_, _ = dm.ToFlatJSON()
+	}
+}
+
+func BenchmarkDnsMessage_ToTextFormat(b *testing.B) {
+	dm := DNSMessage{}
+	dm.Init()
+	dm.InitTransforms()
+
+	textFormat := []string{
+		"timestamp-rfc3339ns", "identity",
+		"operation", "rcode", "queryip", "queryport", "family",
+		"protocol", "length-unit", "qname", "qtype", "latency", "latency_ms",
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		buf := textBufferPool.Get().(*bytes.Buffer)
+		buf.Reset()
+
+		err := dm.ToTextLine(textFormat, " ", "\"", buf)
+		if err != nil {
+			b.Fatalf("could not encode to text format: %v\n", err)
+		}
+
+		textBufferPool.Put(buf)
 	}
 }

--- a/dnsutils/dnsmessage_bench_test.go
+++ b/dnsutils/dnsmessage_bench_test.go
@@ -1,0 +1,25 @@
+package dnsutils
+
+import (
+	"testing"
+)
+
+func Benchmark_DNSMessage_ToJSON(b *testing.B) {
+	dm := DNSMessage{}
+	dm.Init()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = dm.ToJSON()
+	}
+}
+
+func Benchmark_DNSMessage_ToFlatJSON(b *testing.B) {
+	dm := DNSMessage{}
+	dm.Init()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = dm.ToFlatJSON()
+	}
+}

--- a/dnsutils/dnsmessage_json.go
+++ b/dnsutils/dnsmessage_json.go
@@ -3,6 +3,7 @@ package dnsutils
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -28,12 +29,285 @@ func (dm *DNSMessage) ToFlatJSON() (string, error) {
 	buffer.Reset()
 	defer jsonBufferPool.Put(buffer)
 
-	flat, err := dm.Flatten()
-	if err != nil {
-		return "", err
+	if dm.Relabeling != nil {
+		flat, err := dm.Flatten()
+		if err != nil {
+			return "", err
+		}
+		json.NewEncoder(buffer).Encode(flat)
+		return buffer.String(), nil
 	}
-	json.NewEncoder(buffer).Encode(flat)
+
+	dm.EncodeFlatJSON(buffer)
+	buffer.WriteByte('\n')
 	return buffer.String(), nil
+}
+
+func (dm *DNSMessage) EncodeFlatJSON(buffer *bytes.Buffer) {
+	buffer.WriteByte('{')
+	first := true
+
+	writeKey := func(key string) {
+		if !first {
+			buffer.WriteByte(',')
+		}
+		first = false
+		buffer.WriteByte('"')
+		buffer.WriteString(key)
+		buffer.WriteString(`":`)
+	}
+
+	writeBool := func(key string, val bool) {
+		writeKey(key)
+		if val {
+			buffer.WriteString("true")
+		} else {
+			buffer.WriteString("false")
+		}
+	}
+
+	writeInt := func(key string, val int) {
+		writeKey(key)
+		buffer.WriteString(strconv.Itoa(val))
+	}
+
+	writeFloat := func(key string, val float64) {
+		writeKey(key)
+		buffer.WriteString(strconv.FormatFloat(val, 'f', -1, 64))
+	}
+
+	writeString := func(key string, val string) {
+		writeKey(key)
+		b, _ := json.Marshal(val)
+		buffer.Write(b)
+	}
+
+	// Boolean flags
+	writeBool("dns.flags.aa", dm.DNS.Flags.AA)
+	writeBool("dns.flags.ad", dm.DNS.Flags.AD)
+	writeBool("dns.flags.cd", dm.DNS.Flags.CD)
+	writeBool("dns.flags.qr", dm.DNS.Flags.QR)
+	writeBool("dns.flags.ra", dm.DNS.Flags.RA)
+	writeBool("dns.flags.rd", dm.DNS.Flags.RD)
+	writeBool("dns.flags.tc", dm.DNS.Flags.TC)
+
+	// Ints & strings
+	writeInt("dns.ancount", dm.DNS.AnCount)
+	writeInt("dns.arcount", dm.DNS.ArCount)
+	writeInt("dns.id", dm.DNS.ID)
+	writeInt("dns.length", dm.DNS.Length)
+	writeBool("dns.malformed-packet", dm.DNS.MalformedPacket)
+	writeInt("dns.nscount", dm.DNS.NsCount)
+	writeInt("dns.opcode", dm.DNS.Opcode)
+	writeString("dns.qclass", dm.DNS.Qclass)
+	writeInt("dns.qdcount", dm.DNS.QdCount)
+	writeString("dns.qname", dm.DNS.Qname)
+	writeString("dns.qtype", dm.DNS.Qtype)
+	writeString("dns.rcode", dm.DNS.Rcode)
+
+	// Resource Records (AN, AR, NS)
+	buildRRFields := func(rrs []DNSAnswer) (names, rdatatypes, rdatas, ttls, classes string) {
+		if len(rrs) == 0 {
+			return "-", "-", "-", "-", "-"
+		}
+		var sbN, sbT, sbD, sbL, sbC strings.Builder
+		for i, rr := range rrs {
+			if i > 0 {
+				sbN.WriteByte('|')
+				sbT.WriteByte('|')
+				sbD.WriteByte('|')
+				sbL.WriteByte('|')
+				sbC.WriteByte('|')
+			}
+			sbN.WriteString(rr.Name)
+			sbT.WriteString(rr.Rdatatype)
+			sbD.WriteString(rr.Rdata)
+			sbL.WriteString(strconv.Itoa(rr.TTL))
+			sbC.WriteString(rr.Class)
+		}
+		return sbN.String(), sbT.String(), sbD.String(), sbL.String(), sbC.String()
+	}
+
+	anN, anT, anD, anL, anC := buildRRFields(dm.DNS.DNSRRs.Answers)
+	writeString("dns.resource-records.an.classes", anC)
+	writeString("dns.resource-records.an.names", anN)
+	writeString("dns.resource-records.an.rdatas", anD)
+	writeString("dns.resource-records.an.rdatatypes", anT)
+	writeString("dns.resource-records.an.ttls", anL)
+
+	arN, arT, arD, arL, arC := buildRRFields(dm.DNS.DNSRRs.Records)
+	writeString("dns.resource-records.ar.classes", arC)
+	writeString("dns.resource-records.ar.names", arN)
+	writeString("dns.resource-records.ar.rdatas", arD)
+	writeString("dns.resource-records.ar.rdatatypes", arT)
+	writeString("dns.resource-records.ar.ttls", arL)
+
+	nsN, nsT, nsD, nsL, nsC := buildRRFields(dm.DNS.DNSRRs.Nameservers)
+	writeString("dns.resource-records.ns.classes", nsC)
+	writeString("dns.resource-records.ns.names", nsN)
+	writeString("dns.resource-records.ns.rdatas", nsD)
+	writeString("dns.resource-records.ns.rdatatypes", nsT)
+	writeString("dns.resource-records.ns.ttls", nsL)
+
+	// DNSTap fields
+	writeString("dnstap.extra", dm.DNSTap.Extra)
+	writeString("dnstap.identity", dm.DNSTap.Identity)
+	writeFloat("dnstap.latency", dm.DNSTap.Latency)
+	writeInt("dnstap.latency_ms", dm.DNSTap.LatencyMs)
+	writeString("dnstap.operation", dm.DNSTap.Operation)
+	writeString("dnstap.peer-name", dm.DNSTap.PeerName)
+	writeString("dnstap.policy-action", dm.DNSTap.PolicyAction)
+	writeString("dnstap.policy-match", dm.DNSTap.PolicyMatch)
+	writeString("dnstap.policy-rule", dm.DNSTap.PolicyRule)
+	writeString("dnstap.policy-type", dm.DNSTap.PolicyType)
+	writeString("dnstap.policy-value", dm.DNSTap.PolicyValue)
+	writeString("dnstap.query-zone", dm.DNSTap.QueryZone)
+	writeString("dnstap.timestamp-rfc3339ns", dm.DNSTap.TimestampRFC3339)
+	writeString("dnstap.version", dm.DNSTap.Version)
+
+	// EDNS
+	writeInt("edns.dnssec-ok", dm.EDNS.Do)
+	if len(dm.EDNS.Options) == 0 {
+		writeString("edns.options.codes", "-")
+		writeString("edns.options.datas", "-")
+		writeString("edns.options.names", "-")
+	} else {
+		var sbCodes, sbDatas, sbNames strings.Builder
+		for i, opt := range dm.EDNS.Options {
+			if i > 0 {
+				sbCodes.WriteByte('|')
+				sbDatas.WriteByte('|')
+				sbNames.WriteByte('|')
+			}
+			sbCodes.WriteString(strconv.Itoa(opt.Code))
+			sbDatas.WriteString(opt.Data)
+			sbNames.WriteString(opt.Name)
+		}
+		writeString("edns.options.codes", sbCodes.String())
+		writeString("edns.options.datas", sbDatas.String())
+		writeString("edns.options.names", sbNames.String())
+	}
+	writeInt("edns.optionscount", len(dm.EDNS.Options))
+	writeInt("edns.rcode", dm.EDNS.ExtendedRcode)
+	writeInt("edns.udp-size", dm.EDNS.UDPSize)
+	writeInt("edns.version", dm.EDNS.Version)
+
+	// NetworkInfo
+	writeString("network.family", dm.NetworkInfo.Family)
+	writeBool("network.ip-defragmented", dm.NetworkInfo.IPDefragmented)
+	writeString("network.protocol", dm.NetworkInfo.Protocol)
+	writeString("network.query-ip", dm.NetworkInfo.QueryIP)
+	writeString("network.query-port", dm.NetworkInfo.QueryPort)
+	writeString("network.response-ip", dm.NetworkInfo.ResponseIP)
+	writeString("network.response-port", dm.NetworkInfo.ResponsePort)
+	writeBool("network.tcp-reassembled", dm.NetworkInfo.TCPReassembled)
+
+	// Optional Transformer fields
+	if dm.Geo != nil {
+		writeString("geoip.as-number", dm.Geo.AutonomousSystemNumber)
+		writeString("geoip.as-owner", dm.Geo.AutonomousSystemOrg)
+		writeString("geoip.city", dm.Geo.City)
+		writeString("geoip.continent", dm.Geo.Continent)
+		writeString("geoip.country-isocode", dm.Geo.CountryIsoCode)
+		writeFloat("geoip.lat", dm.Geo.Latitude)
+		writeFloat("geoip.lon", dm.Geo.Longitude)
+	}
+
+	if dm.Suspicious != nil {
+		writeString("suspicious.domain", dm.Suspicious.Domain)
+		writeBool("suspicious.excessive-number-labels", dm.Suspicious.ExcessiveNumberLabels)
+		writeBool("suspicious.large-pkt", dm.Suspicious.LargePacket)
+		writeBool("suspicious.long-domain", dm.Suspicious.LongDomain)
+		writeBool("suspicious.malformed-pkt", dm.Suspicious.MalformedPacket)
+		writeFloat("suspicious.score", dm.Suspicious.Score)
+		writeBool("suspicious.slow-domain", dm.Suspicious.SlowDomain)
+		writeBool("suspicious.unallowed-chars", dm.Suspicious.UnallowedChars)
+		writeBool("suspicious.uncommon-qtypes", dm.Suspicious.UncommonQtypes)
+	}
+
+	if dm.PublicSuffix != nil {
+		writeString("publicsuffix.etld+1", dm.PublicSuffix.QnameEffectiveTLDPlusOne)
+		writeBool("publicsuffix.managed-icann", dm.PublicSuffix.ManagedByICANN)
+		writeString("publicsuffix.tld", dm.PublicSuffix.QnamePublicSuffix)
+	}
+
+	if dm.Extracted != nil {
+		writeString("extracted.dns_payload", string(dm.Extracted.Base64Payload))
+		for k, v := range dm.Extracted.Base64Fields {
+			writeString("extracted.base64_fields."+k, fmt.Sprintf("%v", v))
+		}
+		for k, v := range dm.Extracted.HexFields {
+			writeString("extracted.hex_fields."+k, fmt.Sprintf("%v", v))
+		}
+	}
+
+	if dm.Reducer != nil {
+		writeInt("reducer.cumulative-length", dm.Reducer.CumulativeLength)
+		writeInt("reducer.occurrences", dm.Reducer.Occurrences)
+	}
+
+	if dm.Filtering != nil {
+		writeInt("filtering.sample-rate", dm.Filtering.SampleRate)
+	}
+
+	if dm.MachineLearning != nil {
+		writeInt("ml.consecutive-chars", dm.MachineLearning.ConsecutiveChars)
+		writeInt("ml.consecutive-consonants", dm.MachineLearning.ConsecutiveConsonants)
+		writeInt("ml.consecutive-digits", dm.MachineLearning.ConsecutiveDigits)
+		writeInt("ml.consecutive-vowels", dm.MachineLearning.ConsecutiveVowels)
+		writeInt("ml.digits", dm.MachineLearning.Digits)
+		writeFloat("ml.entropy", dm.MachineLearning.Entropy)
+		writeInt("ml.labels", dm.MachineLearning.Labels)
+		writeInt("ml.length", dm.MachineLearning.Length)
+		writeInt("ml.lowers", dm.MachineLearning.Lowers)
+		writeInt("ml.occurrences", dm.MachineLearning.Occurrences)
+		writeInt("ml.others", dm.MachineLearning.Others)
+		writeFloat("ml.ratio-digits", dm.MachineLearning.RatioDigits)
+		writeFloat("ml.ratio-letters", dm.MachineLearning.RatioLetters)
+		writeFloat("ml.ratio-others", dm.MachineLearning.RatioOthers)
+		writeFloat("ml.ratio-specials", dm.MachineLearning.RatioSpecials)
+		writeInt("ml.size", dm.MachineLearning.Size)
+		writeInt("ml.specials", dm.MachineLearning.Specials)
+		writeInt("ml.uncommon-qtypes", dm.MachineLearning.UncommonQtypes)
+		writeInt("ml.uppers", dm.MachineLearning.Uppers)
+	}
+
+	if dm.ATags != nil {
+		if len(dm.ATags.Tags) == 0 {
+			writeString("atags.tags", "-")
+		}
+		for i, tag := range dm.ATags.Tags {
+			writeString("atags.tags."+strconv.Itoa(i), tag)
+		}
+	}
+
+	if dm.PowerDNS != nil {
+		writeString("powerdns.applied-policy", dm.PowerDNS.AppliedPolicy)
+		writeString("powerdns.applied-policy-hit", dm.PowerDNS.AppliedPolicyHit)
+		writeString("powerdns.applied-policy-kind", dm.PowerDNS.AppliedPolicyKind)
+		writeString("powerdns.applied-policy-trigger", dm.PowerDNS.AppliedPolicyTrigger)
+		writeString("powerdns.applied-policy-type", dm.PowerDNS.AppliedPolicyType)
+		writeString("powerdns.device-id", dm.PowerDNS.DeviceID)
+		writeString("powerdns.device-name", dm.PowerDNS.DeviceName)
+		writeString("powerdns.edns-version", dm.PowerDNS.EdnsVersion)
+		writeString("powerdns.http-version", dm.PowerDNS.HTTPVersion)
+		writeString("powerdns.initial-requestor-id", dm.PowerDNS.InitialRequestorID)
+		writeString("powerdns.message-id", dm.PowerDNS.MessageID)
+		for mk, mv := range dm.PowerDNS.Metadata {
+			writeString("powerdns.metadata."+mk, fmt.Sprintf("%v", mv))
+		}
+		writeString("powerdns.opentelemetry-data", dm.PowerDNS.OpenTelemetryData)
+		writeString("powerdns.original-request-subnet", dm.PowerDNS.OriginalRequestSubnet)
+		writeString("powerdns.requestor-id", dm.PowerDNS.RequestorID)
+		if len(dm.PowerDNS.Tags) == 0 {
+			writeString("powerdns.tags", "-")
+		}
+		for i, tag := range dm.PowerDNS.Tags {
+			writeString("powerdns.tags."+strconv.Itoa(i), tag)
+		}
+	}
+
+	buffer.WriteByte('}')
 }
 
 func (dm *DNSMessage) Flatten() (map[string]interface{}, error) {
@@ -87,21 +361,25 @@ func (dm *DNSMessage) Flatten() (map[string]interface{}, error) {
 
 	// Helper function to build RR fields
 	buildRRFields := func(rrs []DNSAnswer) (names, rdatatypes, rdatas, ttls, classes string) {
-		var n, t, d, l, c []string
-		for _, rr := range rrs {
-			n = append(n, rr.Name)
-			t = append(t, rr.Rdatatype)
-			d = append(d, rr.Rdata)
-			l = append(l, strconv.Itoa(rr.TTL))
-			c = append(c, rr.Class)
+		if len(rrs) == 0 {
+			return "-", "-", "-", "-", "-"
 		}
-		joinOrDash := func(arr []string) string {
-			if len(arr) == 0 {
-				return "-"
+		var sbN, sbT, sbD, sbL, sbC strings.Builder
+		for i, rr := range rrs {
+			if i > 0 {
+				sbN.WriteByte('|')
+				sbT.WriteByte('|')
+				sbD.WriteByte('|')
+				sbL.WriteByte('|')
+				sbC.WriteByte('|')
 			}
-			return strings.Join(arr, "|")
+			sbN.WriteString(rr.Name)
+			sbT.WriteString(rr.Rdatatype)
+			sbD.WriteString(rr.Rdata)
+			sbL.WriteString(strconv.Itoa(rr.TTL))
+			sbC.WriteString(rr.Class)
 		}
-		return joinOrDash(n), joinOrDash(t), joinOrDash(d), joinOrDash(l), joinOrDash(c)
+		return sbN.String(), sbT.String(), sbD.String(), sbL.String(), sbC.String()
 	}
 
 	// AN
@@ -129,21 +407,26 @@ func (dm *DNSMessage) Flatten() (map[string]interface{}, error) {
 	dnsFields["dns.resource-records.ar.classes"] = arClasses
 
 	// Add EDNSoptions fields: "edns.options.0.code": 10,
-	var optCodes, optDatas, optNames []string
-	for _, opt := range dm.EDNS.Options {
-		optCodes = append(optCodes, strconv.Itoa(opt.Code))
-		optDatas = append(optDatas, opt.Data)
-		optNames = append(optNames, opt.Name)
-	}
-	joinOrDash := func(arr []string) string {
-		if len(arr) == 0 {
-			return "-"
+	if len(dm.EDNS.Options) == 0 {
+		dnsFields["edns.options.codes"] = "-"
+		dnsFields["edns.options.datas"] = "-"
+		dnsFields["edns.options.names"] = "-"
+	} else {
+		var sbCodes, sbDatas, sbNames strings.Builder
+		for i, opt := range dm.EDNS.Options {
+			if i > 0 {
+				sbCodes.WriteByte('|')
+				sbDatas.WriteByte('|')
+				sbNames.WriteByte('|')
+			}
+			sbCodes.WriteString(strconv.Itoa(opt.Code))
+			sbDatas.WriteString(opt.Data)
+			sbNames.WriteString(opt.Name)
 		}
-		return strings.Join(arr, "|")
+		dnsFields["edns.options.codes"] = sbCodes.String()
+		dnsFields["edns.options.datas"] = sbDatas.String()
+		dnsFields["edns.options.names"] = sbNames.String()
 	}
-	dnsFields["edns.options.codes"] = joinOrDash(optCodes)
-	dnsFields["edns.options.datas"] = joinOrDash(optDatas)
-	dnsFields["edns.options.names"] = joinOrDash(optNames)
 
 	// Add TransformDNSGeo fields
 	if dm.Geo != nil {

--- a/dnsutils/dnsmessage_json.go
+++ b/dnsutils/dnsmessage_json.go
@@ -5,16 +5,29 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
+	"sync"
 )
 
+var jsonBufferPool = sync.Pool{
+	New: func() interface{} {
+		return bytes.NewBuffer(make([]byte, 0, 512))
+	},
+}
+
 func (dm *DNSMessage) ToJSON() string {
-	buffer := new(bytes.Buffer)
+	buffer := jsonBufferPool.Get().(*bytes.Buffer)
+	buffer.Reset()
+	defer jsonBufferPool.Put(buffer)
+
 	json.NewEncoder(buffer).Encode(dm)
 	return buffer.String()
 }
 
 func (dm *DNSMessage) ToFlatJSON() (string, error) {
-	buffer := new(bytes.Buffer)
+	buffer := jsonBufferPool.Get().(*bytes.Buffer)
+	buffer.Reset()
+	defer jsonBufferPool.Put(buffer)
+
 	flat, err := dm.Flatten()
 	if err != nil {
 		return "", err
@@ -24,54 +37,53 @@ func (dm *DNSMessage) ToFlatJSON() (string, error) {
 }
 
 func (dm *DNSMessage) Flatten() (map[string]interface{}, error) {
-	dnsFields := map[string]interface{}{
-		"dns.flags.aa":               dm.DNS.Flags.AA,
-		"dns.flags.ad":               dm.DNS.Flags.AD,
-		"dns.flags.qr":               dm.DNS.Flags.QR,
-		"dns.flags.ra":               dm.DNS.Flags.RA,
-		"dns.flags.tc":               dm.DNS.Flags.TC,
-		"dns.flags.rd":               dm.DNS.Flags.RD,
-		"dns.flags.cd":               dm.DNS.Flags.CD,
-		"dns.length":                 dm.DNS.Length,
-		"dns.malformed-packet":       dm.DNS.MalformedPacket,
-		"dns.id":                     dm.DNS.ID,
-		"dns.opcode":                 dm.DNS.Opcode,
-		"dns.qname":                  dm.DNS.Qname,
-		"dns.qtype":                  dm.DNS.Qtype,
-		"dns.qclass":                 dm.DNS.Qclass,
-		"dns.rcode":                  dm.DNS.Rcode,
-		"dns.qdcount":                dm.DNS.QdCount,
-		"dns.ancount":                dm.DNS.AnCount,
-		"dns.arcount":                dm.DNS.ArCount,
-		"dns.nscount":                dm.DNS.NsCount,
-		"dnstap.identity":            dm.DNSTap.Identity,
-		"dnstap.latency":             dm.DNSTap.Latency,
-		"dnstap.latency_ms":          dm.DNSTap.LatencyMs,
-		"dnstap.operation":           dm.DNSTap.Operation,
-		"dnstap.timestamp-rfc3339ns": dm.DNSTap.TimestampRFC3339,
-		"dnstap.version":             dm.DNSTap.Version,
-		"dnstap.extra":               dm.DNSTap.Extra,
-		"dnstap.policy-rule":         dm.DNSTap.PolicyRule,
-		"dnstap.policy-type":         dm.DNSTap.PolicyType,
-		"dnstap.policy-action":       dm.DNSTap.PolicyAction,
-		"dnstap.policy-match":        dm.DNSTap.PolicyMatch,
-		"dnstap.policy-value":        dm.DNSTap.PolicyValue,
-		"dnstap.peer-name":           dm.DNSTap.PeerName,
-		"dnstap.query-zone":          dm.DNSTap.QueryZone,
-		"edns.optionscount":          len(dm.EDNS.Options),
-		"edns.dnssec-ok":             dm.EDNS.Do,
-		"edns.rcode":                 dm.EDNS.ExtendedRcode,
-		"edns.udp-size":              dm.EDNS.UDPSize,
-		"edns.version":               dm.EDNS.Version,
-		"network.family":             dm.NetworkInfo.Family,
-		"network.ip-defragmented":    dm.NetworkInfo.IPDefragmented,
-		"network.protocol":           dm.NetworkInfo.Protocol,
-		"network.query-ip":           dm.NetworkInfo.QueryIP,
-		"network.query-port":         dm.NetworkInfo.QueryPort,
-		"network.response-ip":        dm.NetworkInfo.ResponseIP,
-		"network.response-port":      dm.NetworkInfo.ResponsePort,
-		"network.tcp-reassembled":    dm.NetworkInfo.TCPReassembled,
-	}
+	dnsFields := make(map[string]interface{}, 80)
+	dnsFields["dns.flags.aa"] = dm.DNS.Flags.AA
+	dnsFields["dns.flags.ad"] = dm.DNS.Flags.AD
+	dnsFields["dns.flags.qr"] = dm.DNS.Flags.QR
+	dnsFields["dns.flags.ra"] = dm.DNS.Flags.RA
+	dnsFields["dns.flags.tc"] = dm.DNS.Flags.TC
+	dnsFields["dns.flags.rd"] = dm.DNS.Flags.RD
+	dnsFields["dns.flags.cd"] = dm.DNS.Flags.CD
+	dnsFields["dns.length"] = dm.DNS.Length
+	dnsFields["dns.malformed-packet"] = dm.DNS.MalformedPacket
+	dnsFields["dns.id"] = dm.DNS.ID
+	dnsFields["dns.opcode"] = dm.DNS.Opcode
+	dnsFields["dns.qname"] = dm.DNS.Qname
+	dnsFields["dns.qtype"] = dm.DNS.Qtype
+	dnsFields["dns.qclass"] = dm.DNS.Qclass
+	dnsFields["dns.rcode"] = dm.DNS.Rcode
+	dnsFields["dns.qdcount"] = dm.DNS.QdCount
+	dnsFields["dns.ancount"] = dm.DNS.AnCount
+	dnsFields["dns.arcount"] = dm.DNS.ArCount
+	dnsFields["dns.nscount"] = dm.DNS.NsCount
+	dnsFields["dnstap.identity"] = dm.DNSTap.Identity
+	dnsFields["dnstap.latency"] = dm.DNSTap.Latency
+	dnsFields["dnstap.latency_ms"] = dm.DNSTap.LatencyMs
+	dnsFields["dnstap.operation"] = dm.DNSTap.Operation
+	dnsFields["dnstap.timestamp-rfc3339ns"] = dm.DNSTap.TimestampRFC3339
+	dnsFields["dnstap.version"] = dm.DNSTap.Version
+	dnsFields["dnstap.extra"] = dm.DNSTap.Extra
+	dnsFields["dnstap.policy-rule"] = dm.DNSTap.PolicyRule
+	dnsFields["dnstap.policy-type"] = dm.DNSTap.PolicyType
+	dnsFields["dnstap.policy-action"] = dm.DNSTap.PolicyAction
+	dnsFields["dnstap.policy-match"] = dm.DNSTap.PolicyMatch
+	dnsFields["dnstap.policy-value"] = dm.DNSTap.PolicyValue
+	dnsFields["dnstap.peer-name"] = dm.DNSTap.PeerName
+	dnsFields["dnstap.query-zone"] = dm.DNSTap.QueryZone
+	dnsFields["edns.optionscount"] = len(dm.EDNS.Options)
+	dnsFields["edns.dnssec-ok"] = dm.EDNS.Do
+	dnsFields["edns.rcode"] = dm.EDNS.ExtendedRcode
+	dnsFields["edns.udp-size"] = dm.EDNS.UDPSize
+	dnsFields["edns.version"] = dm.EDNS.Version
+	dnsFields["network.family"] = dm.NetworkInfo.Family
+	dnsFields["network.ip-defragmented"] = dm.NetworkInfo.IPDefragmented
+	dnsFields["network.protocol"] = dm.NetworkInfo.Protocol
+	dnsFields["network.query-ip"] = dm.NetworkInfo.QueryIP
+	dnsFields["network.query-port"] = dm.NetworkInfo.QueryPort
+	dnsFields["network.response-ip"] = dm.NetworkInfo.ResponseIP
+	dnsFields["network.response-port"] = dm.NetworkInfo.ResponsePort
+	dnsFields["network.tcp-reassembled"] = dm.NetworkInfo.TCPReassembled
 
 	// Helper function to build RR fields
 	buildRRFields := func(rrs []DNSAnswer) (names, rdatatypes, rdatas, ttls, classes string) {

--- a/dnsutils/dnsmessage_text.go
+++ b/dnsutils/dnsmessage_text.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"log"
 	"regexp"
 	"strconv"
@@ -406,11 +405,11 @@ func (dm *DNSMessage) ToTextLine(format []string, fieldDelimiter string, fieldBo
 		case directive == "timestamp-rfc3339ns", directive == "timestamp":
 			s.WriteString(dm.DNSTap.TimestampRFC3339)
 		case directive == "timestamp-unixms":
-			fmt.Fprintf(s, "%d", dm.DNSTap.Timestamp/1000000)
+			s.WriteString(strconv.FormatInt(dm.DNSTap.Timestamp/1000000, 10))
 		case directive == "timestamp-unixus":
-			fmt.Fprintf(s, "%d", dm.DNSTap.Timestamp/1000)
+			s.WriteString(strconv.FormatInt(dm.DNSTap.Timestamp/1000, 10))
 		case directive == "timestamp-unixns":
-			fmt.Fprintf(s, "%d", dm.DNSTap.Timestamp)
+			s.WriteString(strconv.FormatInt(dm.DNSTap.Timestamp, 10))
 		case directive == "localtime":
 			ts := time.Unix(int64(dm.DNSTap.TimeSec), int64(dm.DNSTap.TimeNsec))
 			s.WriteString(ts.Format("2006-01-02 15:04:05.999999999"))
@@ -473,7 +472,8 @@ func (dm *DNSMessage) ToTextLine(format []string, fieldDelimiter string, fieldBo
 		case directive == "protocol":
 			s.WriteString(dm.NetworkInfo.Protocol)
 		case directive == "length-unit":
-			s.WriteString(strconv.Itoa(dm.DNS.Length) + "b")
+			s.WriteString(strconv.Itoa(dm.DNS.Length))
+			s.WriteString("b")
 		case directive == "length":
 			s.WriteString(strconv.Itoa(dm.DNS.Length))
 		case directive == "qtype":
@@ -484,13 +484,13 @@ func (dm *DNSMessage) ToTextLine(format []string, fieldDelimiter string, fieldBo
 			if dm.DNS.Type == DNSQuery {
 				s.WriteByte('-')
 			} else {
-				fmt.Fprintf(s, "%.9f", dm.DNSTap.Latency)
+				s.WriteString(strconv.FormatFloat(dm.DNSTap.Latency, 'f', 9, 64))
 			}
 		case directive == "latency_ms":
 			if dm.DNS.Type == DNSQuery {
 				s.WriteByte('-')
 			} else {
-				fmt.Fprintf(s, "%d", dm.DNSTap.LatencyMs)
+				s.WriteString(strconv.Itoa(dm.DNSTap.LatencyMs))
 			}
 		case directive == "malformed":
 			if dm.DNS.MalformedPacket {

--- a/dnsutils/dnsmessage_text_test.go
+++ b/dnsutils/dnsmessage_text_test.go
@@ -3,44 +3,10 @@ package dnsutils
 import (
 	"bytes"
 	"strings"
-	sync "sync"
 	"testing"
 
 	"github.com/dmachard/go-dnscollector/v2/pkgconfig"
 )
-
-var textBufferPool = sync.Pool{
-	New: func() interface{} {
-		return bytes.NewBuffer(make([]byte, 0, 512))
-	},
-}
-
-func BenchmarkDnsMessage_ToTextFormat(b *testing.B) {
-	dm := DNSMessage{}
-	dm.Init()
-	dm.InitTransforms()
-
-	textFormat := []string{
-		"timestamp-rfc3339ns", "identity",
-		"operation", "rcode", "queryip", "queryport", "family",
-		"protocol", "length-unit", "qname", "qtype", "latency", "latency_ms",
-	}
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		// Get a buffer from the pool
-		buf := textBufferPool.Get().(*bytes.Buffer)
-		buf.Reset()
-
-		err := dm.ToTextLine(textFormat, " ", "\"", buf)
-		if err != nil {
-			b.Fatalf("could not encode to text format: %v\n", err)
-		}
-
-		// return the buffer to the pool
-		textBufferPool.Put(buf)
-	}
-}
 
 // Tests for TEXT format
 func TestDnsMessage_TextFormat_ToString(t *testing.T) {

--- a/dnsutils/edns_parser.go
+++ b/dnsutils/edns_parser.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 
 	"github.com/dmachard/go-dnscollector/v2/pkgconfig"
 )
@@ -15,42 +16,77 @@ var ErrDecodeEdnsOptionTooShort = errors.New("edns, not enough data to decode op
 var ErrDecodeEdnsOptionCsubnetBadFamily = errors.New("edns, csubnet option bad family")
 var ErrDecodeEdnsTooManyOpts = errors.New("edns, packet contained too many OPT RRs")
 
-var (
-	OptCodes = map[int]string{
-		3: "NSID", 8: "CSUBNET", 9: "EXPIRE", 10: "COOKIE", 11: "KEEPALIVE", 12: "PADDING", 15: "ERRORS",
-	}
-	ErrorCodeToString = map[int]string{
-		0:  "Other",
-		1:  "Unsupported DNSKEY Algorithm",
-		2:  "Unsupported DS Digest Type",
-		3:  "Stale Answer",
-		4:  "Forged Answer",
-		5:  "DNSSEC Indeterminate",
-		6:  "DNSSEC Bogus",
-		7:  "Signature Expired",
-		8:  "Signature Not Yet Valid",
-		9:  "DNSKEY Missing",
-		10: "RRSIGs Missing",
-		11: "No Zone Key Bit Set",
-		12: "NSEC Missing",
-		13: "Cached Error",
-		14: "Not Ready",
-		15: "Blocked",
-		16: "Censored",
-		17: "Filtered",
-		18: "Prohibited",
-		19: "Stale NXDOMAIN Answer",
-		20: "Not Authoritative",
-		21: "Not Supported",
-		22: "No Reachable Authority",
-		23: "Network Error",
-		24: "Invalid Data",
-	}
-)
+var optCodesArray = [16]string{
+	3: "NSID", 8: "CSUBNET", 9: "EXPIRE", 10: "COOKIE", 11: "KEEPALIVE", 12: "PADDING", 15: "ERRORS",
+}
+
+var errorCodesArray = [25]string{
+	0:  "Other",
+	1:  "Unsupported DNSKEY Algorithm",
+	2:  "Unsupported DS Digest Type",
+	3:  "Stale Answer",
+	4:  "Forged Answer",
+	5:  "DNSSEC Indeterminate",
+	6:  "DNSSEC Bogus",
+	7:  "Signature Expired",
+	8:  "Signature Not Yet Valid",
+	9:  "DNSKEY Missing",
+	10: "RRSIGs Missing",
+	11: "No Zone Key Bit Set",
+	12: "NSEC Missing",
+	13: "Cached Error",
+	14: "Not Ready",
+	15: "Blocked",
+	16: "Censored",
+	17: "Filtered",
+	18: "Prohibited",
+	19: "Stale NXDOMAIN Answer",
+	20: "Not Authoritative",
+	21: "Not Supported",
+	22: "No Reachable Authority",
+	23: "Network Error",
+	24: "Invalid Data",
+}
+
+// Deprecated: kept for backward compatibility
+var OptCodes = map[int]string{
+	3: "NSID", 8: "CSUBNET", 9: "EXPIRE", 10: "COOKIE", 11: "KEEPALIVE", 12: "PADDING", 15: "ERRORS",
+}
+
+// Deprecated: kept for backward compatibility
+var ErrorCodeToString = map[int]string{
+	0:  "Other",
+	1:  "Unsupported DNSKEY Algorithm",
+	2:  "Unsupported DS Digest Type",
+	3:  "Stale Answer",
+	4:  "Forged Answer",
+	5:  "DNSSEC Indeterminate",
+	6:  "DNSSEC Bogus",
+	7:  "Signature Expired",
+	8:  "Signature Not Yet Valid",
+	9:  "DNSKEY Missing",
+	10: "RRSIGs Missing",
+	11: "No Zone Key Bit Set",
+	12: "NSEC Missing",
+	13: "Cached Error",
+	14: "Not Ready",
+	15: "Blocked",
+	16: "Censored",
+	17: "Filtered",
+	18: "Prohibited",
+	19: "Stale NXDOMAIN Answer",
+	20: "Not Authoritative",
+	21: "Not Supported",
+	22: "No Reachable Authority",
+	23: "Network Error",
+	24: "Invalid Data",
+}
 
 func OptCodeToString(rcode int) string {
-	if value, ok := OptCodes[rcode]; ok {
-		return value
+	if rcode >= 0 && rcode < len(optCodesArray) {
+		if val := optCodesArray[rcode]; val != "" {
+			return val
+		}
 	}
 	return pkgconfig.StrUnknown
 }
@@ -199,10 +235,10 @@ func ParseErrors(d []byte) (string, error) {
 	}
 	code := int(binary.BigEndian.Uint16(d[:2]))
 	infoCode := ""
-	if s, ok := ErrorCodeToString[code]; ok {
-		infoCode = fmt.Sprintf("%d %s", code, s)
+	if code >= 0 && code < len(errorCodesArray) && errorCodesArray[code] != "" {
+		infoCode = strconv.Itoa(code) + " " + errorCodesArray[code]
 	} else {
-		infoCode = fmt.Sprintf("%d -", code)
+		infoCode = strconv.Itoa(code) + " -"
 	}
 
 	extraText := "-"

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -242,7 +242,7 @@ Protocol mapping:
 
 ### Comparison Guide: JSON vs. Flat JSON
 
-- **Choose `json` (Nested)** if you want **maximum Go application throughput** (~13x faster generation in Go) and your consuming application natively supports nested JSON objects.
+- **Choose `json` (Nested)** if you want **maximum Go application throughput** (~3.4x faster generation in Go) and your consuming application natively supports nested JSON objects.
 - **Choose `flat-json`** if you are streaming logs to indexing and analytics engines like **Elasticsearch, Loki, OpenSearch, ClickHouse, or Grafana**. Flat JSON converts all fields to a single 1-level key-value format (e.g. `"dns.flags.aa": false`), making indexing, aggregation, and dashboard querying significantly faster and easier downstream.
 
 ## Data Encoding and UTF-8

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -227,6 +227,24 @@ Protocol mapping:
 | DoT/TCP/853    | DNS UDP/853 (unencrypted)  |
 | DoQ/UDP/443    | DNS UDP/443 (unencrypted)  |
 
+## Which Output Format Should I Choose?
+
+| Output Format | CPU Encoding Speed | Memory Impact | Human Readability | Best Use Cases / Target Systems |
+|---|---|---|---|---|
+| **DNStap (Protobuf)** | ⚡⚡⚡⚡⚡ Ultra Fast | 💧 Minimal | 🔬 Binary | High-speed forwarding, DNStap relays, remote collector pipelines |
+| **Text (CSV / Custom)** | ⚡⚡⚡⚡ Very Fast | 💧 Minimal | 👁️👁️👁️ Excellent | Console output, Syslog, local log files, Grep / AWK scripts |
+| **JSON (Nested)** | ⚡⚡⚡⚡ Fast (~1µs) | 💧 Minimal | 👁️👁️ Good | Webhooks, REST APIs, Application storage with nested JSON support |
+| **Flat JSON** | ⚡⚡ Fast (~11µs) | 💧 Low | 👁️ Fair | Elasticsearch, OpenSearch, Loki, ClickHouse, Scalyr, Grafana |
+| **Jinja Template** | ⚡ Moderate | 💧 Moderate | 👁️👁️👁️ Custom | Complex custom human-readable log formatting |
+| **PCAP** | ⚡⚡⚡ Fast | 💧 Minimal | 🔬 Wireshark | Traffic analysis, Network forensics & troubleshooting |
+
+> **Note on I/O Bottlenecks**: The table above reflects **CPU encoding speed in Go**. When writing to local disk files or remote network sinks, overall throughput is also constrained by disk I/O (HDD vs. NVMe SSD) and network latency. For high-throughput file logging, consider tuning `flush-interval`, `batch-size`, and `chan-buffer-size`.
+
+### Comparison Guide: JSON vs. Flat JSON
+
+- **Choose `json` (Nested)** if you want **maximum Go application throughput** (~13x faster generation in Go) and your consuming application natively supports nested JSON objects.
+- **Choose `flat-json`** if you are streaming logs to indexing and analytics engines like **Elasticsearch, Loki, OpenSearch, ClickHouse, or Grafana**. Flat JSON converts all fields to a single 1-level key-value format (e.g. `"dns.flags.aa": false`), making indexing, aggregation, and dashboard querying significantly faster and easier downstream.
+
 ## Data Encoding and UTF-8
 
 DNS-collector processes all textual fields (qname, rdata, etc.) as **UTF-8 strings**. 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -231,12 +231,12 @@ Protocol mapping:
 
 | Output Format | CPU Encoding Speed | Memory Impact | Human Readability | Best Use Cases / Target Systems |
 |---|---|---|---|---|
-| **DNStap (Protobuf)** | ⚡⚡⚡⚡⚡ Ultra Fast | 💧 Minimal | 🔬 Binary | High-speed forwarding, DNStap relays, remote collector pipelines |
-| **Text (CSV / Custom)** | ⚡⚡⚡⚡ Very Fast | 💧 Minimal | 👁️👁️👁️ Excellent | Console output, Syslog, local log files, Grep / AWK scripts |
-| **JSON (Nested)** | ⚡⚡⚡⚡ Fast (~1µs) | 💧 Minimal | 👁️👁️ Good | Webhooks, REST APIs, Application storage with nested JSON support |
-| **Flat JSON** | ⚡⚡ Fast (~11µs) | 💧 Low | 👁️ Fair | Elasticsearch, OpenSearch, Loki, ClickHouse, Scalyr, Grafana |
-| **Jinja Template** | ⚡ Moderate | 💧 Moderate | 👁️👁️👁️ Custom | Complex custom human-readable log formatting |
-| **PCAP** | ⚡⚡⚡ Fast | 💧 Minimal | 🔬 Wireshark | Traffic analysis, Network forensics & troubleshooting |
+| **DNStap (Protobuf)** | Ultra Fast | Minimal | Binary | High-speed forwarding, DNStap relays, remote collector pipelines |
+| **Text (CSV / Custom)** | Very Fast | Minimal | Excellent | Console output, Syslog, local log files, Grep / AWK scripts |
+| **JSON (Nested)** | Fast (~1µs) | Minimal | Good | Webhooks, REST APIs, Application storage with nested JSON support |
+| **Flat JSON** | Fast (~3.4µs) | Low | Fair | Elasticsearch, OpenSearch, Loki, ClickHouse, Scalyr, Grafana |
+| **Jinja Template** | Moderate | Moderate | Custom | Complex custom human-readable log formatting |
+| **PCAP** | Fast | Minimal | Wireshark | Traffic analysis, Network forensics & troubleshooting |
 
 > **Note on I/O Bottlenecks**: The table above reflects **CPU encoding speed in Go**. When writing to local disk files or remote network sinks, overall throughput is also constrained by disk I/O (HDD vs. NVMe SSD) and network latency. For high-throughput file logging, consider tuning `flush-interval`, `batch-size`, and `chan-buffer-size`.
 


### PR DESCRIPTION
### Summary
This PR optimizes JSON and Flat-JSON serialization performance in `dnsutils` and introduces an output format selection guide in `formats.md`.

### Key Changes
- **JSON Buffer Recycling (`sync.Pool`)**: Introduced `jsonBufferPool` to recycle `bytes.Buffer` instances in `ToJSON()` and `ToFlatJSON()`, eliminating buffer heap allocations per logged packet.
- **Flat-JSON Map Pre-allocation**: Pre-allocated map capacity (`make(map[string]interface{}, 80)`) in `Flatten()` to avoid map bucket re-allocations during field insertion.
- **Documentation Guide (`docs/formats.md`)**: Added a comprehensive **"Which Output Format Should I Choose?"** guide comparing CPU encoding speeds, memory impact, human readability, and target systems (JSON vs. Flat JSON, Text, DNStap Protobuf, PCAP, Jinja).
- **Dedicated Benchmarks**: Isolated JSON benchmark tests into `dnsutils/dnsmessage_bench_test.go`.

### Performance Impact
Benchmarked on AMD Ryzen 9 9900X:

| Function | RAM Allocated | Allocations | Execution Speed | Net Gain |
| :--- | :--- | :--- | :--- | :--- |
| **`ToJSON()`** | 1,841 B -> **897 B** | 3 allocs -> **1 alloc** | 1,144 ns -> **998 ns** | **-51.3% RAM**, **-66% allocs**, **+14.5% faster** |
| **`ToFlatJSON()`** | 14,475 B -> **2,706 B** | 176 allocs -> **78 allocs** | 13,493 ns -> **3,458 ns** | **-81.3% RAM**, **-55.7% allocs**, **3.9x faster** |

### Quality & Safety Checks
- `golangci-lint`: **0 issues**
- Unit Tests: **PASS**
- Race Detector (`go test -race`): **PASS**
