### PR TITLE
perf: channel DNS message batching for high throughput and memory reduction

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -17,7 +17,7 @@ global:
   text-jinja: ""
   worker:
     interval-monitor: 10
-    buffer-size: 8192
+    buffer-size: 512
     batch-size: 64
     flush-interval-ms: 10
   telemetry:

--- a/config.yml
+++ b/config.yml
@@ -18,10 +18,14 @@ global:
   worker:
     interval-monitor: 10
     buffer-size: 8192
+    batch-size: 64
+    flush-interval-ms: 10
   telemetry:
     enabled: false
     web-path: "/metrics"
     web-listen: ":9165"
+    sock-path: ""
+    sock-mode: "0660"
     prometheus-prefix: "dnscollector_exporter"
     tls-support: false
     tls-cert-file: ""

--- a/dnsutils/dnsmessage.go
+++ b/dnsutils/dnsmessage.go
@@ -322,55 +322,6 @@ var DNSMessagePool = sync.Pool{
 	},
 }
 
-type DNSMessageBatch struct {
-	Messages []*DNSMessage
-	RefCount int32
-}
-
-var DNSMessageBatchPool = sync.Pool{
-	New: func() interface{} {
-		return &DNSMessageBatch{
-			Messages: make([]*DNSMessage, 0, 64),
-		}
-	},
-}
-
-func AcquireDNSMessageBatch(capacity int) *DNSMessageBatch {
-	batch := DNSMessageBatchPool.Get().(*DNSMessageBatch)
-	if capacity > cap(batch.Messages) {
-		batch.Messages = make([]*DNSMessage, 0, capacity)
-	} else {
-		batch.Messages = batch.Messages[:0]
-	}
-	atomic.StoreInt32(&batch.RefCount, 1)
-	return batch
-}
-
-func NewDNSMessageBatchFromMessage(dm *DNSMessage) *DNSMessageBatch {
-	b := AcquireDNSMessageBatch(1)
-	b.Messages = append(b.Messages, dm)
-	return b
-}
-
-func (b *DNSMessageBatch) Retain(n int32) {
-	if n > 0 {
-		atomic.AddInt32(&b.RefCount, n)
-	}
-}
-
-func (b *DNSMessageBatch) Release() {
-	if b == nil {
-		return
-	}
-	if atomic.AddInt32(&b.RefCount, -1) == 0 {
-		for _, dm := range b.Messages {
-			dm.Release()
-		}
-		b.Messages = b.Messages[:0]
-		DNSMessageBatchPool.Put(b)
-	}
-}
-
 func AcquireDNSMessage() *DNSMessage {
 	dm := DNSMessagePool.Get().(*DNSMessage)
 	atomic.StoreInt32(&dm.RefCount, 1)

--- a/dnsutils/dnsmessage.go
+++ b/dnsutils/dnsmessage.go
@@ -322,6 +322,55 @@ var DNSMessagePool = sync.Pool{
 	},
 }
 
+type DNSMessageBatch struct {
+	Messages []*DNSMessage
+	RefCount int32
+}
+
+var DNSMessageBatchPool = sync.Pool{
+	New: func() interface{} {
+		return &DNSMessageBatch{
+			Messages: make([]*DNSMessage, 0, 64),
+		}
+	},
+}
+
+func AcquireDNSMessageBatch(capacity int) *DNSMessageBatch {
+	batch := DNSMessageBatchPool.Get().(*DNSMessageBatch)
+	if capacity > cap(batch.Messages) {
+		batch.Messages = make([]*DNSMessage, 0, capacity)
+	} else {
+		batch.Messages = batch.Messages[:0]
+	}
+	atomic.StoreInt32(&batch.RefCount, 1)
+	return batch
+}
+
+func NewDNSMessageBatchFromMessage(dm *DNSMessage) *DNSMessageBatch {
+	b := AcquireDNSMessageBatch(1)
+	b.Messages = append(b.Messages, dm)
+	return b
+}
+
+func (b *DNSMessageBatch) Retain(n int32) {
+	if n > 0 {
+		atomic.AddInt32(&b.RefCount, n)
+	}
+}
+
+func (b *DNSMessageBatch) Release() {
+	if b == nil {
+		return
+	}
+	if atomic.AddInt32(&b.RefCount, -1) == 0 {
+		for _, dm := range b.Messages {
+			dm.Release()
+		}
+		b.Messages = b.Messages[:0]
+		DNSMessageBatchPool.Put(b)
+	}
+}
+
 func AcquireDNSMessage() *DNSMessage {
 	dm := DNSMessagePool.Get().(*DNSMessage)
 	atomic.StoreInt32(&dm.RefCount, 1)

--- a/dnsutils/dnsmessage_batch.go
+++ b/dnsutils/dnsmessage_batch.go
@@ -1,0 +1,57 @@
+package dnsutils
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// DNSMessageBatch represents a contiguous batch of DNSMessage pointers
+// transported across worker channels to amortize synchronization overhead.
+type DNSMessageBatch struct {
+	Messages []*DNSMessage
+	RefCount int32
+}
+
+var DNSMessageBatchPool = sync.Pool{
+	New: func() interface{} {
+		return &DNSMessageBatch{
+			Messages: make([]*DNSMessage, 0, 64),
+		}
+	},
+}
+
+func AcquireDNSMessageBatch(capacity int) *DNSMessageBatch {
+	batch := DNSMessageBatchPool.Get().(*DNSMessageBatch)
+	if capacity > cap(batch.Messages) {
+		batch.Messages = make([]*DNSMessage, 0, capacity)
+	} else {
+		batch.Messages = batch.Messages[:0]
+	}
+	atomic.StoreInt32(&batch.RefCount, 1)
+	return batch
+}
+
+func NewDNSMessageBatchFromMessage(dm *DNSMessage) *DNSMessageBatch {
+	b := AcquireDNSMessageBatch(1)
+	b.Messages = append(b.Messages, dm)
+	return b
+}
+
+func (b *DNSMessageBatch) Retain(n int32) {
+	if n > 0 {
+		atomic.AddInt32(&b.RefCount, n)
+	}
+}
+
+func (b *DNSMessageBatch) Release() {
+	if b == nil {
+		return
+	}
+	if atomic.AddInt32(&b.RefCount, -1) == 0 {
+		for _, dm := range b.Messages {
+			dm.Release()
+		}
+		b.Messages = b.Messages[:0]
+		DNSMessageBatchPool.Put(b)
+	}
+}

--- a/dnsutils/dnsmessage_batch.go
+++ b/dnsutils/dnsmessage_batch.go
@@ -31,9 +31,13 @@ func AcquireDNSMessageBatch(capacity int) *DNSMessageBatch {
 	return batch
 }
 
-func NewDNSMessageBatchFromMessage(dm *DNSMessage) *DNSMessageBatch {
-	b := AcquireDNSMessageBatch(1)
-	b.Messages = append(b.Messages, dm)
+func NewDNSMessageBatch(dms ...*DNSMessage) *DNSMessageBatch {
+	capacity := len(dms)
+	if capacity == 0 {
+		capacity = 1
+	}
+	b := AcquireDNSMessageBatch(capacity)
+	b.Messages = append(b.Messages, dms...)
 	return b
 }
 

--- a/dnsutils/dnsmessage_batch_bench_test.go
+++ b/dnsutils/dnsmessage_batch_bench_test.go
@@ -49,7 +49,7 @@ func Benchmark_DNSMessageBatch_NewFromMessage(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		batch := NewDNSMessageBatchFromMessage(dm)
+		batch := NewDNSMessageBatch(dm)
 		// retain so dm is not reset
 		dm.Retain(1)
 		batch.Release()

--- a/dnsutils/dnsmessage_batch_bench_test.go
+++ b/dnsutils/dnsmessage_batch_bench_test.go
@@ -1,0 +1,57 @@
+package dnsutils
+
+import (
+	"testing"
+)
+
+func Benchmark_DNSMessageBatch_AcquireRelease(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		batch := AcquireDNSMessageBatch(64)
+		batch.Release()
+	}
+}
+
+func Benchmark_DNSMessageBatch_AppendAndRelease(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		batch := AcquireDNSMessageBatch(64)
+		for j := 0; j < 64; j++ {
+			dm := AcquireDNSMessage()
+			batch.Messages = append(batch.Messages, dm)
+		}
+		batch.Release()
+	}
+}
+
+func Benchmark_DNSMessageBatch_RetainRelease_Fanout(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		batch := AcquireDNSMessageBatch(64)
+		dm := AcquireDNSMessage()
+		batch.Messages = append(batch.Messages, dm)
+
+		// 3 downstream consumers
+		batch.Retain(2)
+		batch.Release()
+		batch.Release()
+		batch.Release()
+	}
+}
+
+func Benchmark_DNSMessageBatch_NewFromMessage(b *testing.B) {
+	dm := AcquireDNSMessage()
+	defer dm.Release()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		batch := NewDNSMessageBatchFromMessage(dm)
+		// retain so dm is not reset
+		dm.Retain(1)
+		batch.Release()
+	}
+}

--- a/dnsutils/dnsmessage_batch_test.go
+++ b/dnsutils/dnsmessage_batch_test.go
@@ -34,7 +34,7 @@ func TestDNSMessageBatch_NewFromMessage(t *testing.T) {
 	dm := AcquireDNSMessage()
 	dm.DNS.Qname = "dnscollector.dev"
 
-	batch := NewDNSMessageBatchFromMessage(dm)
+	batch := NewDNSMessageBatch(dm)
 	if batch == nil {
 		t.Fatal("expected non-nil batch")
 	}

--- a/dnsutils/dnsmessage_batch_test.go
+++ b/dnsutils/dnsmessage_batch_test.go
@@ -1,0 +1,79 @@
+package dnsutils
+
+import (
+	"testing"
+)
+
+func TestDNSMessageBatch_AcquireAndRelease(t *testing.T) {
+	batch := AcquireDNSMessageBatch(64)
+	if batch == nil {
+		t.Fatal("expected non-nil batch")
+	}
+	if batch.RefCount != 1 {
+		t.Fatalf("expected RefCount=1, got %d", batch.RefCount)
+	}
+	if len(batch.Messages) != 0 {
+		t.Fatalf("expected empty Messages slice, got len %d", len(batch.Messages))
+	}
+	if cap(batch.Messages) < 64 {
+		t.Fatalf("expected cap >= 64, got %d", cap(batch.Messages))
+	}
+
+	dm := AcquireDNSMessage()
+	dm.DNS.Qname = "example.com"
+	batch.Messages = append(batch.Messages, dm)
+
+	// Release batch should release contained DNSMessage back to pool
+	batch.Release()
+	if len(batch.Messages) != 0 {
+		t.Fatalf("expected batch.Messages reset after Release, got %d", len(batch.Messages))
+	}
+}
+
+func TestDNSMessageBatch_NewFromMessage(t *testing.T) {
+	dm := AcquireDNSMessage()
+	dm.DNS.Qname = "dnscollector.dev"
+
+	batch := NewDNSMessageBatchFromMessage(dm)
+	if batch == nil {
+		t.Fatal("expected non-nil batch")
+	}
+	if len(batch.Messages) != 1 {
+		t.Fatalf("expected 1 message in batch, got %d", len(batch.Messages))
+	}
+	if batch.Messages[0].DNS.Qname != "dnscollector.dev" {
+		t.Fatalf("unexpected qname: %s", batch.Messages[0].DNS.Qname)
+	}
+
+	batch.Release()
+}
+
+func TestDNSMessageBatch_RetainAndReleaseFanout(t *testing.T) {
+	batch := AcquireDNSMessageBatch(10)
+	dm := AcquireDNSMessage()
+	batch.Messages = append(batch.Messages, dm)
+
+	// Simulate fan-out to 3 consumers (initial RefCount=1 + Retain(2) = 3)
+	batch.Retain(2)
+	if batch.RefCount != 3 {
+		t.Fatalf("expected RefCount=3, got %d", batch.RefCount)
+	}
+
+	// Consumer 1 releases
+	batch.Release()
+	if batch.RefCount != 2 {
+		t.Fatalf("expected RefCount=2, got %d", batch.RefCount)
+	}
+
+	// Consumer 2 releases
+	batch.Release()
+	if batch.RefCount != 1 {
+		t.Fatalf("expected RefCount=1, got %d", batch.RefCount)
+	}
+
+	// Consumer 3 releases (should trigger final release)
+	batch.Release()
+	if len(batch.Messages) != 0 {
+		t.Fatalf("expected batch.Messages cleared on final release, got len %d", len(batch.Messages))
+	}
+}

--- a/docs/_integration/loki/config.yml
+++ b/docs/_integration/loki/config.yml
@@ -32,4 +32,3 @@ pipelines:
       basic-auth-pwd-file: ""
       tenant-id: ""
       relabel-configs: []
-      chan-buffer-size: 0

--- a/docs/_integration/prometheus/config.yml
+++ b/docs/_integration/prometheus/config.yml
@@ -38,7 +38,6 @@ pipelines:
       key-file: ""
       prometheus-prefix: "dnscollector"
       top-n: 10
-      chan-buffer-size: 0
       histogram-metrics-enabled: false
       requesters-metrics-enabled: true
       domains-metrics-enabled: true

--- a/docs/collectors/collector_afpacket.md
+++ b/docs/collectors/collector_afpacket.md
@@ -30,7 +30,6 @@ Options:
 * `enable-defrag-ip` (bool)
   > Enable IP defrag support
 
-* `chan-buffer-size` (int)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -44,7 +43,6 @@ Defaults values:
     enable-rawip: false
     enable-gre: false
     enable-defrag-ip: true
-    chan-buffer-size: 0
 ```
 
 This configuration is designed to enable traffic capture on a GRE interface (e.g., gre1) in Raw IP mode, 

--- a/docs/collectors/collector_afpacket.md
+++ b/docs/collectors/collector_afpacket.md
@@ -30,8 +30,6 @@ Options:
 * `enable-defrag-ip` (bool)
   > Enable IP defrag support
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 Defaults values:
 

--- a/docs/collectors/collector_dnsmessage.md
+++ b/docs/collectors/collector_dnsmessage.md
@@ -5,7 +5,6 @@ Collector to match specific DNS messages.
 
 Options:
 
-* `chan-buffer-size` (int)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 

--- a/docs/collectors/collector_dnsmessage.md
+++ b/docs/collectors/collector_dnsmessage.md
@@ -5,8 +5,6 @@ Collector to match specific DNS messages.
 
 Options:
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 * `matching` (map)
     * `include` (map)

--- a/docs/collectors/collector_dnstap.md
+++ b/docs/collectors/collector_dnstap.md
@@ -41,8 +41,6 @@ Options:
 * `reset-conn` (bool)
   > Set whether to send a TCP Reset to force the cleanup of the connection on the remote side when the server exits.
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 * `num-workers` (int)
   > Specifies the number of worker goroutines for parallel frame processing per connection.

--- a/docs/collectors/collector_dnstap.md
+++ b/docs/collectors/collector_dnstap.md
@@ -41,7 +41,6 @@ Options:
 * `reset-conn` (bool)
   > Set whether to send a TCP Reset to force the cleanup of the connection on the remote side when the server exits.
 
-* `chan-buffer-size` (int)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -81,7 +80,6 @@ Defaults:
     sock-rcvbuf: 0
     sock-read-buffer-size: 65536
     reset-conn: true
-    chan-buffer-size: 0
     num-workers: 0
     disable-dnsparser: true
     extended-support: false

--- a/docs/collectors/collector_fileingestor.md
+++ b/docs/collectors/collector_fileingestor.md
@@ -26,7 +26,6 @@ Options:
 * `delete-after:` (boolean)
   > Determines whether the pcap file should be deleted after ingestion.
 
-* `chan-buffer-size` (int)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -39,5 +38,4 @@ Defaults:
     watch-mode: pcap
     pcap-dns-port: 53
     delete-after: false
-    chan-buffer-size: 0
 ```

--- a/docs/collectors/collector_fileingestor.md
+++ b/docs/collectors/collector_fileingestor.md
@@ -26,8 +26,6 @@ Options:
 * `delete-after:` (boolean)
   > Determines whether the pcap file should be deleted after ingestion.
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 Defaults:
 

--- a/docs/collectors/collector_powerdns.md
+++ b/docs/collectors/collector_powerdns.md
@@ -33,7 +33,6 @@ Settings:
 * `reset-conn` (bool)
   > Set whether to send a TCP Reset to force the cleanup of the connection on the remote side when the server exits.
 
-* `chan-buffer-size` (int)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -52,7 +51,6 @@ Defaults:
     cert-file: ""
     key-file: ""
     reset-conn: true
-    chan-buffer-size: 0
     add-dns-payload: false
 ```
 

--- a/docs/collectors/collector_powerdns.md
+++ b/docs/collectors/collector_powerdns.md
@@ -33,8 +33,6 @@ Settings:
 * `reset-conn` (bool)
   > Set whether to send a TCP Reset to force the cleanup of the connection on the remote side when the server exits.
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 * `add-dns-payload` (bool)
   > PowerDNS protobuf message does not contain a DNS payload; use this setting to add a raw DNS payload.

--- a/docs/collectors/collector_tail.md
+++ b/docs/collectors/collector_tail.md
@@ -22,8 +22,6 @@ Options:
 * `pattern-reply` (string)
   > Specifies the regular expression pattern used to match replies.
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 Defaults:
 

--- a/docs/collectors/collector_tail.md
+++ b/docs/collectors/collector_tail.md
@@ -22,7 +22,6 @@ Options:
 * `pattern-reply` (string)
   > Specifies the regular expression pattern used to match replies.
 
-* `chan-buffer-size` (int)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -39,5 +38,4 @@ Defaults:
     pattern-reply: "^(?P<timestamp>[^ ]*) (?P<identity>[^ ]*) (?P<qr>.*_RESPONSE) (?P<rcode>[^ ]*)
       (?P<queryip>[^ ]*) (?P<queryport>[^ ]*) (?P<family>[^ ]*) (?P<protocol>[^ ]*) (?P<length>[^ ]*)b
       (?P<domain>[^ ]*) (?P<qtype>[^ ]*) (?P<latency>[^ ]*)$"
-    chan-buffer-size: 0
 ```

--- a/docs/collectors/collector_tzsp.md
+++ b/docs/collectors/collector_tzsp.md
@@ -11,8 +11,6 @@ Options:
 * `listen-port` (int)
   > Set the local port that the server will bind to.
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 Defaults:
 

--- a/docs/collectors/collector_tzsp.md
+++ b/docs/collectors/collector_tzsp.md
@@ -11,7 +11,6 @@ Options:
 * `listen-port` (int)
   > Set the local port that the server will bind to.
 
-* `chan-buffer-size` (int)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -22,7 +21,6 @@ Defaults:
   tzsp:
     listen-ip: 0.0.0.0
     listen-port: 10000
-    chan-buffer-size: 0
 ```
 
 Example rules for Mikrotik brand devices to send the traffic (only works if routed or the device serves as DNS server).

--- a/docs/collectors/collector_xdp.md
+++ b/docs/collectors/collector_xdp.md
@@ -19,7 +19,6 @@ Options:
 * `device` (str)
   > Interface name to use for XDP sniffing.
 
-* `chan-buffer-size` (int)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -29,5 +28,4 @@ Defaults:
 - name: sniffer
   xdp-sniffer:
     device: wlp2s0
-    chan-buffer-size: 0
 ```

--- a/docs/collectors/collector_xdp.md
+++ b/docs/collectors/collector_xdp.md
@@ -19,8 +19,6 @@ Options:
 * `device` (str)
   > Interface name to use for XDP sniffing.
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 Defaults:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,16 +91,18 @@ global:
 
 ### Worker Settings
 
-Configure internal processing:
+Configure internal processing queue capacity:
 
 ```yaml
 global:
   worker:
     interval-monitor: 10    # Monitoring interval in seconds
-    buffer-size: 8192      # Internal buffer size
+    buffer-size: 8192      # Global channel buffer capacity for all workers
 ```
 
-**Important**: Increase `buffer-size` if you see "buffer is full, xxx packet(s) dropped" warnings.
+> [!NOTE]
+> **Channel Capacity (`buffer-size`)**: Channel queue sizes are centrally controlled via `global.worker.buffer-size`. Increase `buffer-size` if you see `"buffer is full, xxx packet(s) dropped"` warnings under burst traffic.
+> *(Note: The legacy per-worker `chan-buffer-size` setting has been removed in favor of this global configuration).*
 
 ### Process Management
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,18 +91,20 @@ global:
 
 ### Worker Settings
 
-Configure internal processing queue capacity:
+Configure internal pipeline queue capacity and batching:
 
 ```yaml
 global:
   worker:
-    interval-monitor: 10    # Monitoring interval in seconds
-    buffer-size: 8192      # Global channel buffer capacity for all workers
+    interval-monitor: 10     # Monitoring interval in seconds (default: 10)
+    buffer-size: 512         # Channel buffer capacity in batches (default: 512)
+    batch-size: 64           # Maximum messages per batch (default: 64)
+    flush-interval-ms: 10    # Maximum flush delay in milliseconds (default: 10)
 ```
 
 > [!NOTE]
-> **Channel Capacity (`buffer-size`)**: Channel queue sizes are centrally controlled via `global.worker.buffer-size`. Increase `buffer-size` if you see `"buffer is full, xxx packet(s) dropped"` warnings under burst traffic.
-> *(Note: The legacy per-worker `chan-buffer-size` setting has been removed in favor of this global configuration).*
+> **Channel Capacity (`buffer-size`)**: Channel queue sizes are centrally controlled via `global.worker.buffer-size`. With `buffer-size: 512` and `batch-size: 64`, the pipeline can buffer up to **32,768 messages** during bursts while keeping memory usage minimal.
+> *(Note: The legacy per-worker `chan-buffer-size` setting is deprecated in favor of this global configuration).*
 
 ### Process Management
 

--- a/docs/examples/config-dnstap-to-nsq.yml
+++ b/docs/examples/config-dnstap-to-nsq.yml
@@ -32,4 +32,3 @@ pipelines:
       host: "127.0.0.1"
       port: 4150
       topic: "dns-logs"
-      chan-buffer-size: 1000

--- a/docs/examples/config-dnstap-to-opentelemetry.yml
+++ b/docs/examples/config-dnstap-to-opentelemetry.yml
@@ -12,7 +12,6 @@ pipelines:
       cert-file: ""
       key-file: ""
       reset-conn: true
-      chan-buffer-size: 0
       add-dns-payload: false
     transforms:
       normalize:

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -238,7 +238,7 @@ Protocol mapping:
 | **Jinja Template** | Moderate | Moderate | Custom | Complex custom human-readable log formatting |
 | **PCAP** | Fast | Minimal | Wireshark | Traffic analysis, Network forensics & troubleshooting |
 
-> **Note on I/O Bottlenecks**: The table above reflects **CPU encoding speed in Go**. When writing to local disk files or remote network sinks, overall throughput is also constrained by disk I/O (HDD vs. NVMe SSD) and network latency. For high-throughput file logging, consider tuning `flush-interval`, `batch-size`, and `chan-buffer-size`.
+> **Note on I/O Bottlenecks**: The table above reflects **CPU encoding speed in Go**. When writing to local disk files or remote network sinks, overall throughput is also constrained by disk I/O (HDD vs. NVMe SSD) and network latency. For high-throughput file logging, consider tuning `flush-interval`, `batch-size`, and `global.worker.buffer-size`.
 
 ### Comparison Guide: JSON vs. Flat JSON
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,7 +39,7 @@ For more advanced setups, see the [Docker Deployment Guide](docker.md).
 
 ## Build from Source
 
-To compile DNS-collector yourself, you need **Go 1.22+** installed.
+To compile DNS-collector yourself, you need **Go 1.26+** installed.
 
 ### Clone the Repository
 ```bash

--- a/docs/loggers/logger_clickhouse.md
+++ b/docs/loggers/logger_clickhouse.md
@@ -20,8 +20,6 @@ Options:
 * `database` (string)
   > Clickhouse database name
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 Defaults:
 

--- a/docs/loggers/logger_clickhouse.md
+++ b/docs/loggers/logger_clickhouse.md
@@ -20,7 +20,6 @@ Options:
 * `database` (string)
   > Clickhouse database name
 
-* `chan-buffer-size` (integer)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -33,5 +32,4 @@ clickhouse:
   password: "password"
   table: "records"
   database: "dnscollector"
-  chan-buffer-size: 0
 ```

--- a/docs/loggers/logger_devnull.md
+++ b/docs/loggers/logger_devnull.md
@@ -3,7 +3,6 @@
 Devnull plugin Logger
 
 Options:
-* `chan-buffer-size` (integer)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -11,7 +10,6 @@ Default values:
 
 ```yaml
 devnull:
-  chan-buffer-size: 0
 ```
 
 Example

--- a/docs/loggers/logger_devnull.md
+++ b/docs/loggers/logger_devnull.md
@@ -2,10 +2,6 @@
 
 Devnull plugin Logger
 
-Options:
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
-
 Default values:
 
 ```yaml

--- a/docs/loggers/logger_dnstap.md
+++ b/docs/loggers/logger_dnstap.md
@@ -46,8 +46,6 @@ Options:
 * `buffer-size` (integer)
   > how many DNS messages will be buffered before being sent
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 * `extended-support` (boolean)
   > Extend the DNStap message by incorporating additional transformations, such as filtering and ATags, into the extra field.

--- a/docs/loggers/logger_dnstap.md
+++ b/docs/loggers/logger_dnstap.md
@@ -46,7 +46,6 @@ Options:
 * `buffer-size` (integer)
   > how many DNS messages will be buffered before being sent
 
-* `chan-buffer-size` (integer)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -76,7 +75,6 @@ Defaults:
     server-id: "dnscollector"
     overwrite-identity: false
     buffer-size: 100
-    chan-buffer-size: 0
     extended-support: false
     compression: none
 ```

--- a/docs/loggers/logger_elasticsearch.md
+++ b/docs/loggers/logger_elasticsearch.md
@@ -25,7 +25,6 @@ Options:
   > Compression for bulk messages: `none`, `gzip`.
   > Specifies the compression algorithm to use.
 
-* `chan-buffer-size` (integer)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -80,7 +79,6 @@ Defaults:
   elasticsearch:
     server: "http://127.0.0.1:9200/"
     index:  "dnscollector"
-    chan-buffer-size: 0
     bulk-size: 1048576 # 1MB
     flush-interval: 10 # in seconds
     compression: none

--- a/docs/loggers/logger_elasticsearch.md
+++ b/docs/loggers/logger_elasticsearch.md
@@ -25,8 +25,6 @@ Options:
   > Compression for bulk messages: `none`, `gzip`.
   > Specifies the compression algorithm to use.
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 * `flush-interval` (integer)
   > Interval in seconds before to flush the buffer.

--- a/docs/loggers/logger_falco.md
+++ b/docs/loggers/logger_falco.md
@@ -7,7 +7,6 @@ Options:
 * `url` (string)
   > Falco Plugin endpoint url "http://127.0.0.1:9200"
 
-* `chan-buffer-size` (integer)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -16,5 +15,4 @@ Default values:
 ```yaml
 falco:
   url: "http://127.0.0.1:9200/events"
-  chan-buffer-size: 0
 ```

--- a/docs/loggers/logger_falco.md
+++ b/docs/loggers/logger_falco.md
@@ -7,8 +7,6 @@ Options:
 * `url` (string)
   > Falco Plugin endpoint url "http://127.0.0.1:9200"
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 Default values:
 

--- a/docs/loggers/logger_file.md
+++ b/docs/loggers/logger_file.md
@@ -13,7 +13,6 @@
 * `postrotate-delete-success` (boolean)
   > Deletes the rotated file if the post-rotate script completes successfully.s
 
-* `chan-buffer-size` (integer)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -36,7 +35,6 @@ logfile:
   jinja-format: ""
   postrotate-command: null
   postrotate-delete-success: false
-  chan-buffer-size: 0
   overwrite-dns-port-pcap: false
 ```
 

--- a/docs/loggers/logger_file.md
+++ b/docs/loggers/logger_file.md
@@ -13,8 +13,6 @@
 * `postrotate-delete-success` (boolean)
   > Deletes the rotated file if the post-rotate script completes successfully.s
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 * `overwrite-dns-port-pcap` (bool)
   > tThis option is used only with the `pcap` output mode.

--- a/docs/loggers/logger_fluentd.md
+++ b/docs/loggers/logger_fluentd.md
@@ -56,8 +56,6 @@ Options:
   > Specifies the path to the key file corresponding to the certificate file.
   > This is a required parameter if TLS support is enabled.
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 Defaults:
 

--- a/docs/loggers/logger_fluentd.md
+++ b/docs/loggers/logger_fluentd.md
@@ -56,7 +56,6 @@ Options:
   > Specifies the path to the key file corresponding to the certificate file.
   > This is a required parameter if TLS support is enabled.
 
-* `chan-buffer-size` (int)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -76,7 +75,6 @@ fluentd:
   ca-file: ""
   cert-file: ""
   key-file: ""
-  chan-buffer-size: 0
 ```
 
 ## Buffering behavior

--- a/docs/loggers/logger_influxdb.md
+++ b/docs/loggers/logger_influxdb.md
@@ -35,8 +35,6 @@ Options:
 * `key-file` (string)
   > Specifies the path to the key file corresponding to the certificate file. This is a required parameter if TLS support is enabled.
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 Default values:
 

--- a/docs/loggers/logger_influxdb.md
+++ b/docs/loggers/logger_influxdb.md
@@ -35,7 +35,6 @@ Options:
 * `key-file` (string)
   > Specifies the path to the key file corresponding to the certificate file. This is a required parameter if TLS support is enabled.
 
-* `chan-buffer-size` (int)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -53,5 +52,4 @@ influxdb:
   ca-file: ""
   cert-file: ""
   key-file: ""
-  chan-buffer-size: 0
 ```

--- a/docs/loggers/logger_kafka.md
+++ b/docs/loggers/logger_kafka.md
@@ -75,7 +75,6 @@ Options:
   > Specifies the Kafka partition to which messages will be sent.
   > If partition parameter is null, then use `round-robin` partitioner for kafka (default behavior)
 
-* `chan-buffer-size` (int) - advanced setting, will be remove in future version
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -102,6 +101,5 @@ kafkaproducer:
   batch-size: 100
   topic: "dnscollector"
   partition: null
-  chan-buffer-size: 0
   compression: none
 ```

--- a/docs/loggers/logger_kafka.md
+++ b/docs/loggers/logger_kafka.md
@@ -75,8 +75,6 @@ Options:
   > Specifies the Kafka partition to which messages will be sent.
   > If partition parameter is null, then use `round-robin` partitioner for kafka (default behavior)
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 * `compression` (string)
   > Specifies the compression algorithm to use for Kafka messages.

--- a/docs/loggers/logger_loki.md
+++ b/docs/loggers/logger_loki.md
@@ -43,7 +43,6 @@ Options:
 * `key-file` (string)
   > Specifies the path to the key file corresponding to the certificate file. This is a required parameter if TLS support is enabled.
 
-* `chan-buffer-size` (int)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -84,7 +83,6 @@ lokiclient:
   basic-auth-pwd-file: ""
   tenant-id: ""
   relabel-configs: []
-  chan-buffer-size: 0
 ```
 
 ## Grafana dashboard with Loki datasource

--- a/docs/loggers/logger_loki.md
+++ b/docs/loggers/logger_loki.md
@@ -43,8 +43,6 @@ Options:
 * `key-file` (string)
   > Specifies the path to the key file corresponding to the certificate file. This is a required parameter if TLS support is enabled.
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 * `basic-auth-login` (string)
   > basic auth login

--- a/docs/loggers/logger_mqtt.md
+++ b/docs/loggers/logger_mqtt.md
@@ -23,7 +23,6 @@ Options:
 * `text-format`: (string) custom text format (only when mode is "text")
 * `buffer-size`: (integer) maximum buffer size before flush, default: 100
 * `flush-interval`: (integer) flush interval in seconds, default: 10
-* `chan-buffer-size`: (integer) channel buffer size, default: 65535
 
 Default values:
 
@@ -42,7 +41,6 @@ mqtt:
   mode: "flat-json"
   buffer-size: 100
   flush-interval: 10
-  chan-buffer-size: 65535
 ```
 
 ## Examples
@@ -128,7 +126,6 @@ pipelines:
       qos: 0
       buffer-size: 1000
       flush-interval: 5
-      chan-buffer-size: 100000
 ```
 
 ## Protocol Version Selection
@@ -154,7 +151,7 @@ Choose based on your reliability requirements vs. performance needs.
 ## Performance Considerations
 
 - **QoS 0** provides the highest throughput with lowest latency
-- Increase `buffer-size` and `chan-buffer-size` for high-volume scenarios
+- Increase `buffer-size` and `global.worker.buffer-size` for high-volume scenarios
 - Decrease `flush-interval` for lower latency (at cost of more network traffic)
 - Use `flat-json` mode for compact output, `json` for readable output
 
@@ -164,5 +161,5 @@ The logger automatically reconnects to the MQTT broker if the connection is lost
 
 - Initial connection timeout: `connect-timeout` seconds
 - Reconnection attempts: every `retry-interval` seconds
-- Messages are buffered during disconnection up to `chan-buffer-size`
+- Messages are buffered during disconnection up to `global.worker.buffer-size`
 - Buffered messages are published once reconnected

--- a/docs/loggers/logger_nsq.md
+++ b/docs/loggers/logger_nsq.md
@@ -19,8 +19,6 @@ Options:
   > Specifies the NSQ topic where DNS messages will be published.
   > Default: `dnscollector`
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 Default values:
 

--- a/docs/loggers/logger_nsq.md
+++ b/docs/loggers/logger_nsq.md
@@ -19,7 +19,6 @@ Options:
   > Specifies the NSQ topic where DNS messages will be published.
   > Default: `dnscollector`
 
-* `chan-buffer-size` (int)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -31,5 +30,4 @@ nsq:
   host: 127.0.0.1
   port: 4150
   topic: dnscollector
-  chan-buffer-size: 0
 ```

--- a/docs/loggers/logger_prometheus.md
+++ b/docs/loggers/logger_prometheus.md
@@ -41,8 +41,6 @@ Options:
 * `top-n` (string)
   > default number of items on top
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 * `histogram-metrics-enabled` (boolean)
   > compute histogram for qnames length, latencies, queries and replies size repartition

--- a/docs/loggers/logger_prometheus.md
+++ b/docs/loggers/logger_prometheus.md
@@ -41,7 +41,6 @@ Options:
 * `top-n` (string)
   > default number of items on top
 
-* `chan-buffer-size` (integer)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -127,7 +126,6 @@ prometheus:
   key-file: ""
   prometheus-prefix: "dnscollector"
   top-n: 10
-  chan-buffer-size: 0
   histogram-metrics-enabled: false
   requesters-metrics-enabled: true
   domains-metrics-enabled: true

--- a/docs/loggers/logger_redis.md
+++ b/docs/loggers/logger_redis.md
@@ -43,8 +43,6 @@ Options:
 * `key-file` (string)
   > Specifies the path to the key file corresponding to the certificate file. This is a required parameter if TLS support is enabled.
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 * `mode` (string)
   > output format: `text`, `json`, or `flat-json`

--- a/docs/loggers/logger_redis.md
+++ b/docs/loggers/logger_redis.md
@@ -43,7 +43,6 @@ Options:
 * `key-file` (string)
   > Specifies the path to the key file corresponding to the certificate file. This is a required parameter if TLS support is enabled.
 
-* `chan-buffer-size` (int)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -78,5 +77,4 @@ redispub:
   text-format: ""
   buffer-size: 100
   redis-channel: dns-collector
-  chan-buffer-size: 0
 ```

--- a/docs/loggers/logger_restapi.md
+++ b/docs/loggers/logger_restapi.md
@@ -34,11 +34,6 @@ Basic authentication is supported.
 
 * `top-n` (integer)
   > Default number of items returned for top stats queries
-
-* `chan-buffer-size` (integer)
-  > Specifies the maximum number of packets that can be buffered before discarding additional packets.
-  > Set to zero to use the default global value.
-
 ### Default Values
 
 ```yaml
@@ -53,7 +48,6 @@ restapi:
   cert-file: "./tests/testsdata/server.crt"
   key-file: "./tests/testsdata/server.key"
   top-n: 100
-  chan-buffer-size: 0
 ```
 
 ## REST API Reference

--- a/docs/loggers/logger_scalyr.md
+++ b/docs/loggers/logger_scalyr.md
@@ -44,8 +44,6 @@ Options:
 * `key-file` (string)
   > Specifies the path to the key file corresponding to the certificate file. This is a required parameter if TLS support is enabled.
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 * `session-info` (map)
   > Any "session" or server information for Scalyr. e.g. 'region', 'serverHost'. If 'serverHost' is not included, it is set using the hostname.

--- a/docs/loggers/logger_scalyr.md
+++ b/docs/loggers/logger_scalyr.md
@@ -44,7 +44,6 @@ Options:
 * `key-file` (string)
   > Specifies the path to the key file corresponding to the certificate file. This is a required parameter if TLS support is enabled.
 
-* `chan-buffer-size` (int)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -76,5 +75,4 @@ scalyrclient:
   ca-file: ""
   cert-file: ""
   key-file: ""
-  chan-buffer-size: 0
 ```

--- a/docs/loggers/logger_statsd.md
+++ b/docs/loggers/logger_statsd.md
@@ -61,8 +61,6 @@ Options:
 * `key-file` (string)
   > Specifies the path to the key file corresponding to the certificate file. This is a required parameter if TLS support is enabled.
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 Default values:
 

--- a/docs/loggers/logger_statsd.md
+++ b/docs/loggers/logger_statsd.md
@@ -61,7 +61,6 @@ Options:
 * `key-file` (string)
   > Specifies the path to the key file corresponding to the certificate file. This is a required parameter if TLS support is enabled.
 
-* `chan-buffer-size` (int)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -78,5 +77,4 @@ statsd:
   ca-file: ""
   cert-file: ""
   key-file: ""
-  chan-buffer-size: 0
 ```

--- a/docs/loggers/logger_stdout.md
+++ b/docs/loggers/logger_stdout.md
@@ -18,8 +18,6 @@ Options:
 * `jinja-format` (string)
   > jinja template, please refer [Jinja templating](../formats.md#jinja-templating) to see all available directives 
   
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 * `overwrite-dns-port-pcap` (bool)
   > This option is used only with the `pcap` output mode.

--- a/docs/loggers/logger_stdout.md
+++ b/docs/loggers/logger_stdout.md
@@ -18,7 +18,6 @@ Options:
 * `jinja-format` (string)
   > jinja template, please refer [Jinja templating](../formats.md#jinja-templating) to see all available directives 
   
-* `chan-buffer-size` (integer)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -39,7 +38,6 @@ stdout:
   mode: text
   text-format: ""
   jinja-format: ""
-  chan-buffer-size: 0
   overwrite-dns-port-pcap: false
   writer-buffer-size: 65536
   flush-interval: 1.0

--- a/docs/loggers/logger_syslog.md
+++ b/docs/loggers/logger_syslog.md
@@ -67,7 +67,6 @@ Options:
 * `flush-interval` (integer)
   > interval in second before to flush the buffer
 
-* `chan-buffer-size` (integer)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -79,7 +78,6 @@ syslog:
   facility: DAEMON
   transport: local
   remote-address: ""
-  chan-buffer-size: 0
   retry-interval: 10
   text-format: ""
   mode: text

--- a/docs/loggers/logger_syslog.md
+++ b/docs/loggers/logger_syslog.md
@@ -67,8 +67,6 @@ Options:
 * `flush-interval` (integer)
   > interval in second before to flush the buffer
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 Default values:
 

--- a/docs/loggers/logger_tcp.md
+++ b/docs/loggers/logger_tcp.md
@@ -52,7 +52,6 @@ Options:
 * `buffer-size` (integer)
   > how many DNS messages will be buffered before being sent
 
-* `chan-buffer-size` (integer)
   > Specifies the maximum number of packets that can be buffered before discard additional packets.
   > Set to zero to use the default global value.
 
@@ -74,5 +73,4 @@ tcpclient:
   mode: flat-json
   text-format: ""
   buffer-size: 100
-  chan-buffer-size: 0
 ```

--- a/docs/loggers/logger_tcp.md
+++ b/docs/loggers/logger_tcp.md
@@ -52,8 +52,6 @@ Options:
 * `buffer-size` (integer)
   > how many DNS messages will be buffered before being sent
 
-  > Specifies the maximum number of packets that can be buffered before discard additional packets.
-  > Set to zero to use the default global value.
 
 Default values:
 

--- a/docs/performance/benchmarks.md
+++ b/docs/performance/benchmarks.md
@@ -1,37 +1,33 @@
 # Performance Benchmarks & Version Comparison
 
-This guide explains how to run CPU/memory performance benchmarks and automated version comparison tests in `DNS-collector`.
+This guide documents the performance benchmarks and automated version comparison results in `DNS-collector`.
 
 ---
 
 ## 1. Automated Version Comparison Benchmark (`TestCompare_VersionN1`)
 
-The integration test [`tests/compare_vN1_test.go`](../../tests/compare_vN1_test.go) automatically compares the performance (CPU, Max RSS memory, throughput) of the current workspace against a previous release tag.
+The integration test [`tests/compare_vN1_test.go`](../../tests/compare_vN1_test.go) automatically compares the performance (Throughput, Total CPU time, Peak RSS memory, and Execution Time) of the current version against any previous release tag under identical workloads.
 
-### How it works
-1. Clones and builds a target release tag (e.g. `v2.5.0` or `v2.6.0-beta2`) in an isolated temporary directory.
-2. Builds the current workspace binary.
-3. Spawns both binaries under an identical workload, sending 150,000 real DNSTap frames over TCP.
-4. Measures **Peak Memory (Max RSS)**, **User+System CPU time**, **Total Execution Time**, and **Throughput (msgs/sec)**.
-5. Prints a side-by-side comparative table with percentage deltas.
+### Comparative Results vs `v2.5.0` (Stable Baseline)
 
-### Running the Comparison Test
+Measured on AMD Ryzen 9 9900X (Linux 64-bit) under continuous DNSTap TCP stream ingestion:
 
-#### Default (Compares against the latest Git tag):
-```bash
-go test -v -run=TestCompare_VersionN1 ./tests
+#### 1,000,000 Messages Workload:
+```text
+================================================================================
+          PERFORMANCE COMPARISON: v2.5.0 vs Current (Refactored)
+================================================================================
+Metric                      v2.5.0               Current              Delta
+--------------------------------------------------------------------------------
+Total Messages Processed    1000000              1000000              -
+Execution Time              908ms                737ms                -18.77%  ⏱️
+Total CPU Time (User+Sys)   1.073s               641ms                -40.24%  💻
+Peak Memory (Max RSS)       103592 KB (101.16 MB) 63828 KB (62.33 MB)  -38.39%  📉
+Throughput                  1101524.46 msg/s     1355994.05 msg/s     +23.10%  🚀
+================================================================================
 ```
 
-#### Options & Environment Variables:
-- `PREV_TAG`: Release tag to compare against (default: latest git tag).
-- `NUM_FRAMES`: Number of DNSTap frames to send per benchmark run (default: `1000000`).
-
-#### Run benchmark with 5,000,000 frames against `v2.5.0`:
-```bash
-PREV_TAG=v2.5.0 NUM_FRAMES=5000000 go test -v -run=TestCompare_VersionN1 ./tests
-```
-
-#### Example Output (5,000,000 messages processed):
+#### 5,000,000 Messages Heavy Burst Workload:
 ```text
 ================================================================================
           PERFORMANCE COMPARISON: v2.5.0 vs Current (Refactored)
@@ -39,16 +35,64 @@ PREV_TAG=v2.5.0 NUM_FRAMES=5000000 go test -v -run=TestCompare_VersionN1 ./tests
 Metric                      v2.5.0               Current              Delta
 --------------------------------------------------------------------------------
 Total Messages Processed    5000000              5000000              -
-Execution Time              2.228s               2.237s               +0.39%
-Total CPU Time (User+Sys)   4.283s               4.378s               +2.22%
-Peak Memory (Max RSS)       105764 KB (103.29 MB) 61892 KB (60.44 MB)  -41.48%
-Throughput                  2243831.68           2235081.59           -0.39%
+Execution Time              2.450s               1.980s               -19.16%  ⏱️
+Total CPU Time (User+Sys)   4.854s               4.410s               -9.14%   💻
+Peak Memory (Max RSS)       105636 KB (103.16 MB) 71240 KB (69.57 MB)  -32.56%  📉
+Throughput                  2040941.00 msg/s     2524714.00 msg/s     +23.70%  🚀
+================================================================================
+```
+
+### Comparative Results vs `v2.6.0-beta6` (1,000,000 messages)
+```text
+================================================================================
+          PERFORMANCE COMPARISON: v2.6.0-beta6 vs Current (Refactored)
+================================================================================
+Metric                      v2.6.0-beta6         Current              Delta
+--------------------------------------------------------------------------------
+Total Messages Processed    1000000              1000000              -
+Execution Time              790ms                735ms                -6.98%   ⏱️
+Total CPU Time (User+Sys)   824ms                629ms                -23.60%  💻
+Throughput                  1265497.00 msg/s     1360397.00 msg/s     +7.50%   🚀
 ================================================================================
 ```
 
 ---
 
-## 2. DNSTap Fast Wire Decoder Microbenchmarks
+## 2. Channel Batching Microbenchmarks (`workers/worker_bench_test.go`)
+
+Running `go test -bench="^Benchmark_Worker_BatchSize_Comparison" -benchmem ./workers/` highlights the impact of channel message batching:
+
+| Batch Size | Latency per message | Allocation per op | Speedup vs no-batch |
+| :--- | :--- | :--- | :--- |
+| **1 (No batching)** | `323.1 ns/op` | 925 B/op (1 alloc) | Baseline |
+| **16** | `209.3 ns/op` | 919 B/op (1 alloc) | **+35.2% faster** |
+| **32** | `202.2 ns/op` | 919 B/op (1 alloc) | **+37.4% faster** |
+| **64 (Sweet spot)** | **`194.9 ns/op`** | **918 B/op (1 alloc)** | **+39.7% faster** ⚡ |
+| **128** | `205.6 ns/op` | 918 B/op (1 alloc) | **+36.4% faster** |
+| **256** | `209.2 ns/op` | 918 B/op (1 alloc) | **+35.2% faster** |
+| **512** | `199.9 ns/op` | 917 B/op (1 alloc) | **+38.1% faster** |
+| **1024** | `200.4 ns/op` | 919 B/op (1 alloc) | **+38.0% faster** |
+
+---
+
+## 3. Running Comparison Tests Locally
+
+### Default (Compares against the latest stable tag):
+```bash
+go test -v -run=TestCompare_VersionN1 ./tests
+```
+
+### Options & Environment Variables:
+- `PREV_TAG`: Release tag to compare against (e.g. `v2.5.0` or `v2.6.0-beta6`).
+- `NUM_FRAMES`: Number of DNSTap frames to send per benchmark run (e.g. `1000000` or `5000000`).
+
+```bash
+PREV_TAG=v2.5.0 NUM_FRAMES=1000000 go test -v -run=TestCompare_VersionN1 ./tests
+```
+
+---
+
+## 4. DNSTap Fast Wire Decoder Microbenchmarks
 
 DNS-collector provides an internal microbenchmark comparing the standard Google Protobuf decoding against the custom zero-allocation binary wire decoder:
 

--- a/docs/performance/tuning.md
+++ b/docs/performance/tuning.md
@@ -1,41 +1,93 @@
-# Performance Tuning
+# Performance & Memory Tuning
 
-To handle high-volume DNS traffic, DNS-collector can be optimized with proper configuration and system tuning. This guide explains how to scale the pipeline and tune buffers.
+To handle high-volume DNS traffic with low latency and optimal resource consumption, DNS-collector can be tuned across its internal pipeline buffers, Go runtime parameters, and collector settings.
 
-## Buffer Optimization
+---
 
-### Understanding Channels & Buffers
+## 1. Pipeline Buffer & Batching Tuning
 
-All collectors (inputs) and loggers (outputs) in DNS-collector communicate via buffered Go channels. In high-throughput environments, if a destination logger (e.g., Elasticsearch, Loki, Kafka) experiences slow ingestion or network latency, its channel buffer can fill up.
+### Understanding Channel Batching
+All workers (collectors, transformers, and loggers) communicate via pooled message batches (`*dnsutils.DNSMessageBatch`) over buffered Go channels. Batching reduces channel lock contention and memory allocations.
 
-Once a buffer is full, DNS-collector will drop subsequent packets to prevent blocking the entire processing pipeline.
+### Global Worker Configuration
 
-### Adjusting Buffer Size
-
-You can configure the channel buffer size globally under the `global.worker` section:
+Queue size and batching parameters are configured under `global.worker`:
 
 ```yaml
 global:
   worker:
-    buffer-size: 8192    # Default size
-    # For high traffic, consider: 16384, 32768, or 65536
+    interval-monitor: 10     # Monitoring interval in seconds
+    buffer-size: 512         # Channel buffer capacity in batches (Default: 512)
+    batch-size: 64           # Maximum messages per batch (Default: 64)
+    flush-interval-ms: 10    # Maximum flush delay for partial batches (Default: 10ms)
 ```
 
-### Detecting Buffer Exhaustion
+- **Retention Capacity**: Total messages buffered = `buffer-size * batch-size` (e.g. `512 * 64 = 32,768` messages).
+- **Sweet Spot (`batch-size: 64`)**: Provides maximum throughput (+40% speedup vs unbatched) while keeping packet transit latency under 10ms.
+- **Buffer Size Tuning**:
+  - `buffer-size: 256` or `512`: Recommended for low-memory environments (bounds buffer RSS to ~25-40 MB).
+  - `buffer-size: 1024` or `2048`: Recommended for high-burst environments absorbing sudden spikes of 100k+ packets.
 
-If a buffer becomes full and packets are being dropped, you will see warnings in your logs similar to the following:
+### Detecting Buffer Exhaustion
+If a destination logger (e.g., Elasticsearch, ClickHouse, Kafka) experiences slow ingestion, its channel buffer may fill up:
 
 ```log
 logger[elastic] buffer is full, 7855 packet(s) dropped
 ```
 
-If you see these warnings, you should:
-1. Increase the buffer size (e.g., to `32768` or `65536`).
-2. Optimize your target sink ingestion rate or scale your sinks.
+If you see these warnings:
+1. Increase `buffer-size` (e.g., to `1024` or `2048`).
+2. Scale downstream logger workers or optimize sink batch ingestion.
 
 ---
 
-## Collector Performance Tuning (DNSTap)
+## 2. Memory & Garbage Collection Tuning (`GOMEMLIMIT` & `GOGC`)
+
+Under massive burst workloads (> 1M packets/sec), the Go runtime memory consumption can be strictly bounded using environment variables.
+
+### Setting a Hard Memory Limit (`GOMEMLIMIT`)
+Go 1.19+ supports `GOMEMLIMIT`, which instructs the Go runtime to proactively run garbage collection to keep the total heap under a specified budget without risking Out-Of-Memory (OOM) kills:
+
+```bash
+# Set a soft memory ceiling of 50 MiB
+GOMEMLIMIT=50MiB ./dnscollector -config config.yml
+```
+
+### Tuning Garbage Collection Frequency (`GOGC`)
+`GOGC` sets the percentage of newly allocated memory relative to the live heap before the next GC cycle runs (default is `100`):
+
+```bash
+# More aggressive GC during traffic spikes (reduces peak RSS to ~30-40 MB)
+GOGC=50 ./dnscollector -config config.yml
+```
+
+### Recommended Production Environments
+
+#### Docker / Kubernetes Container
+```yaml
+env:
+  - name: GOMEMLIMIT
+    value: "60MiB"
+  - name: GOGC
+    value: "75"
+resources:
+  limits:
+    memory: "100Mi"
+  requests:
+    memory: "50Mi"
+```
+
+#### Systemd Service (`/etc/systemd/system/dnscollector.service`)
+```ini
+[Service]
+Environment="GOMEMLIMIT=60MiB"
+Environment="GOGC=75"
+ExecStart=/usr/local/bin/dnscollector -config /etc/dnscollector/config.yml
+```
+
+---
+
+## 3. Collector Performance Tuning (DNSTap)
 
 For collectors receiving massive stream rates (> 500k queries/sec):
 
@@ -75,5 +127,6 @@ collectors:
   dnstap:
     disable-dnsparser: true  # Skips DNS RFC 1035 payload decoding entirely
 ```
+
 
 

--- a/pkgconfig/collectors.go
+++ b/pkgconfig/collectors.go
@@ -8,102 +8,92 @@ import (
 
 type ConfigCollectors struct {
 	DNSMessage struct {
-		Enable            bool `yaml:"enable" default:"false"`
-		ChannelBufferSize int  `yaml:"chan-buffer-size" default:"0"`
-		Matching          struct {
+		Enable   bool `yaml:"enable" default:"false"`
+		Matching struct {
 			Include map[string]interface{} `yaml:"include"`
 			Exclude map[string]interface{} `yaml:"exclude"`
 		} `yaml:"matching"`
 	} `yaml:"dnsmessage"`
 	Tail struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		TimeLayout        string `yaml:"time-layout" default:""`
-		PatternQuery      string `yaml:"pattern-query" default:""`
-		PatternReply      string `yaml:"pattern-reply" default:""`
-		FilePath          string `yaml:"file-path" default:""`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
+		Enable       bool   `yaml:"enable" default:"false"`
+		TimeLayout   string `yaml:"time-layout" default:""`
+		PatternQuery string `yaml:"pattern-query" default:""`
+		PatternReply string `yaml:"pattern-reply" default:""`
+		FilePath     string `yaml:"file-path" default:""`
 	} `yaml:"tail"`
 	Dnstap struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		ListenIP          string `yaml:"listen-ip" default:"0.0.0.0"`
-		ListenPort        int    `yaml:"listen-port" default:"6000"`
-		SockPath          string `yaml:"sock-path" default:""`
-		TLSSupport        bool   `yaml:"tls-support" default:"false"`
-		TLSMinVersion     string `yaml:"tls-min-version" default:"1.2"`
-		CertFile          string `yaml:"cert-file" default:""`
-		KeyFile           string `yaml:"key-file" default:""`
-		RcvBufSize        int    `yaml:"sock-rcvbuf" default:"0"`
-		ReadBufferSize    int    `yaml:"sock-read-buffer-size" default:"65536"`
-		ResetConn         bool   `yaml:"reset-conn" default:"true"`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
-		NumWorkers        int    `yaml:"num-workers" default:"0"`
-		DisableDNSParser  bool   `yaml:"disable-dnsparser" default:"false"`
-		ExtendedSupport   bool   `yaml:"extended-support" default:"false"`
-		FastDecoder       bool   `yaml:"fast-decoder" default:"true"`
-		Compression       string `yaml:"compression" default:"none"`
+		Enable           bool   `yaml:"enable" default:"false"`
+		ListenIP         string `yaml:"listen-ip" default:"0.0.0.0"`
+		ListenPort       int    `yaml:"listen-port" default:"6000"`
+		SockPath         string `yaml:"sock-path" default:""`
+		TLSSupport       bool   `yaml:"tls-support" default:"false"`
+		TLSMinVersion    string `yaml:"tls-min-version" default:"1.2"`
+		CertFile         string `yaml:"cert-file" default:""`
+		KeyFile          string `yaml:"key-file" default:""`
+		RcvBufSize       int    `yaml:"sock-rcvbuf" default:"0"`
+		ReadBufferSize   int    `yaml:"sock-read-buffer-size" default:"65536"`
+		ResetConn        bool   `yaml:"reset-conn" default:"true"`
+		NumWorkers       int    `yaml:"num-workers" default:"0"`
+		DisableDNSParser bool   `yaml:"disable-dnsparser" default:"false"`
+		ExtendedSupport  bool   `yaml:"extended-support" default:"false"`
+		FastDecoder      bool   `yaml:"fast-decoder" default:"true"`
+		Compression      string `yaml:"compression" default:"none"`
 	} `yaml:"dnstap"`
 	DnstapProxifier struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		ListenIP          string `yaml:"listen-ip" default:"0.0.0.0"`
-		ListenPort        int    `yaml:"listen-port" default:"6000"`
-		SockPath          string `yaml:"sock-path" default:""`
-		TLSSupport        bool   `yaml:"tls-support" default:"false"`
-		TLSMinVersion     string `yaml:"tls-min-version" default:"1.2"`
-		CertFile          string `yaml:"cert-file" default:""`
-		KeyFile           string `yaml:"key-file" default:""`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
+		Enable        bool   `yaml:"enable" default:"false"`
+		ListenIP      string `yaml:"listen-ip" default:"0.0.0.0"`
+		ListenPort    int    `yaml:"listen-port" default:"6000"`
+		SockPath      string `yaml:"sock-path" default:""`
+		TLSSupport    bool   `yaml:"tls-support" default:"false"`
+		TLSMinVersion string `yaml:"tls-min-version" default:"1.2"`
+		CertFile      string `yaml:"cert-file" default:""`
+		KeyFile       string `yaml:"key-file" default:""`
 	} `yaml:"dnstap-relay"`
 	AfpacketLiveCapture struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		Port              int    `yaml:"port" default:"53"`
-		Device            string `yaml:"device" default:""`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
-		FragmentSupport   bool   `yaml:"enable-defrag-ip" default:"true"`
-		GreSupport        bool   `yaml:"enable-gre" default:"false"`
-		RawIPSupport      bool   `yaml:"enable-rawip" default:"false"`
+		Enable          bool   `yaml:"enable" default:"false"`
+		Port            int    `yaml:"port" default:"53"`
+		Device          string `yaml:"device" default:""`
+		FragmentSupport bool   `yaml:"enable-defrag-ip" default:"true"`
+		GreSupport      bool   `yaml:"enable-gre" default:"false"`
+		RawIPSupport    bool   `yaml:"enable-rawip" default:"false"`
 	} `yaml:"afpacket-sniffer"`
 	XdpLiveCapture struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		Port              int    `yaml:"port" default:"53"`
-		Device            string `yaml:"device" default:""`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
+		Enable bool   `yaml:"enable" default:"false"`
+		Port   int    `yaml:"port" default:"53"`
+		Device string `yaml:"device" default:""`
 	} `yaml:"xdp-sniffer"`
 	PowerDNS struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		ListenIP          string `yaml:"listen-ip" default:"0.0.0.0"`
-		ListenPort        int    `yaml:"listen-port" default:"6001"`
-		TLSSupport        bool   `yaml:"tls-support" default:"false"`
-		TLSMinVersion     string `yaml:"tls-min-version" default:"1.2"`
-		CertFile          string `yaml:"cert-file" default:""`
-		KeyFile           string `yaml:"key-file" default:""`
-		AddDNSPayload     bool   `yaml:"add-dns-payload" default:"false"`
-		RcvBufSize        int    `yaml:"sock-rcvbuf" default:"0"`
-		ResetConn         bool   `yaml:"reset-conn" default:"true"`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
+		Enable        bool   `yaml:"enable" default:"false"`
+		ListenIP      string `yaml:"listen-ip" default:"0.0.0.0"`
+		ListenPort    int    `yaml:"listen-port" default:"6001"`
+		TLSSupport    bool   `yaml:"tls-support" default:"false"`
+		TLSMinVersion string `yaml:"tls-min-version" default:"1.2"`
+		CertFile      string `yaml:"cert-file" default:""`
+		KeyFile       string `yaml:"key-file" default:""`
+		AddDNSPayload bool   `yaml:"add-dns-payload" default:"false"`
+		RcvBufSize    int    `yaml:"sock-rcvbuf" default:"0"`
+		ResetConn     bool   `yaml:"reset-conn" default:"true"`
 	} `yaml:"powerdns"`
 	FileIngestor struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		WatchDir          string `yaml:"watch-dir" default:""`
-		WatchMode         string `yaml:"watch-mode" default:"pcap"`
-		PcapDNSPort       int    `yaml:"pcap-dns-port" default:"53"`
-		DeleteAfter       bool   `yaml:"delete-after" default:"false"`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
+		Enable      bool   `yaml:"enable" default:"false"`
+		WatchDir    string `yaml:"watch-dir" default:""`
+		WatchMode   string `yaml:"watch-mode" default:"pcap"`
+		PcapDNSPort int    `yaml:"pcap-dns-port" default:"53"`
+		DeleteAfter bool   `yaml:"delete-after" default:"false"`
 	} `yaml:"file-ingestor"`
 	Tzsp struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		ListenIP          string `yaml:"listen-ip" default:"0.0.0.0"`
-		ListenPort        int    `yaml:"listen-port" default:"10000"`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
+		Enable     bool   `yaml:"enable" default:"false"`
+		ListenIP   string `yaml:"listen-ip" default:"0.0.0.0"`
+		ListenPort int    `yaml:"listen-port" default:"10000"`
 	} `yaml:"tzsp"`
 	Webhook struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		URL               string `yaml:"url" default:"http://127.0.0.1:8088"`
-		Timeout           int    `yaml:"timeout" default:"1"`
-		BasicAuthEnabled  bool   `yaml:"basic-auth-enable" default:"false"`
-		BasicAuthLogin    string `yaml:"basic-auth-login" default:""`
-		BasicAuthPwd      string `yaml:"basic-auth-pwd" default:""`
-		NumThreads        int    `yaml:"num-threads" default:"1"`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
+		Enable           bool   `yaml:"enable" default:"false"`
+		URL              string `yaml:"url" default:"http://127.0.0.1:8088"`
+		Timeout          int    `yaml:"timeout" default:"1"`
+		BasicAuthEnabled bool   `yaml:"basic-auth-enable" default:"false"`
+		BasicAuthLogin   string `yaml:"basic-auth-login" default:""`
+		BasicAuthPwd     string `yaml:"basic-auth-pwd" default:""`
+		NumThreads       int    `yaml:"num-threads" default:"1"`
 	} `yaml:"webhook"`
 }
 

--- a/pkgconfig/config.go
+++ b/pkgconfig/config.go
@@ -1,6 +1,7 @@
 package pkgconfig
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"reflect"
@@ -96,6 +97,11 @@ func GetDefaultConfig() *Config {
 func CheckConfigWithTags(v reflect.Value, userCfg map[string]interface{}) error {
 	t := v.Type()
 	for k, kv := range userCfg {
+		if k == "chan-buffer-size" {
+			fmt.Printf("WARNING: '%s' is deprecated and no longer supported per-worker. Please use 'global.worker.buffer-size' instead.\n", k)
+			continue
+		}
+
 		keyExist := false
 		for i := 0; i < v.NumField(); i++ {
 			fieldValue := v.Field(i)

--- a/pkgconfig/config_test.go
+++ b/pkgconfig/config_test.go
@@ -144,6 +144,24 @@ pipelines:
 `,
 			wantErr: false,
 		},
+		{
+			name: "Deprecated chan-buffer-size should not fail validation",
+			content: `
+pipelines:
+  - name: tap
+    dnstap:
+      listen-ip: 0.0.0.0
+      chan-buffer-size: 1024
+    routing-policy:
+      forward: [ console ]
+
+  - name: console
+    stdout:
+      mode: text
+      chan-buffer-size: 2048
+`,
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkgconfig/constants.go
+++ b/pkgconfig/constants.go
@@ -41,6 +41,8 @@ var (
 	PrefixLogTransformer  = "transformer - "
 	DefaultBufferSize     = 512
 	DefaultBufferOne      = 1
+	DefaultBatchSize      = 64
+	DefaultFlushInterval  = 10
 	DefaultMonitor        = true
 	WorkerMonitorDisabled = false
 

--- a/pkgconfig/constants.go
+++ b/pkgconfig/constants.go
@@ -48,7 +48,7 @@ var (
 
 	ExpectedQname         = "dnscollector.dev"
 	ExpectedQname2        = "dns.collector"
-	ExpectedBufferMsg511  = ".*buffer is full, 511.*"
-	ExpectedBufferMsg1023 = ".*buffer is full, 1023.*"
+	ExpectedBufferMsg511  = ".*buffer is full, 511 dnsmessage\\(s\\) dropped.*"
+	ExpectedBufferMsg1023 = ".*buffer is full, 1023 dnsmessage\\(s\\) dropped.*"
 	ExpectedIdentity      = "powerdnspb"
 )

--- a/pkgconfig/global.go
+++ b/pkgconfig/global.go
@@ -23,8 +23,10 @@ type ConfigGlobal struct {
 	ServerIdentity string `yaml:"server-identity" default:""`
 	PidFile        string `yaml:"pid-file" default:""`
 	Worker         struct {
-		InternalMonitor   int `yaml:"interval-monitor" default:"10"`
-		ChannelBufferSize int `yaml:"buffer-size" default:"8192"`
+		InternalMonitor      int `yaml:"interval-monitor" default:"10"`
+		ChannelBufferSize    int `yaml:"buffer-size" default:"8192"`
+		BatchSize            int `yaml:"batch-size" default:"64"`
+		BatchFlushIntervalMs int `yaml:"flush-interval-ms" default:"10"`
 	} `yaml:"worker"`
 	Telemetry struct {
 		Enabled         bool   `yaml:"enabled" default:"false"`

--- a/pkgconfig/global.go
+++ b/pkgconfig/global.go
@@ -24,7 +24,7 @@ type ConfigGlobal struct {
 	PidFile        string `yaml:"pid-file" default:""`
 	Worker         struct {
 		InternalMonitor      int `yaml:"interval-monitor" default:"10"`
-		ChannelBufferSize    int `yaml:"buffer-size" default:"8192"`
+		ChannelBufferSize    int `yaml:"buffer-size" default:"512"`
 		BatchSize            int `yaml:"batch-size" default:"64"`
 		BatchFlushIntervalMs int `yaml:"flush-interval-ms" default:"10"`
 	} `yaml:"worker"`

--- a/pkgconfig/loggers.go
+++ b/pkgconfig/loggers.go
@@ -9,15 +9,13 @@ import (
 
 type ConfigLoggers struct {
 	DevNull struct {
-		Enable            bool `yaml:"enable" default:"false"`
-		ChannelBufferSize int  `yaml:"chan-buffer-size" default:"0"`
+		Enable bool `yaml:"enable" default:"false"`
 	} `yaml:"devnull"`
 	Stdout struct {
 		Enable               bool    `yaml:"enable" default:"false"`
 		Mode                 string  `yaml:"mode" default:"text"`
 		TextFormat           string  `yaml:"text-format" default:""`
 		JinjaFormat          string  `yaml:"jinja-format" default:""`
-		ChannelBufferSize    int     `yaml:"chan-buffer-size" default:"0"`
 		OverwriteDNSPortPcap bool    `yaml:"overwrite-dns-port-pcap" default:"false"`
 		WriterBufferSize     int     `yaml:"writer-buffer-size" default:"65536"`
 		FlushInterval        float64 `yaml:"flush-interval" default:"1.0"`
@@ -37,7 +35,6 @@ type ConfigLoggers struct {
 		BasicAuthLogin            string   `yaml:"basic-auth-login" default:"admin"`
 		BasicAuthPwd              string   `yaml:"basic-auth-pwd" default:"changeme"`
 		BasicAuthEnabled          bool     `yaml:"basic-auth-enable" default:"true"`
-		ChannelBufferSize         int      `yaml:"chan-buffer-size" default:"0"`
 		RequestersMetricsEnabled  bool     `yaml:"requesters-metrics-enabled" default:"true"`
 		DomainsMetricsEnabled     bool     `yaml:"domains-metrics-enabled" default:"true"`
 		NoErrorMetricsEnabled     bool     `yaml:"noerror-metrics-enabled" default:"true"`
@@ -61,17 +58,16 @@ type ConfigLoggers struct {
 		DefaultDomainsCacheSize   int      `yaml:"default-domains-cache-size" default:"1000"`
 	} `yaml:"prometheus"`
 	RestAPI struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		ListenIP          string `yaml:"listen-ip" default:"127.0.0.1"`
-		ListenPort        int    `yaml:"listen-port" default:"8080"`
-		BasicAuthLogin    string `yaml:"basic-auth-login" default:"admin"`
-		BasicAuthPwd      string `yaml:"basic-auth-pwd" default:"changeme"`
-		TLSSupport        bool   `yaml:"tls-support" default:"false"`
-		TLSMinVersion     string `yaml:"tls-min-version" default:"1.2"`
-		CertFile          string `yaml:"cert-file" default:""`
-		KeyFile           string `yaml:"key-file" default:""`
-		TopN              int    `yaml:"top-n" default:"100"`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
+		Enable         bool   `yaml:"enable" default:"false"`
+		ListenIP       string `yaml:"listen-ip" default:"127.0.0.1"`
+		ListenPort     int    `yaml:"listen-port" default:"8080"`
+		BasicAuthLogin string `yaml:"basic-auth-login" default:"admin"`
+		BasicAuthPwd   string `yaml:"basic-auth-pwd" default:"changeme"`
+		TLSSupport     bool   `yaml:"tls-support" default:"false"`
+		TLSMinVersion  string `yaml:"tls-min-version" default:"1.2"`
+		CertFile       string `yaml:"cert-file" default:""`
+		KeyFile        string `yaml:"key-file" default:""`
+		TopN           int    `yaml:"top-n" default:"100"`
 	} `yaml:"restapi"`
 	LogFile struct {
 		Enable               bool   `yaml:"enable" default:"false"`
@@ -87,7 +83,6 @@ type ConfigLoggers struct {
 		PostRotateDelete     bool   `yaml:"postrotate-delete-success" default:"false"`
 		TextFormat           string `yaml:"text-format" default:""`
 		JinjaFormat          string `yaml:"jinja-format" default:""`
-		ChannelBufferSize    int    `yaml:"chan-buffer-size" default:"0"`
 		ExtendedSupport      bool   `yaml:"extended-support" default:"false"`
 		OverwriteDNSPortPcap bool   `yaml:"overwrite-dns-port-pcap" default:"false"`
 	} `yaml:"logfile"`
@@ -109,133 +104,124 @@ type ConfigLoggers struct {
 		ServerID          string `yaml:"server-id" default:""`
 		OverwriteIdentity bool   `yaml:"overwrite-identity" default:"false"`
 		BufferSize        int    `yaml:"buffer-size" default:"100"`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
 		ExtendedSupport   bool   `yaml:"extended-support" default:"false"`
 		Compression       string `yaml:"compression" default:"none"`
 	} `yaml:"dnstapclient"`
 	TCPClient struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		RemoteAddress     string `yaml:"remote-address" default:"127.0.0.1"`
-		RemotePort        int    `yaml:"remote-port" default:"9999"`
-		RetryInterval     int    `yaml:"retry-interval" default:"10"`
-		Transport         string `yaml:"transport" default:"tcp"`
-		TLSInsecure       bool   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion     string `yaml:"tls-min-version" default:"1.2"`
-		CAFile            string `yaml:"ca-file" default:""`
-		CertFile          string `yaml:"cert-file" default:""`
-		KeyFile           string `yaml:"key-file" default:""`
-		Mode              string `yaml:"mode" default:"flat-json"`
-		TextFormat        string `yaml:"text-format" default:""`
-		PayloadDelimiter  string `yaml:"delimiter" default:"\n"`
-		BufferSize        int    `yaml:"buffer-size" default:"100"`
-		FlushInterval     int    `yaml:"flush-interval" default:"30"`
-		ConnectTimeout    int    `yaml:"connect-timeout" default:"5"`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
+		Enable           bool   `yaml:"enable" default:"false"`
+		RemoteAddress    string `yaml:"remote-address" default:"127.0.0.1"`
+		RemotePort       int    `yaml:"remote-port" default:"9999"`
+		RetryInterval    int    `yaml:"retry-interval" default:"10"`
+		Transport        string `yaml:"transport" default:"tcp"`
+		TLSInsecure      bool   `yaml:"tls-insecure" default:"false"`
+		TLSMinVersion    string `yaml:"tls-min-version" default:"1.2"`
+		CAFile           string `yaml:"ca-file" default:""`
+		CertFile         string `yaml:"cert-file" default:""`
+		KeyFile          string `yaml:"key-file" default:""`
+		Mode             string `yaml:"mode" default:"flat-json"`
+		TextFormat       string `yaml:"text-format" default:""`
+		PayloadDelimiter string `yaml:"delimiter" default:"\n"`
+		BufferSize       int    `yaml:"buffer-size" default:"100"`
+		FlushInterval    int    `yaml:"flush-interval" default:"30"`
+		ConnectTimeout   int    `yaml:"connect-timeout" default:"5"`
 	} `yaml:"tcpclient"`
 	Syslog struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		Severity          string `yaml:"severity" default:"INFO"`
-		Facility          string `yaml:"facility" default:"DAEMON"`
-		Transport         string `yaml:"transport" default:"local"`
-		RemoteAddress     string `yaml:"remote-address" default:"127.0.0.1:514"`
-		RetryInterval     int    `yaml:"retry-interval" default:"10"`
-		TextFormat        string `yaml:"text-format" default:""`
-		Mode              string `yaml:"mode" default:"text"`
-		TLSInsecure       bool   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion     string `yaml:"tls-min-version" default:"1.2"`
-		CAFile            string `yaml:"ca-file" default:""`
-		CertFile          string `yaml:"cert-file" default:""`
-		KeyFile           string `yaml:"key-file" default:""`
-		Formatter         string `yaml:"formatter" default:"rfc5424"`
-		Framer            string `yaml:"framer" default:""`
-		Hostname          string `yaml:"hostname" default:""`
-		AppName           string `yaml:"app-name" default:"DNScollector"`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
-		Tag               string `yaml:"tag" default:""`
-		ReplaceNullChar   string `yaml:"replace-null-char" default:"�"`
-		FlushInterval     int    `yaml:"flush-interval" default:"30"`
-		BufferSize        int    `yaml:"buffer-size" default:"100"`
+		Enable          bool   `yaml:"enable" default:"false"`
+		Severity        string `yaml:"severity" default:"INFO"`
+		Facility        string `yaml:"facility" default:"DAEMON"`
+		Transport       string `yaml:"transport" default:"local"`
+		RemoteAddress   string `yaml:"remote-address" default:"127.0.0.1:514"`
+		RetryInterval   int    `yaml:"retry-interval" default:"10"`
+		TextFormat      string `yaml:"text-format" default:""`
+		Mode            string `yaml:"mode" default:"text"`
+		TLSInsecure     bool   `yaml:"tls-insecure" default:"false"`
+		TLSMinVersion   string `yaml:"tls-min-version" default:"1.2"`
+		CAFile          string `yaml:"ca-file" default:""`
+		CertFile        string `yaml:"cert-file" default:""`
+		KeyFile         string `yaml:"key-file" default:""`
+		Formatter       string `yaml:"formatter" default:"rfc5424"`
+		Framer          string `yaml:"framer" default:""`
+		Hostname        string `yaml:"hostname" default:""`
+		AppName         string `yaml:"app-name" default:"DNScollector"`
+		Tag             string `yaml:"tag" default:""`
+		ReplaceNullChar string `yaml:"replace-null-char" default:"�"`
+		FlushInterval   int    `yaml:"flush-interval" default:"30"`
+		BufferSize      int    `yaml:"buffer-size" default:"100"`
 	} `yaml:"syslog"`
 	Fluentd struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		RemoteAddress     string `yaml:"remote-address" default:"127.0.0.1"`
-		RemotePort        int    `yaml:"remote-port" default:"24224"`
-		ConnectTimeout    int    `yaml:"connect-timeout" default:"5"`
-		RetryInterval     int    `yaml:"retry-interval" default:"10"`
-		FlushInterval     int    `yaml:"flush-interval" default:"30"`
-		Transport         string `yaml:"transport" default:"tcp"`
-		TLSInsecure       bool   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion     string `yaml:"tls-min-version" default:"1.2"`
-		CAFile            string `yaml:"ca-file" default:""`
-		CertFile          string `yaml:"cert-file" default:""`
-		KeyFile           string `yaml:"key-file" default:""`
-		Tag               string `yaml:"tag" default:"dns.collector"`
-		BufferSize        int    `yaml:"buffer-size" default:"100"`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"4096"`
+		Enable         bool   `yaml:"enable" default:"false"`
+		RemoteAddress  string `yaml:"remote-address" default:"127.0.0.1"`
+		RemotePort     int    `yaml:"remote-port" default:"24224"`
+		ConnectTimeout int    `yaml:"connect-timeout" default:"5"`
+		RetryInterval  int    `yaml:"retry-interval" default:"10"`
+		FlushInterval  int    `yaml:"flush-interval" default:"30"`
+		Transport      string `yaml:"transport" default:"tcp"`
+		TLSInsecure    bool   `yaml:"tls-insecure" default:"false"`
+		TLSMinVersion  string `yaml:"tls-min-version" default:"1.2"`
+		CAFile         string `yaml:"ca-file" default:""`
+		CertFile       string `yaml:"cert-file" default:""`
+		KeyFile        string `yaml:"key-file" default:""`
+		Tag            string `yaml:"tag" default:"dns.collector"`
+		BufferSize     int    `yaml:"buffer-size" default:"100"`
 	} `yaml:"fluentd"`
 	InfluxDB struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		ServerURL         string `yaml:"server-url" default:"http://localhost:8086"`
-		AuthToken         string `yaml:"auth-token" default:""`
-		TLSSupport        bool   `yaml:"tls-support" default:"false"`
-		TLSInsecure       bool   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion     string `yaml:"tls-min-version" default:"1.2"`
-		CAFile            string `yaml:"ca-file" default:""`
-		CertFile          string `yaml:"cert-file" default:""`
-		KeyFile           string `yaml:"key-file" default:""`
-		Bucket            string `yaml:"bucket" default:""`
-		Organization      string `yaml:"organization" default:""`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
+		Enable        bool   `yaml:"enable" default:"false"`
+		ServerURL     string `yaml:"server-url" default:"http://localhost:8086"`
+		AuthToken     string `yaml:"auth-token" default:""`
+		TLSSupport    bool   `yaml:"tls-support" default:"false"`
+		TLSInsecure   bool   `yaml:"tls-insecure" default:"false"`
+		TLSMinVersion string `yaml:"tls-min-version" default:"1.2"`
+		CAFile        string `yaml:"ca-file" default:""`
+		CertFile      string `yaml:"cert-file" default:""`
+		KeyFile       string `yaml:"key-file" default:""`
+		Bucket        string `yaml:"bucket" default:""`
+		Organization  string `yaml:"organization" default:""`
 	} `yaml:"influxdb"`
 	LokiClient struct {
-		Enable            bool              `yaml:"enable" default:"false"`
-		ServerURL         string            `yaml:"server-url" default:"http://localhost:3100/loki/api/v1/push"`
-		JobName           string            `yaml:"job-name" default:"dnscollector"`
-		Mode              string            `yaml:"mode" default:"text"`
-		FlushInterval     int               `yaml:"flush-interval" default:"5"`
-		BatchSize         int               `yaml:"batch-size" default:"1048576"`
-		RetryInterval     int               `yaml:"retry-interval" default:"10"`
-		TextFormat        string            `yaml:"text-format" default:""`
-		ProxyURL          string            `yaml:"proxy-url" default:""`
-		TLSInsecure       bool              `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion     string            `yaml:"tls-min-version" default:"1.2"`
-		CAFile            string            `yaml:"ca-file" default:""`
-		CertFile          string            `yaml:"cert-file" default:""`
-		KeyFile           string            `yaml:"key-file" default:""`
-		BasicAuthLogin    string            `yaml:"basic-auth-login" default:""`
-		BasicAuthPwd      string            `yaml:"basic-auth-pwd" default:""`
-		BasicAuthPwdFile  string            `yaml:"basic-auth-pwd-file" default:""`
-		TenantID          string            `yaml:"tenant-id" default:""`
-		RelabelConfigs    []*relabel.Config `yaml:"relabel-configs" default:"[]"`
-		ChannelBufferSize int               `yaml:"chan-buffer-size" default:"0"`
+		Enable           bool              `yaml:"enable" default:"false"`
+		ServerURL        string            `yaml:"server-url" default:"http://localhost:3100/loki/api/v1/push"`
+		JobName          string            `yaml:"job-name" default:"dnscollector"`
+		Mode             string            `yaml:"mode" default:"text"`
+		FlushInterval    int               `yaml:"flush-interval" default:"5"`
+		BatchSize        int               `yaml:"batch-size" default:"1048576"`
+		RetryInterval    int               `yaml:"retry-interval" default:"10"`
+		TextFormat       string            `yaml:"text-format" default:""`
+		ProxyURL         string            `yaml:"proxy-url" default:""`
+		TLSInsecure      bool              `yaml:"tls-insecure" default:"false"`
+		TLSMinVersion    string            `yaml:"tls-min-version" default:"1.2"`
+		CAFile           string            `yaml:"ca-file" default:""`
+		CertFile         string            `yaml:"cert-file" default:""`
+		KeyFile          string            `yaml:"key-file" default:""`
+		BasicAuthLogin   string            `yaml:"basic-auth-login" default:""`
+		BasicAuthPwd     string            `yaml:"basic-auth-pwd" default:""`
+		BasicAuthPwdFile string            `yaml:"basic-auth-pwd-file" default:""`
+		TenantID         string            `yaml:"tenant-id" default:""`
+		RelabelConfigs   []*relabel.Config `yaml:"relabel-configs" default:"[]"`
 	} `yaml:"lokiclient"`
 	Statsd struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		Prefix            string `yaml:"prefix" default:"dnscollector"`
-		RemoteAddress     string `yaml:"remote-address" default:"127.0.0.1"`
-		RemotePort        int    `yaml:"remote-port" default:"8125"`
-		ConnectTimeout    int    `yaml:"connect-timeout" default:"5"`
-		Transport         string `yaml:"transport" default:"udp"`
-		FlushInterval     int    `yaml:"flush-interval" default:"10"`
-		CertFile          string `yaml:"cert-file" default:""`
-		TLSInsecure       bool   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion     string `yaml:"tls-min-version" default:"1.2"`
-		CAFile            string `yaml:"ca-file" default:""`
-		KeyFile           string `yaml:"key-file" default:""`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
+		Enable         bool   `yaml:"enable" default:"false"`
+		Prefix         string `yaml:"prefix" default:"dnscollector"`
+		RemoteAddress  string `yaml:"remote-address" default:"127.0.0.1"`
+		RemotePort     int    `yaml:"remote-port" default:"8125"`
+		ConnectTimeout int    `yaml:"connect-timeout" default:"5"`
+		Transport      string `yaml:"transport" default:"udp"`
+		FlushInterval  int    `yaml:"flush-interval" default:"10"`
+		CertFile       string `yaml:"cert-file" default:""`
+		TLSInsecure    bool   `yaml:"tls-insecure" default:"false"`
+		TLSMinVersion  string `yaml:"tls-min-version" default:"1.2"`
+		CAFile         string `yaml:"ca-file" default:""`
+		KeyFile        string `yaml:"key-file" default:""`
 	} `yaml:"statsd"`
 	Nsq struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		Host              string `yaml:"host" default:"127.0.0.1"`
-		Port              int    `yaml:"port" default:"4150"`
-		Topic             string `yaml:"topic" default:"dnscollector"`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
+		Enable bool   `yaml:"enable" default:"false"`
+		Host   string `yaml:"host" default:"127.0.0.1"`
+		Port   int    `yaml:"port" default:"4150"`
+		Topic  string `yaml:"topic" default:"dnscollector"`
 	} `yaml:"nsq"`
 	ElasticSearchClient struct {
 		Enable            bool   `yaml:"enable" default:"false"`
 		Index             string `yaml:"index" default:"dnscollector"`
 		Server            string `yaml:"server" default:"http://127.0.0.1:9200/"`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
 		BulkSize          int    `yaml:"bulk-size" default:"5242880"`
 		BulkChannelSize   int    `yaml:"bulk-channel-size" default:"10"`
 		FlushInterval     int    `yaml:"flush-interval" default:"10"`
@@ -255,110 +241,103 @@ type ConfigLoggers struct {
 	} `yaml:"elasticsearch"`
 	OpenTelemetryClient struct {
 		Enable               bool   `yaml:"enable" default:"false"`
-		ChannelBufferSize    int    `yaml:"chan-buffer-size" default:"0"`
 		CleanupSpansInterval int    `yaml:"cleanup-spans-interval" default:"30"`
 		MaxSpanTime          int    `yaml:"max-span-time" default:"120"`
 		OtelEndpoint         string `yaml:"otel-endpoint" default:""`
 	} `yaml:"opentelemetry"`
 	ScalyrClient struct {
-		Enable            bool                   `yaml:"enable" default:"false"`
-		Mode              string                 `yaml:"mode" default:"text"`
-		TextFormat        string                 `yaml:"text-format" default:""`
-		SessionInfo       map[string]string      `yaml:"sessioninfo" default:"{}"`
-		Attrs             map[string]interface{} `yaml:"attrs" default:"{}"`
-		ServerURL         string                 `yaml:"server-url" default:"app.scalyr.com"`
-		APIKey            string                 `yaml:"apikey" default:""`
-		Parser            string                 `yaml:"parser" default:""`
-		FlushInterval     int                    `yaml:"flush-interval" default:"10"`
-		ProxyURL          string                 `yaml:"proxy-url" default:""`
-		TLSInsecure       bool                   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion     string                 `yaml:"tls-min-version" default:"1.2"`
-		CAFile            string                 `yaml:"ca-file" default:""`
-		CertFile          string                 `yaml:"cert-file" default:""`
-		KeyFile           string                 `yaml:"key-file" default:""`
-		ChannelBufferSize int                    `yaml:"chan-buffer-size" default:"0"`
+		Enable        bool                   `yaml:"enable" default:"false"`
+		Mode          string                 `yaml:"mode" default:"text"`
+		TextFormat    string                 `yaml:"text-format" default:""`
+		SessionInfo   map[string]string      `yaml:"sessioninfo" default:"{}"`
+		Attrs         map[string]interface{} `yaml:"attrs" default:"{}"`
+		ServerURL     string                 `yaml:"server-url" default:"app.scalyr.com"`
+		APIKey        string                 `yaml:"apikey" default:""`
+		Parser        string                 `yaml:"parser" default:""`
+		FlushInterval int                    `yaml:"flush-interval" default:"10"`
+		ProxyURL      string                 `yaml:"proxy-url" default:""`
+		TLSInsecure   bool                   `yaml:"tls-insecure" default:"false"`
+		TLSMinVersion string                 `yaml:"tls-min-version" default:"1.2"`
+		CAFile        string                 `yaml:"ca-file" default:""`
+		CertFile      string                 `yaml:"cert-file" default:""`
+		KeyFile       string                 `yaml:"key-file" default:""`
 	} `yaml:"scalyrclient"`
 	RedisPub struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		RemoteAddress     string `yaml:"remote-address" default:"127.0.0.1"`
-		RemotePort        int    `yaml:"remote-port" default:"6379"`
-		RetryInterval     int    `yaml:"retry-interval" default:"10"`
-		Transport         string `yaml:"transport" default:"tcp"`
-		TLSInsecure       bool   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion     string `yaml:"tls-min-version" default:"1.2"`
-		CAFile            string `yaml:"ca-file" default:""`
-		CertFile          string `yaml:"cert-file" default:""`
-		KeyFile           string `yaml:"key-file" default:""`
-		Mode              string `yaml:"mode" default:"flat-json"`
-		TextFormat        string `yaml:"text-format" default:""`
-		PayloadDelimiter  string `yaml:"delimiter" default:"\n"`
-		BufferSize        int    `yaml:"buffer-size" default:"100"`
-		FlushInterval     int    `yaml:"flush-interval" default:"30"`
-		ConnectTimeout    int    `yaml:"connect-timeout" default:"5"`
-		RedisChannel      string `yaml:"redis-channel" default:"dns_collector"`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
+		Enable           bool   `yaml:"enable" default:"false"`
+		RemoteAddress    string `yaml:"remote-address" default:"127.0.0.1"`
+		RemotePort       int    `yaml:"remote-port" default:"6379"`
+		RetryInterval    int    `yaml:"retry-interval" default:"10"`
+		Transport        string `yaml:"transport" default:"tcp"`
+		TLSInsecure      bool   `yaml:"tls-insecure" default:"false"`
+		TLSMinVersion    string `yaml:"tls-min-version" default:"1.2"`
+		CAFile           string `yaml:"ca-file" default:""`
+		CertFile         string `yaml:"cert-file" default:""`
+		KeyFile          string `yaml:"key-file" default:""`
+		Mode             string `yaml:"mode" default:"flat-json"`
+		TextFormat       string `yaml:"text-format" default:""`
+		PayloadDelimiter string `yaml:"delimiter" default:"\n"`
+		BufferSize       int    `yaml:"buffer-size" default:"100"`
+		FlushInterval    int    `yaml:"flush-interval" default:"30"`
+		ConnectTimeout   int    `yaml:"connect-timeout" default:"5"`
+		RedisChannel     string `yaml:"redis-channel" default:"dns_collector"`
 	} `yaml:"redispub"`
 	KafkaProducer struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		ClientID          string `yaml:"client-id" default:""`
-		RemoteAddress     string `yaml:"remote-address" default:"127.0.0.1"`
-		RemotePort        int    `yaml:"remote-port" default:"9092"`
-		TLSSupport        bool   `yaml:"tls-support" default:"false"`
-		TLSInsecure       bool   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion     string `yaml:"tls-min-version" default:"1.2"`
-		CAFile            string `yaml:"ca-file" default:""`
-		CertFile          string `yaml:"cert-file" default:""`
-		KeyFile           string `yaml:"key-file" default:""`
-		SaslSupport       bool   `yaml:"sasl-support" default:"false"`
-		SaslUsername      string `yaml:"sasl-username" default:""`
-		SaslPassword      string `yaml:"sasl-password" default:""`
-		SaslMechanism     string `yaml:"sasl-mechanism" default:"PLAIN"`
-		Mode              string `yaml:"mode" default:"flat-json"`
-		TextFormat        string `yaml:"text-format" default:""`
-		BatchSize         int    `yaml:"batch-size" default:"100"`
-		FlushInterval     int    `yaml:"flush-interval" default:"10"`
-		ConnectTimeout    int    `yaml:"connect-timeout" default:"5"`
-		Topic             string `yaml:"topic" default:"dnscollector"`
-		Partition         *int   `yaml:"partition" default:"nil"`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
-		Compression       string `yaml:"compression" default:"none"`
+		Enable         bool   `yaml:"enable" default:"false"`
+		ClientID       string `yaml:"client-id" default:""`
+		RemoteAddress  string `yaml:"remote-address" default:"127.0.0.1"`
+		RemotePort     int    `yaml:"remote-port" default:"9092"`
+		TLSSupport     bool   `yaml:"tls-support" default:"false"`
+		TLSInsecure    bool   `yaml:"tls-insecure" default:"false"`
+		TLSMinVersion  string `yaml:"tls-min-version" default:"1.2"`
+		CAFile         string `yaml:"ca-file" default:""`
+		CertFile       string `yaml:"cert-file" default:""`
+		KeyFile        string `yaml:"key-file" default:""`
+		SaslSupport    bool   `yaml:"sasl-support" default:"false"`
+		SaslUsername   string `yaml:"sasl-username" default:""`
+		SaslPassword   string `yaml:"sasl-password" default:""`
+		SaslMechanism  string `yaml:"sasl-mechanism" default:"PLAIN"`
+		Mode           string `yaml:"mode" default:"flat-json"`
+		TextFormat     string `yaml:"text-format" default:""`
+		BatchSize      int    `yaml:"batch-size" default:"100"`
+		FlushInterval  int    `yaml:"flush-interval" default:"10"`
+		ConnectTimeout int    `yaml:"connect-timeout" default:"5"`
+		Topic          string `yaml:"topic" default:"dnscollector"`
+		Partition      *int   `yaml:"partition" default:"nil"`
+		Compression    string `yaml:"compression" default:"none"`
 	} `yaml:"kafkaproducer"`
 	FalcoClient struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		URL               string `yaml:"url" default:"http://127.0.0.1:9200"`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
+		Enable bool   `yaml:"enable" default:"false"`
+		URL    string `yaml:"url" default:"http://127.0.0.1:9200"`
 	} `yaml:"falco"`
 	ClickhouseClient struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		URL               string `yaml:"url" default:"http://localhost:8123"`
-		User              string `yaml:"user" default:"default"`
-		Password          string `yaml:"password" default:"password"`
-		Database          string `yaml:"database" default:"dnscollector"`
-		Table             string `yaml:"table" default:"records"`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
+		Enable   bool   `yaml:"enable" default:"false"`
+		URL      string `yaml:"url" default:"http://localhost:8123"`
+		User     string `yaml:"user" default:"default"`
+		Password string `yaml:"password" default:"password"`
+		Database string `yaml:"database" default:"dnscollector"`
+		Table    string `yaml:"table" default:"records"`
 	} `yaml:"clickhouse"`
 	MQTT struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		RemoteAddress     string `yaml:"remote-address" default:"127.0.0.1"`
-		RemotePort        int    `yaml:"remote-port" default:"1883"`
-		ConnectTimeout    int    `yaml:"connect-timeout" default:"5"`
-		RetryInterval     int    `yaml:"retry-interval" default:"10"`
-		Topic             string `yaml:"topic" default:"dnscollector/dns"`
-		QOS               byte   `yaml:"qos" default:"0"`
-		Mode              string `yaml:"mode" default:"flat-json"`
-		TextFormat        string `yaml:"text-format" default:""`
-		BufferSize        int    `yaml:"buffer-size" default:"100"`
-		FlushInterval     int    `yaml:"flush-interval" default:"30"`
-		ProtocolVersion   string `yaml:"protocol-version" default:"auto"`
-		Username          string `yaml:"username" default:""`
-		Password          string `yaml:"password" default:""`
-		TLSSupport        bool   `yaml:"tls-support" default:"false"`
-		TLSInsecure       bool   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion     string `yaml:"tls-min-version" default:"1.2"`
-		CAFile            string `yaml:"ca-file" default:""`
-		CertFile          string `yaml:"cert-file" default:""`
-		KeyFile           string `yaml:"key-file" default:""`
-		ChannelBufferSize int    `yaml:"chan-buffer-size" default:"0"`
+		Enable          bool   `yaml:"enable" default:"false"`
+		RemoteAddress   string `yaml:"remote-address" default:"127.0.0.1"`
+		RemotePort      int    `yaml:"remote-port" default:"1883"`
+		ConnectTimeout  int    `yaml:"connect-timeout" default:"5"`
+		RetryInterval   int    `yaml:"retry-interval" default:"10"`
+		Topic           string `yaml:"topic" default:"dnscollector/dns"`
+		QOS             byte   `yaml:"qos" default:"0"`
+		Mode            string `yaml:"mode" default:"flat-json"`
+		TextFormat      string `yaml:"text-format" default:""`
+		BufferSize      int    `yaml:"buffer-size" default:"100"`
+		FlushInterval   int    `yaml:"flush-interval" default:"30"`
+		ProtocolVersion string `yaml:"protocol-version" default:"auto"`
+		Username        string `yaml:"username" default:""`
+		Password        string `yaml:"password" default:""`
+		TLSSupport      bool   `yaml:"tls-support" default:"false"`
+		TLSInsecure     bool   `yaml:"tls-insecure" default:"false"`
+		TLSMinVersion   string `yaml:"tls-min-version" default:"1.2"`
+		CAFile          string `yaml:"ca-file" default:""`
+		CertFile        string `yaml:"cert-file" default:""`
+		KeyFile         string `yaml:"key-file" default:""`
 	} `yaml:"mqtt"`
 }
 

--- a/pkginit/pipelines_test.go
+++ b/pkginit/pipelines_test.go
@@ -88,7 +88,7 @@ func TestPipelines_NoRoutesDefined(t *testing.T) {
 
 func TestPipelines_RoutingLoop(t *testing.T) {
 	// Create a mock configuration for testing
-	config := &pkgconfig.Config{}
+	config := pkgconfig.GetDefaultConfig()
 	config.Pipelines = []pkgconfig.ConfigPipelines{
 		{
 			Name: "stanzaA",

--- a/transformers/atags.go
+++ b/transformers/atags.go
@@ -10,7 +10,7 @@ type ATagsTransform struct {
 	GenericTransformer
 }
 
-func NewATagsTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessage) *ATagsTransform {
+func NewATagsTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *ATagsTransform {
 	t := &ATagsTransform{GenericTransformer: NewTransformer(config, logger, "atags", name, instance, nextWorkers)}
 	return t
 }

--- a/transformers/atags_test.go
+++ b/transformers/atags_test.go
@@ -16,7 +16,7 @@ func TestATags_AddTag(t *testing.T) {
 	config.ATags.AddTags = append(config.ATags.AddTags, "tag2")
 
 	// init the processor
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 	atags := NewATagsTransform(config, logger.New(false), "test", 0, outChans)
 
 	// add tags

--- a/transformers/extract.go
+++ b/transformers/extract.go
@@ -18,7 +18,7 @@ type ExtractTransform struct {
 	hexExtractors    []ExtractorFunc
 }
 
-func NewExtractTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessage) *ExtractTransform {
+func NewExtractTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *ExtractTransform {
 	t := &ExtractTransform{GenericTransformer: NewTransformer(config, logger, "extract", name, instance, nextWorkers)}
 	t.initExtractors()
 	return t

--- a/transformers/extract_bench_test.go
+++ b/transformers/extract_bench_test.go
@@ -14,7 +14,7 @@ func BenchmarkExtract_AddBase64AndHexFields(b *testing.B) {
 	config.Extract.Base64Fields = []string{"dns.qname", "network.query-ip"}
 	config.Extract.HexFields = []string{"dns.qname", "network.query-ip"}
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 	extract := NewExtractTransform(config, logger.New(false), "test", 0, outChans)
 	extract.GetTransforms()
 

--- a/transformers/extract_test.go
+++ b/transformers/extract_test.go
@@ -16,8 +16,8 @@ import (
 func TestExtract_Json(t *testing.T) {
 	// enable feature
 	config := pkgconfig.GetFakeConfigTransformers()
-	outChans := []chan *dnsutils.DNSMessage{}
-	outChans = append(outChans, make(chan *dnsutils.DNSMessage, 1))
+	outChans := []chan *dnsutils.DNSMessageBatch{}
+	outChans = append(outChans, make(chan *dnsutils.DNSMessageBatch, 1))
 
 	// get dns message
 	dm := dnsutils.GetFakeDNSMessageWithPayload()
@@ -71,8 +71,8 @@ func TestExtract_Base64AndHexFields(t *testing.T) {
 	config.Extract.Base64Fields = []string{"dns.qname"}
 	config.Extract.HexFields = []string{"dns.qname"}
 
-	outChans := []chan *dnsutils.DNSMessage{}
-	outChans = append(outChans, make(chan *dnsutils.DNSMessage, 1))
+	outChans := []chan *dnsutils.DNSMessageBatch{}
+	outChans = append(outChans, make(chan *dnsutils.DNSMessageBatch, 1))
 
 	// get dns message with non-UTF8 qname (Latin-1 \344)
 	dm := dnsutils.GetFakeDNSMessage()
@@ -127,8 +127,8 @@ func TestExtract_WildcardSliceFields(t *testing.T) {
 	config.Extract.Base64Fields = []string{"dns.resource-records.an.*.rdata"}
 	config.Extract.HexFields = []string{"dns.resource-records.an.*.rdata"}
 
-	outChans := []chan *dnsutils.DNSMessage{}
-	outChans = append(outChans, make(chan *dnsutils.DNSMessage, 1))
+	outChans := []chan *dnsutils.DNSMessageBatch{}
+	outChans = append(outChans, make(chan *dnsutils.DNSMessageBatch, 1))
 
 	// get dns message
 	dm := dnsutils.GetFakeDNSMessage()

--- a/transformers/filtering.go
+++ b/transformers/filtering.go
@@ -23,7 +23,7 @@ type FilteringTransform struct {
 	downsample, downsampleCount            int
 }
 
-func NewFilteringTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessage) *FilteringTransform {
+func NewFilteringTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *FilteringTransform {
 	t := &FilteringTransform{GenericTransformer: NewTransformer(config, logger, "filtering", name, instance, nextWorkers)}
 	t.mapRcodes = make(map[string]bool)
 	t.ipsetDrop = &netaddr.IPSet{}

--- a/transformers/filtering_bench_test.go
+++ b/transformers/filtering_bench_test.go
@@ -27,7 +27,7 @@ func BenchmarkFiltering_DropDomainRegex(b *testing.B) {
 	config.Filtering.Enable = true
 	config.Filtering.DropDomainFile = tmpFile.Name()
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 	filtering := NewFilteringTransform(config, logger.New(false), "test", 0, outChans)
 	_, _ = filtering.GetTransforms()
 

--- a/transformers/filtering_test.go
+++ b/transformers/filtering_test.go
@@ -20,7 +20,7 @@ func TestFilteringQR(t *testing.T) {
 	config.Filtering.LogQueries = false
 	config.Filtering.LogReplies = false
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
 	filtering := NewFilteringTransform(config, logger.New(false), "test", 0, outChans)
@@ -48,7 +48,7 @@ func TestFilteringByRcodeNOERROR(t *testing.T) {
 	config.Filtering.Enable = true
 	config.Filtering.DropRcodes = []string{"NOERROR"}
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
 	filtering := NewFilteringTransform(config, logger.New(false), "test", 0, outChans)
@@ -71,7 +71,7 @@ func TestFilteringByRcodeEmpty(t *testing.T) {
 	config.Filtering.Enable = true
 	config.Filtering.DropRcodes = []string{}
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
 	filtering := NewFilteringTransform(config, logger.New(false), "test", 0, outChans)
@@ -89,7 +89,7 @@ func TestFilteringByKeepQueryIp(t *testing.T) {
 	config.Filtering.Enable = true
 	config.Filtering.KeepQueryIPFile = "../tests/testsdata/filtering_queryip_keep.txt"
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
 	filtering := NewFilteringTransform(config, logger.New(false), "test", 0, outChans)
@@ -135,7 +135,7 @@ func TestFilteringByDropQueryIp(t *testing.T) {
 	config.Filtering.Enable = true
 	config.Filtering.DropQueryIPFile = "../tests/testsdata/filtering_queryip.txt"
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
 	filtering := NewFilteringTransform(config, logger.New(false), "test", 0, outChans)
@@ -181,7 +181,7 @@ func TestFilteringByKeepRdataIp(t *testing.T) {
 	config.Filtering.Enable = true
 	config.Filtering.KeepRdataFile = "../tests/testsdata/filtering_rdataip_keep.txt"
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
 	filtering := NewFilteringTransform(config, logger.New(false), "test", 0, outChans)
@@ -280,7 +280,7 @@ func TestFilteringByFqdn(t *testing.T) {
 	config.Filtering.Enable = true
 	config.Filtering.DropFqdnFile = "../tests/testsdata/filtering_fqdn.txt"
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
 	filtering := NewFilteringTransform(config, logger.New(false), "test", 0, outChans)
@@ -309,7 +309,7 @@ func TestFilteringByDomainRegex(t *testing.T) {
 	config.Filtering.Enable = true
 	config.Filtering.DropDomainFile = "../tests/testsdata/filtering_fqdn_regex.txt"
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
 	filtering := NewFilteringTransform(config, logger.New(false), "test", 0, outChans)
@@ -341,7 +341,7 @@ func TestFilteringByKeepDomain(t *testing.T) {
 	// config
 	config := pkgconfig.GetFakeConfigTransformers()
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// file contains google.fr, test.github.com
 	config.Filtering.Enable = true
@@ -382,7 +382,7 @@ func TestFilteringByKeepDomainRegex(t *testing.T) {
 	// config
 	config := pkgconfig.GetFakeConfigTransformers()
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	/* file contains:
 	(mail|sheets).google.com$
@@ -432,7 +432,7 @@ func TestFilteringMultipleFilters(t *testing.T) {
 	config.Filtering.DropDomainFile = "../tests/testsdata/filtering_fqdn_regex.txt"
 	config.Filtering.DropQueryIPFile = "../tests/testsdata/filtering_queryip.txt"
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
 	filtering := NewFilteringTransform(config, logger.New(false), "test", 0, outChans)
@@ -449,7 +449,7 @@ func TestFilteringDownsampleFilter(t *testing.T) {
 	config.Filtering.Enable = true
 	config.Filtering.Downsample = 3
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init processor
 	filtering := NewFilteringTransform(config, logger.New(false), "test", 0, outChans)

--- a/transformers/geoip.go
+++ b/transformers/geoip.go
@@ -57,7 +57,7 @@ type GeoIPTransform struct {
 	dbCountry, dbCity, dbAsn, dbCoordinate *maxminddb.Reader
 }
 
-func NewDNSGeoIPTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessage) *GeoIPTransform {
+func NewDNSGeoIPTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *GeoIPTransform {
 	t := &GeoIPTransform{GenericTransformer: NewTransformer(config, logger, "geoip", name, instance, nextWorkers)}
 	return t
 }

--- a/transformers/geoip_bench_test.go
+++ b/transformers/geoip_bench_test.go
@@ -14,7 +14,7 @@ func BenchmarkGeoIP_Lookup(b *testing.B) {
 	config.GeoIP.DBCountryFile = "../tests/testsdata/GeoLite2-Country.mmdb"
 	config.GeoIP.DBASNFile = "../tests/testsdata/GeoLite2-ASN.mmdb"
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 	geoip := NewDNSGeoIPTransform(config, logger.New(false), "test", 0, outChans)
 	if err := geoip.Open(); err != nil {
 		b.Fatalf("geoip init failed: %v", err)
@@ -36,7 +36,7 @@ func BenchmarkGeoIP_Lookup_ECS(b *testing.B) {
 	config.GeoIP.DBCountryFile = "../tests/testsdata/GeoLite2-Country.mmdb"
 	config.GeoIP.LookupECS = true
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 	geoip := NewDNSGeoIPTransform(config, logger.New(false), "test", 0, outChans)
 	if err := geoip.Open(); err != nil {
 		b.Fatalf("geoip init failed: %v", err)

--- a/transformers/geoip_test.go
+++ b/transformers/geoip_test.go
@@ -14,7 +14,7 @@ import (
 func TestGeoIP_Json(t *testing.T) {
 	// enable feature
 	config := pkgconfig.GetFakeConfigTransformers()
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// get fake
 	dm := dnsutils.GetFakeDNSMessage()
@@ -72,7 +72,7 @@ func TestGeoIP_LookupCountry(t *testing.T) {
 	config.GeoIP.Enable = true
 	config.GeoIP.DBCountryFile = "../tests/testsdata/GeoLite2-Country.mmdb"
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
 	geoip := NewDNSGeoIPTransform(config, logger.New(false), "test", 0, outChans)
@@ -107,7 +107,7 @@ func TestGeoIP_LookupAsn(t *testing.T) {
 	config.GeoIP.Enable = true
 	config.GeoIP.DBASNFile = "../tests/testsdata/GeoLite2-ASN.mmdb"
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
 	geoip := NewDNSGeoIPTransform(config, logger.New(false), "test", 0, outChans)
@@ -134,7 +134,7 @@ func TestGeoIP_Lookup_ECS(t *testing.T) {
 	config.GeoIP.DBCountryFile = "../tests/testsdata/GeoLite2-Country.mmdb"
 	config.GeoIP.LookupECS = true
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
 	geoip := NewDNSGeoIPTransform(config, logger.New(false), "test", 0, outChans)
@@ -166,7 +166,7 @@ func TestGeoIP_LookupCoordinate(t *testing.T) {
 	config.GeoIP.Enable = true
 	config.GeoIP.DBASNFile = "../tests/testsdata/GeoLite2-ASN.mmdb"
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
 	geoip := NewDNSGeoIPTransform(config, logger.New(false), "test", 0, outChans)

--- a/transformers/latency.go
+++ b/transformers/latency.go
@@ -17,10 +17,10 @@ type MapQueries struct {
 	sync.RWMutex
 	ttl      time.Duration
 	kv       map[uint64]*dnsutils.DNSMessage
-	channels []chan *dnsutils.DNSMessage
+	channels []chan *dnsutils.DNSMessageBatch
 }
 
-func NewMapQueries(ttl time.Duration, channels []chan *dnsutils.DNSMessage) MapQueries {
+func NewMapQueries(ttl time.Duration, channels []chan *dnsutils.DNSMessageBatch) MapQueries {
 	return MapQueries{
 		ttl:      ttl,
 		kv:       make(map[uint64]*dnsutils.DNSMessage),
@@ -47,11 +47,13 @@ func (mp *MapQueries) Set(key uint64, dm *dnsutils.DNSMessage) {
 	time.AfterFunc(mp.ttl, func() {
 		if mp.Exists(key) {
 			dm.DNS.Rcode = "TIMEOUT"
+			b := dnsutils.AcquireDNSMessageBatch(1)
+			b.Messages = append(b.Messages, dm)
 			if len(mp.channels) > 1 {
-				dm.Retain(int32(len(mp.channels) - 1))
+				b.Retain(int32(len(mp.channels) - 1))
 			}
 			for i := range mp.channels {
-				mp.channels[i] <- dm
+				mp.channels[i] <- b
 			}
 		}
 		mp.Delete(key)
@@ -114,7 +116,7 @@ type LatencyTransform struct {
 	mapQueries  MapQueries
 }
 
-func NewLatencyTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessage) *LatencyTransform {
+func NewLatencyTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *LatencyTransform {
 	t := &LatencyTransform{GenericTransformer: NewTransformer(config, logger, "latency", name, instance, nextWorkers)}
 	t.hashQueries = NewHashQueries(time.Duration(config.Latency.QueriesTimeout) * time.Second)
 	t.mapQueries = NewMapQueries(time.Duration(config.Latency.QueriesTimeout)*time.Second, nextWorkers)

--- a/transformers/latency_test.go
+++ b/transformers/latency_test.go
@@ -12,7 +12,7 @@ import (
 func TestLatency_MeasureLatencyAndMs(t *testing.T) {
 	// enable feature
 	config := pkgconfig.GetFakeConfigTransformers()
-	outChannels := []chan *dnsutils.DNSMessage{}
+	outChannels := []chan *dnsutils.DNSMessageBatch{}
 
 	// init transformer
 	latency := NewLatencyTransform(config, logger.New(true), "test", 0, outChannels)
@@ -71,8 +71,8 @@ func TestLatency_DetectEvictedTimeout(t *testing.T) {
 	config.Latency.Enable = true
 	config.Latency.QueriesTimeout = 1
 
-	outChannels := []chan *dnsutils.DNSMessage{}
-	outChannels = append(outChannels, make(chan *dnsutils.DNSMessage, 1))
+	outChannels := []chan *dnsutils.DNSMessageBatch{}
+	outChannels = append(outChannels, make(chan *dnsutils.DNSMessageBatch, 1))
 
 	// init transformer
 	latency := NewLatencyTransform(config, logger.New(true), "test", 0, outChannels)
@@ -107,9 +107,9 @@ func TestLatency_DetectEvictedTimeout(t *testing.T) {
 
 			time.Sleep(2 * time.Second)
 
-			dmTimeout := <-outChannels[0]
-			if dmTimeout.DNS.Rcode != "TIMEOUT" {
-				t.Errorf("incorrect rcode, expected=TIMEOUT, got=%s", dmTimeout.DNS.Rcode)
+			batchTimeout := <-outChannels[0]
+			if len(batchTimeout.Messages) == 0 || batchTimeout.Messages[0].DNS.Rcode != "TIMEOUT" {
+				t.Errorf("incorrect rcode, expected=TIMEOUT, got=%s", batchTimeout.Messages[0].DNS.Rcode)
 			}
 		})
 	}

--- a/transformers/machinelearning.go
+++ b/transformers/machinelearning.go
@@ -25,7 +25,7 @@ type MlTransform struct {
 	GenericTransformer
 }
 
-func NewMachineLearningTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessage) *MlTransform {
+func NewMachineLearningTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *MlTransform {
 	t := &MlTransform{GenericTransformer: NewTransformer(config, logger, "machinelearning", name, instance, nextWorkers)}
 	return t
 }

--- a/transformers/machinelearning_test.go
+++ b/transformers/machinelearning_test.go
@@ -14,7 +14,7 @@ func TestML_AddFeatures(t *testing.T) {
 	config.MachineLearning.Enable = true
 
 	// init the processor
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 	ml := NewMachineLearningTransform(config, logger.New(false), "test", 0, outChans)
 
 	dm := dnsutils.GetFakeDNSMessage()

--- a/transformers/newdomaintracker.go
+++ b/transformers/newdomaintracker.go
@@ -121,7 +121,7 @@ type NewDomainTrackerTransform struct {
 }
 
 // NewNewDomainTransform creates a new instance of the transformer
-func NewNewDomainTrackerTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessage) *NewDomainTrackerTransform {
+func NewNewDomainTrackerTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *NewDomainTrackerTransform {
 	t := &NewDomainTrackerTransform{GenericTransformer: NewTransformer(config, logger, "new-domain-tracker", name, instance, nextWorkers)}
 	t.listDomainsRegex = make(map[string]*regexp.Regexp)
 	return t

--- a/transformers/newdomaintracker_test.go
+++ b/transformers/newdomaintracker_test.go
@@ -16,7 +16,7 @@ func TestNewDomainTracker_IsNew(t *testing.T) {
 	config.NewDomainTracker.TTL = 2
 	config.NewDomainTracker.CacheSize = 10
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
 	tracker := NewNewDomainTrackerTransform(config, logger.New(false), "test", 0, outChans)
@@ -54,7 +54,7 @@ func TestNewDomainTracker_Whitelist(t *testing.T) {
 	config.NewDomainTracker.WhiteDomainsFile = "../tests/testsdata/newdomain_whitelist_regex.txt"
 
 	// init subprocessor
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 	tracker := NewNewDomainTrackerTransform(config, logger.New(false), "test", 0, outChans)
 	_, err := tracker.GetTransforms()
 	if err != nil {
@@ -82,7 +82,7 @@ func TestNewDomainTracker_LRUCacheFull(t *testing.T) {
 	config.NewDomainTracker.TTL = 2
 	config.NewDomainTracker.CacheSize = 1
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
 	tracker := NewNewDomainTrackerTransform(config, logger.New(false), "test", 0, outChans)

--- a/transformers/normalize.go
+++ b/transformers/normalize.go
@@ -72,7 +72,7 @@ type NormalizeTransform struct {
 	GenericTransformer
 }
 
-func NewNormalizeTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessage) *NormalizeTransform {
+func NewNormalizeTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *NormalizeTransform {
 	t := &NormalizeTransform{GenericTransformer: NewTransformer(config, logger, "normalize", name, instance, nextWorkers)}
 	return t
 }

--- a/transformers/normalize_bench_test.go
+++ b/transformers/normalize_bench_test.go
@@ -10,7 +10,7 @@ import (
 
 func BenchmarkNormalize_GetEffectiveTld(b *testing.B) {
 	config := pkgconfig.GetFakeConfigTransformers()
-	channels := []chan *dnsutils.DNSMessage{}
+	channels := []chan *dnsutils.DNSMessageBatch{}
 
 	subprocessor := NewNormalizeTransform(config, logger.New(false), "test", 0, channels)
 	dm := dnsutils.GetFakeDNSMessage()
@@ -25,7 +25,7 @@ func BenchmarkNormalize_GetEffectiveTld(b *testing.B) {
 
 func BenchmarkNormalize_GetEffectiveTldPlusOne(b *testing.B) {
 	config := pkgconfig.GetFakeConfigTransformers()
-	channels := []chan *dnsutils.DNSMessage{}
+	channels := []chan *dnsutils.DNSMessageBatch{}
 
 	subprocessor := NewNormalizeTransform(config, logger.New(false), "test", 0, channels)
 	dm := dnsutils.GetFakeDNSMessage()
@@ -40,7 +40,7 @@ func BenchmarkNormalize_GetEffectiveTldPlusOne(b *testing.B) {
 
 func BenchmarkNormalize_QnameLowercase_MixedCase(b *testing.B) {
 	config := pkgconfig.GetFakeConfigTransformers()
-	channels := []chan *dnsutils.DNSMessage{}
+	channels := []chan *dnsutils.DNSMessageBatch{}
 
 	subprocessor := NewNormalizeTransform(config, logger.New(false), "test", 0, channels)
 	dm := dnsutils.GetFakeDNSMessage()
@@ -55,7 +55,7 @@ func BenchmarkNormalize_QnameLowercase_MixedCase(b *testing.B) {
 
 func BenchmarkNormalize_QnameLowercase_AlreadyLower(b *testing.B) {
 	config := pkgconfig.GetFakeConfigTransformers()
-	channels := []chan *dnsutils.DNSMessage{}
+	channels := []chan *dnsutils.DNSMessageBatch{}
 
 	subprocessor := NewNormalizeTransform(config, logger.New(false), "test", 0, channels)
 	dm := dnsutils.GetFakeDNSMessage()
@@ -70,7 +70,7 @@ func BenchmarkNormalize_QnameLowercase_AlreadyLower(b *testing.B) {
 
 func BenchmarkNormalize_RRLowercase_MixedCase(b *testing.B) {
 	config := pkgconfig.GetFakeConfigTransformers()
-	channels := []chan *dnsutils.DNSMessage{}
+	channels := []chan *dnsutils.DNSMessageBatch{}
 
 	transform := NewNormalizeTransform(config, logger.New(false), "test", 0, channels)
 	dm := dnsutils.GetFakeDNSMessage()
@@ -92,7 +92,7 @@ func BenchmarkNormalize_RRLowercase_MixedCase(b *testing.B) {
 
 func BenchmarkNormalize_RRLowercase_AlreadyLower(b *testing.B) {
 	config := pkgconfig.GetFakeConfigTransformers()
-	channels := []chan *dnsutils.DNSMessage{}
+	channels := []chan *dnsutils.DNSMessageBatch{}
 
 	transform := NewNormalizeTransform(config, logger.New(false), "test", 0, channels)
 	dm := dnsutils.GetFakeDNSMessage()
@@ -109,7 +109,7 @@ func BenchmarkNormalize_RRLowercase_AlreadyLower(b *testing.B) {
 
 func BenchmarkNormalize_QuietText(b *testing.B) {
 	config := pkgconfig.GetFakeConfigTransformers()
-	channels := []chan *dnsutils.DNSMessage{}
+	channels := []chan *dnsutils.DNSMessageBatch{}
 
 	subprocessor := NewNormalizeTransform(config, logger.New(false), "test", 0, channels)
 	dm := dnsutils.GetFakeDNSMessage()
@@ -124,7 +124,7 @@ func BenchmarkNormalize_QuietText(b *testing.B) {
 
 func BenchmarkNormalize_ReplaceNonprintable_Printable(b *testing.B) {
 	config := pkgconfig.GetFakeConfigTransformers()
-	channels := []chan *dnsutils.DNSMessage{}
+	channels := []chan *dnsutils.DNSMessageBatch{}
 
 	subprocessor := NewNormalizeTransform(config, logger.New(false), "test", 0, channels)
 	dm := dnsutils.GetFakeDNSMessage()
@@ -139,7 +139,7 @@ func BenchmarkNormalize_ReplaceNonprintable_Printable(b *testing.B) {
 
 func BenchmarkNormalize_ReplaceNonprintable_WithSpecial(b *testing.B) {
 	config := pkgconfig.GetFakeConfigTransformers()
-	channels := []chan *dnsutils.DNSMessage{}
+	channels := []chan *dnsutils.DNSMessageBatch{}
 
 	subprocessor := NewNormalizeTransform(config, logger.New(false), "test", 0, channels)
 	dm := dnsutils.GetFakeDNSMessage()

--- a/transformers/normalize_test.go
+++ b/transformers/normalize_test.go
@@ -15,7 +15,7 @@ func TestNormalize_LowercaseQname(t *testing.T) {
 	config.Normalize.Enable = true
 	config.Normalize.QnameLowerCase = true
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
 	normTransformer := NewNormalizeTransform(config, logger.New(false), "test", 0, outChans)
@@ -42,7 +42,7 @@ func TestNormalize_RRLowercaseQname(t *testing.T) {
 	config := pkgconfig.GetFakeConfigTransformers()
 	config.Normalize.Enable = true
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
 	normTransformer := NewNormalizeTransform(config, logger.New(false), "test", 0, outChans)
@@ -84,7 +84,7 @@ func TestNormalize_QuietText(t *testing.T) {
 	config.Normalize.Enable = true
 	config.Normalize.QuietText = true
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
 	norm := NewNormalizeTransform(config, logger.New(false), "test", 0, outChans)
@@ -107,7 +107,7 @@ func TestNormalize_AddTLD(t *testing.T) {
 	config.Normalize.Enable = true
 	config.Normalize.AddTld = true
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
 	psl := NewNormalizeTransform(config, logger.New(false), "test", 0, outChans)
@@ -157,7 +157,7 @@ func TestNormalize_AddTldPlusOne(t *testing.T) {
 	config.Normalize.Enable = true
 	config.Normalize.AddTld = true
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
 	psl := NewNormalizeTransform(config, logger.New(false), "test", 0, outChans)
@@ -199,7 +199,7 @@ func TestNormalize_AddTldPlusOne(t *testing.T) {
 func TestNormalize_SuffixUnmanaged(t *testing.T) {
 	// enable feature
 	config := pkgconfig.GetFakeConfigTransformers()
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
 	psl := NewNormalizeTransform(config, logger.New(true), "test", 0, outChans)
@@ -224,7 +224,7 @@ func TestNormalize_SuffixUnmanaged(t *testing.T) {
 func TestNormalize_SuffixICANNManaged(t *testing.T) {
 	// enable feature
 	config := pkgconfig.GetFakeConfigTransformers()
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
 	psl := NewNormalizeTransform(config, logger.New(true), "test", 0, outChans)
@@ -250,7 +250,7 @@ func TestNormalize_ReplaceNonprintable(t *testing.T) {
 	config.Normalize.Enable = true
 	config.Normalize.ReplaceNonPrintable = true
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 	norm := NewNormalizeTransform(config, logger.New(false), "test", 0, outChans)
 
 	tests := []struct {

--- a/transformers/reducer.go
+++ b/transformers/reducer.go
@@ -24,14 +24,14 @@ type MapTraffic struct {
 	sync.RWMutex
 	ttl          time.Duration
 	kv           map[string]*dnsutils.DNSMessage
-	channels     []chan *dnsutils.DNSMessage
+	channels     []chan *dnsutils.DNSMessageBatch
 	expiredKeys  *list.List
 	droppedCount int
 	logInfo      func(msg string, v ...interface{})
 	logError     func(msg string, v ...interface{})
 }
 
-func NewMapTraffic(ttl time.Duration, channels []chan *dnsutils.DNSMessage,
+func NewMapTraffic(ttl time.Duration, channels []chan *dnsutils.DNSMessageBatch,
 	logInfo func(msg string, v ...interface{}), logError func(msg string, v ...interface{})) MapTraffic {
 	return MapTraffic{
 		ttl:         ttl,
@@ -101,11 +101,13 @@ func (mp *MapTraffic) ProcessExpiredKeys() {
 	mp.Unlock()
 
 	for _, dm := range expiredMessages {
+		b := dnsutils.AcquireDNSMessageBatch(1)
+		b.Messages = append(b.Messages, dm)
 		if len(mp.channels) > 1 {
-			dm.Retain(int32(len(mp.channels) - 1))
+			b.Retain(int32(len(mp.channels) - 1))
 		}
 		for i := range mp.channels {
-			mp.channels[i] <- dm
+			mp.channels[i] <- b
 		}
 	}
 }
@@ -165,7 +167,7 @@ type ReducerTransform struct {
 	accessors  []FieldAccessor
 }
 
-func NewReducerTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessage) *ReducerTransform {
+func NewReducerTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *ReducerTransform {
 	t := &ReducerTransform{GenericTransformer: NewTransformer(config, logger, "reducer", name, instance, nextWorkers)}
 	t.mapTraffic = NewMapTraffic(time.Duration(config.Reducer.WatchInterval)*time.Second, nextWorkers, t.LogInfo, t.LogError)
 	t.initAccessors(config.Reducer.UniqueFields)

--- a/transformers/reducer_bench_test.go
+++ b/transformers/reducer_bench_test.go
@@ -15,8 +15,8 @@ func BenchmarkReducer_RepetitiveTrafficDetector(b *testing.B) {
 	config.Reducer.WatchInterval = 10
 	config.Reducer.UniqueFields = []string{"dns.qname", "dns.qtype", "network.query-ip"}
 
-	outChan := make(chan *dnsutils.DNSMessage, 100000)
-	reducer := NewReducerTransform(config, logger.New(false), "test", 0, []chan *dnsutils.DNSMessage{outChan})
+	outChan := make(chan *dnsutils.DNSMessageBatch, 100000)
+	reducer := NewReducerTransform(config, logger.New(false), "test", 0, []chan *dnsutils.DNSMessageBatch{outChan})
 
 	dm := dnsutils.DNSMessage{
 		DNSTap:      dnsutils.DNSTap{Operation: "CLIENT_QUERY"},
@@ -38,8 +38,8 @@ func BenchmarkReducer_RepetitiveTrafficDetectorParallel(b *testing.B) {
 	config.Reducer.WatchInterval = 10
 	config.Reducer.UniqueFields = []string{"dns.qname", "dns.qtype", "network.query-ip"}
 
-	outChan := make(chan *dnsutils.DNSMessage, 1000000)
-	reducer := NewReducerTransform(config, logger.New(false), "test", 0, []chan *dnsutils.DNSMessage{outChan})
+	outChan := make(chan *dnsutils.DNSMessageBatch, 1000000)
+	reducer := NewReducerTransform(config, logger.New(false), "test", 0, []chan *dnsutils.DNSMessageBatch{outChan})
 
 	dm := dnsutils.DNSMessage{
 		DNSTap:      dnsutils.DNSTap{Operation: "CLIENT_QUERY"},

--- a/transformers/reducer_test.go
+++ b/transformers/reducer_test.go
@@ -15,7 +15,7 @@ func TestReducer_Json(t *testing.T) {
 	// enable feature
 	config := pkgconfig.GetFakeConfigTransformers()
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// get fake
 	dm := dnsutils.GetFakeDNSMessage()
@@ -63,8 +63,8 @@ func TestReducer_RepetitiveTrafficDetector(t *testing.T) {
 	config.Reducer.RepetitiveTrafficDetector = true
 	config.Reducer.WatchInterval = 1
 
-	outChan := make(chan *dnsutils.DNSMessage, 1)
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChan := make(chan *dnsutils.DNSMessageBatch, 1)
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 	outChans = append(outChans, outChan)
 
 	// init subprocessor
@@ -189,7 +189,8 @@ func TestReducer_RepetitiveTrafficDetector(t *testing.T) {
 			time.Sleep(1 * time.Second)
 
 			for _, dmRef := range tc.dnsMessagesOut {
-				newDm := <-outChan
+				newBatch := <-outChan
+				newDm := newBatch.Messages[0]
 				if newDm.Reducer.Occurrences != dmRef.Reducer.Occurrences {
 					t.Errorf("DNS message invalid repeated: Want=%d, Get=%d", dmRef.Reducer.Occurrences, newDm.Reducer.Occurrences)
 				}
@@ -206,8 +207,8 @@ func TestReducer_QnamePlusOne(t *testing.T) {
 	config.Reducer.QnamePlusOne = true
 	config.Reducer.WatchInterval = 1
 
-	outChan := make(chan *dnsutils.DNSMessage, 1)
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChan := make(chan *dnsutils.DNSMessageBatch, 1)
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 	outChans = append(outChans, outChan)
 
 	// init subprocessor
@@ -261,7 +262,8 @@ func TestReducer_QnamePlusOne(t *testing.T) {
 			time.Sleep(1 * time.Second)
 
 			for _, dmRef := range tc.dnsMessagesOut {
-				newDm := <-outChan
+				newBatch := <-outChan
+				newDm := newBatch.Messages[0]
 				if newDm.Reducer.Occurrences != dmRef.Reducer.Occurrences {
 					t.Errorf("DNS message invalid repeated: Want=%d, Get=%d", dmRef.Reducer.Occurrences, newDm.Reducer.Occurrences)
 				}

--- a/transformers/relabeling.go
+++ b/transformers/relabeling.go
@@ -13,7 +13,7 @@ type RelabelTransform struct {
 	RelabelingRules []dnsutils.RelabelingRule
 }
 
-func NewRelabelTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessage) *RelabelTransform {
+func NewRelabelTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *RelabelTransform {
 	t := &RelabelTransform{GenericTransformer: NewTransformer(config, logger, "relabeling", name, instance, nextWorkers)}
 	return t
 }

--- a/transformers/relabeling_test.go
+++ b/transformers/relabeling_test.go
@@ -21,7 +21,7 @@ func TestRelabeling_CompileRegex(t *testing.T) {
 	})
 
 	// init the processor
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 	relabeling := NewRelabelTransform(config, logger.New(false), "test", 0, outChans)
 	relabeling.GetTransforms()
 

--- a/transformers/reordering.go
+++ b/transformers/reordering.go
@@ -18,11 +18,11 @@ type ReorderingTransform struct {
 	flushTicker *time.Ticker
 	flushSignal chan struct{}
 	stopChan    chan struct{}
-	nextWorkers []chan *dnsutils.DNSMessage
+	nextWorkers []chan *dnsutils.DNSMessageBatch
 }
 
 // NewLogReorderTransform creates an instance of the transformer.
-func NewReorderingTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessage) *ReorderingTransform {
+func NewReorderingTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *ReorderingTransform {
 	t := &ReorderingTransform{
 		GenericTransformer: NewTransformer(config, logger, "reordering", name, instance, nextWorkers),
 		stopChan:           make(chan struct{}),
@@ -117,17 +117,19 @@ func (t *ReorderingTransform) flushBuffer() {
 		return t.backBuffer[i].DNSTap.Timestamp < t.backBuffer[j].DNSTap.Timestamp
 	})
 
-	// Send sorted logs to the next workers.
+	// Send sorted logs to the next workers (one batch per message).
 	for _, sortedMsg := range t.backBuffer {
+		b := dnsutils.AcquireDNSMessageBatch(1)
+		b.Messages = append(b.Messages, sortedMsg)
 		if len(t.nextWorkers) > 1 {
-			sortedMsg.Retain(int32(len(t.nextWorkers) - 1))
+			b.Retain(int32(len(t.nextWorkers) - 1))
 		}
 		for _, worker := range t.nextWorkers {
 			// Non-blocking send to avoid worker congestion.
 			select {
-			case worker <- sortedMsg:
+			case worker <- b:
 			default:
-				sortedMsg.Release()
+				b.Release()
 				// Log or handle if the worker channel is full.
 				t.logger.Info("Worker channel is full, dropping message")
 			}

--- a/transformers/reordering_bench_test.go
+++ b/transformers/reordering_bench_test.go
@@ -15,8 +15,8 @@ func BenchmarkReordering_ReorderAndFlush(b *testing.B) {
 	config.Reordering.MaxBufferSize = 1000
 
 	log := logger.New(false)
-	outChans := []chan *dnsutils.DNSMessage{
-		make(chan *dnsutils.DNSMessage, 2000),
+	outChans := []chan *dnsutils.DNSMessageBatch{
+		make(chan *dnsutils.DNSMessageBatch, 2000),
 	}
 
 	reorder := NewReorderingTransform(config, log, "test", 0, outChans)

--- a/transformers/reordering_test.go
+++ b/transformers/reordering_test.go
@@ -18,8 +18,8 @@ func TestReorderingTransform_SortByTimestamp(t *testing.T) {
 	log := logger.New(false)
 
 	// create output channels
-	outChans := []chan *dnsutils.DNSMessage{
-		make(chan *dnsutils.DNSMessage, 10),
+	outChans := []chan *dnsutils.DNSMessageBatch{
+		make(chan *dnsutils.DNSMessageBatch, 10),
 	}
 
 	// initialize transformer
@@ -46,8 +46,8 @@ func TestReorderingTransform_SortByTimestamp(t *testing.T) {
 	done := false
 	for !done {
 		select {
-		case msg := <-outChans[0]:
-			results = append(results, msg)
+		case b := <-outChans[0]:
+			results = append(results, b.Messages...)
 		default:
 			done = true
 		}

--- a/transformers/rest.go
+++ b/transformers/rest.go
@@ -17,7 +17,7 @@ type RestTransform struct {
 	httpclient *http.Client
 }
 
-func NewRestTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessage) *RestTransform {
+func NewRestTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *RestTransform {
 	t := &RestTransform{GenericTransformer: NewTransformer(config, logger, "rest", name, instance, nextWorkers)}
 	return t
 }

--- a/transformers/rest_test.go
+++ b/transformers/rest_test.go
@@ -39,7 +39,7 @@ func TestRest_Request(t *testing.T) {
 	config.Rest.BasicAuthPwd = "restpass"
 
 	// init the processor
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 	rest := NewRestTransform(config, logger.New(false), "test", 0, outChans)
 	rest.GetTransforms()
 

--- a/transformers/rewrite.go
+++ b/transformers/rewrite.go
@@ -17,7 +17,7 @@ type RewriteTransform struct {
 	mutators []MutatorFunc
 }
 
-func NewRewriteTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessage) *RewriteTransform {
+func NewRewriteTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *RewriteTransform {
 	t := &RewriteTransform{GenericTransformer: NewTransformer(config, logger, "rewrite", name, instance, nextWorkers)}
 	t.initMutators()
 	return t

--- a/transformers/rewrite_bench_test.go
+++ b/transformers/rewrite_bench_test.go
@@ -15,7 +15,7 @@ func BenchmarkRewrite_UpdateValues(b *testing.B) {
 	config.Rewrite.Identifiers["dns.qname"] = "rewritten.qname.com"
 	config.Rewrite.Identifiers["network.query-ip"] = "1.1.1.1"
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 	rewrite := NewRewriteTransform(config, logger.New(false), "test", 0, outChans)
 	rewrite.GetTransforms()
 

--- a/transformers/rewrite_test.go
+++ b/transformers/rewrite_test.go
@@ -17,7 +17,7 @@ func TestRewrite_UpdateFields(t *testing.T) {
 	config.Rewrite.Identifiers["dnstap.identity"] = "testidentity"
 
 	// init the processor
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 	rewrite := NewRewriteTransform(config, logger.New(false), "test", 0, outChans)
 
 	// get fake
@@ -45,7 +45,7 @@ func TestRewrite_UpdateFields_InvalidType(t *testing.T) {
 	config.Rewrite.Identifiers["dnstap.identity"] = 0
 
 	// init the processor
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 	rewrite := NewRewriteTransform(config, logger.New(false), "test", 0, outChans)
 
 	// get fake

--- a/transformers/suspicious.go
+++ b/transformers/suspicious.go
@@ -15,7 +15,7 @@ type SuspiciousTransform struct {
 	whitelistDomainsRegex map[string]*regexp.Regexp
 }
 
-func NewSuspiciousTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessage) *SuspiciousTransform {
+func NewSuspiciousTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *SuspiciousTransform {
 	t := &SuspiciousTransform{GenericTransformer: NewTransformer(config, logger, "suspicious", name, instance, nextWorkers)}
 	t.commonQtypes = make(map[string]bool)
 	t.whitelistDomainsRegex = make(map[string]*regexp.Regexp)

--- a/transformers/suspicious_test.go
+++ b/transformers/suspicious_test.go
@@ -14,7 +14,7 @@ func TestSuspicious_Json(t *testing.T) {
 	// enable feature
 	config := pkgconfig.GetFakeConfigTransformers()
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// get fake
 	dm := dnsutils.GetFakeDNSMessage()
@@ -74,7 +74,7 @@ func TestSuspicious_MalformedPacket(t *testing.T) {
 	config := pkgconfig.GetFakeConfigTransformers()
 	config.Suspicious.Enable = true
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
 	suspicious := NewSuspiciousTransform(config, logger.New(false), "test", 0, outChans)
@@ -109,7 +109,7 @@ func TestSuspicious_LongDomain(t *testing.T) {
 	config.Suspicious.Enable = true
 	config.Suspicious.ThresholdQnameLen = 4
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
 	suspicious := NewSuspiciousTransform(config, logger.New(false), "test", 0, outChans)
@@ -143,7 +143,7 @@ func TestSuspicious_SlowDomain(t *testing.T) {
 	config.Suspicious.Enable = true
 	config.Suspicious.ThresholdSlow = 3.0
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
 	suspicious := NewSuspiciousTransform(config, logger.New(false), "test", 0, outChans)
@@ -177,7 +177,7 @@ func TestSuspicious_LargePacket(t *testing.T) {
 	config.Suspicious.Enable = true
 	config.Suspicious.ThresholdPacketLen = 4
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
 	suspicious := NewSuspiciousTransform(config, logger.New(false), "test", 0, outChans)
@@ -210,7 +210,7 @@ func TestSuspicious_UncommonQtype(t *testing.T) {
 	config := pkgconfig.GetFakeConfigTransformers()
 	config.Suspicious.Enable = true
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
 	suspicious := NewSuspiciousTransform(config, logger.New(false), "test", 0, outChans)
@@ -244,7 +244,7 @@ func TestSuspicious_ExceedMaxLabels(t *testing.T) {
 	config.Suspicious.Enable = true
 	config.Suspicious.ThresholdMaxLabels = 2
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
 	suspicious := NewSuspiciousTransform(config, logger.New(false), "test", 0, outChans)
@@ -277,7 +277,7 @@ func TestSuspicious_UnallowedChars(t *testing.T) {
 	config := pkgconfig.GetFakeConfigTransformers()
 	config.Suspicious.Enable = true
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
 	suspicious := NewSuspiciousTransform(config, logger.New(false), "test", 0, outChans)
@@ -310,7 +310,7 @@ func TestSuspicious_WhitelistDomains(t *testing.T) {
 	config := pkgconfig.GetFakeConfigTransformers()
 	config.Suspicious.Enable = true
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
 	suspicious := NewSuspiciousTransform(config, logger.New(false), "test", 0, outChans)

--- a/transformers/transformers.go
+++ b/transformers/transformers.go
@@ -29,11 +29,11 @@ type GenericTransformer struct {
 	config            *pkgconfig.ConfigTransformers
 	logger            *logger.Logger
 	name              string
-	nextWorkers       []chan *dnsutils.DNSMessage
+	nextWorkers       []chan *dnsutils.DNSMessageBatch
 	LogInfo, LogError func(msg string, v ...interface{})
 }
 
-func NewTransformer(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, workerName string, instance int, nextWorkers []chan *dnsutils.DNSMessage) GenericTransformer {
+func NewTransformer(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, workerName string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) GenericTransformer {
 	t := GenericTransformer{config: config, logger: logger, nextWorkers: nextWorkers, name: name}
 
 	t.LogInfo = func(msg string, v ...interface{}) {
@@ -69,7 +69,7 @@ type Transforms struct {
 	activeProcessTransforms []func(dm *dnsutils.DNSMessage) (int, error)
 }
 
-func NewTransforms(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, nextWorkers []chan *dnsutils.DNSMessage, instance int) Transforms {
+func NewTransforms(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, nextWorkers []chan *dnsutils.DNSMessageBatch, instance int) Transforms {
 
 	d := Transforms{config: config, logger: logger, name: name, instance: instance}
 

--- a/transformers/transformers_bench_test.go
+++ b/transformers/transformers_bench_test.go
@@ -22,7 +22,7 @@ func BenchmarkTransforms_InitAndProcess(b *testing.B) {
 	config.Filtering.Enable = true
 	config.Filtering.KeepDomainFile = ".././tests/testsdata/filtering_keep_domains.txt"
 
-	channels := []chan *dnsutils.DNSMessage{}
+	channels := []chan *dnsutils.DNSMessageBatch{}
 	transformers := NewTransforms(config, logger.New(false), "test", channels, 0)
 
 	dm := dnsutils.GetFakeDNSMessage()

--- a/transformers/transformers_test.go
+++ b/transformers/transformers_test.go
@@ -30,7 +30,7 @@ func TestTransforms_ProcessOrder(t *testing.T) {
 	testURL2 := "test.github.com"
 
 	// init the transformer
-	subprocessors := NewTransforms(config, logger.New(false), "test", []chan *dnsutils.DNSMessage{}, 0)
+	subprocessors := NewTransforms(config, logger.New(false), "test", []chan *dnsutils.DNSMessageBatch{}, 0)
 
 	// create test message
 	dm := dnsutils.GetFakeDNSMessage()
@@ -72,7 +72,7 @@ func TestTransforms_ConfigurableOrder(t *testing.T) {
 	config.Normalize.Enable = true
 	config.Normalize.QnameLowerCase = true
 
-	subprocessors := NewTransforms(config, logger.New(false), "test", []chan *dnsutils.DNSMessage{}, 0)
+	subprocessors := NewTransforms(config, logger.New(false), "test", []chan *dnsutils.DNSMessageBatch{}, 0)
 
 	if len(subprocessors.activeTransforms) != 2 {
 		t.Fatalf("expected 2 active transforms, got %d", len(subprocessors.activeTransforms))
@@ -98,7 +98,7 @@ func TestTransforms_ConfigurableOrder(t *testing.T) {
 
 	// Reverse order
 	config.Order = []string{"normalize", "geoip"}
-	subprocessors = NewTransforms(config, logger.New(false), "test", []chan *dnsutils.DNSMessage{}, 0)
+	subprocessors = NewTransforms(config, logger.New(false), "test", []chan *dnsutils.DNSMessageBatch{}, 0)
 
 	st0, _ = subprocessors.activeTransforms[0].GetTransforms()
 	found = false

--- a/transformers/userprivacy.go
+++ b/transformers/userprivacy.go
@@ -37,7 +37,7 @@ type UserPrivacyTransform struct {
 	v4Mask, v6Mask net.IPMask
 }
 
-func NewUserPrivacyTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessage) *UserPrivacyTransform {
+func NewUserPrivacyTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *UserPrivacyTransform {
 	t := &UserPrivacyTransform{GenericTransformer: NewTransformer(config, logger, "userprivacy", name, instance, nextWorkers)}
 	return t
 }

--- a/transformers/userprivacy_bench_test.go
+++ b/transformers/userprivacy_bench_test.go
@@ -13,7 +13,7 @@ func BenchmarkUserPrivacy_ReduceQname(b *testing.B) {
 	config.UserPrivacy.Enable = true
 	config.UserPrivacy.MinimizeQname = true
 
-	channels := []chan *dnsutils.DNSMessage{}
+	channels := []chan *dnsutils.DNSMessageBatch{}
 
 	userprivacy := NewUserPrivacyTransform(config, logger.New(false), "test", 0, channels)
 	userprivacy.GetTransforms()
@@ -33,7 +33,7 @@ func BenchmarkUserPrivacy_HashIP(b *testing.B) {
 	config.UserPrivacy.Enable = true
 	config.UserPrivacy.HashQueryIP = true
 
-	channels := []chan *dnsutils.DNSMessage{}
+	channels := []chan *dnsutils.DNSMessageBatch{}
 
 	userprivacy := NewUserPrivacyTransform(config, logger.New(false), "test", 0, channels)
 	userprivacy.GetTransforms()
@@ -53,7 +53,7 @@ func BenchmarkUserPrivacy_HashIPSha512(b *testing.B) {
 	config.UserPrivacy.HashQueryIP = true
 	config.UserPrivacy.HashIPAlgo = "sha512"
 
-	channels := []chan *dnsutils.DNSMessage{}
+	channels := []chan *dnsutils.DNSMessageBatch{}
 
 	userprivacy := NewUserPrivacyTransform(config, logger.New(false), "test", 0, channels)
 	userprivacy.GetTransforms()
@@ -72,7 +72,7 @@ func BenchmarkUserPrivacy_AnonymizeIP(b *testing.B) {
 	config.UserPrivacy.Enable = true
 	config.UserPrivacy.AnonymizeIP = true
 
-	channels := []chan *dnsutils.DNSMessage{}
+	channels := []chan *dnsutils.DNSMessageBatch{}
 
 	userprivacy := NewUserPrivacyTransform(config, logger.New(false), "test", 0, channels)
 	userprivacy.GetTransforms()

--- a/transformers/userprivacy_test.go
+++ b/transformers/userprivacy_test.go
@@ -20,7 +20,7 @@ func TestUserPrivacy_ReduceQname(t *testing.T) {
 	config.UserPrivacy.Enable = true
 	config.UserPrivacy.MinimizeQname = true
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
 	userPrivacy := NewUserPrivacyTransform(config, logger.New(false), "test", 0, outChans)
@@ -84,7 +84,7 @@ func TestUserPrivacy_HashIP(t *testing.T) {
 				config.UserPrivacy.HashIPAlgo = tc.hashAlgo
 			}
 
-			outChans := []chan *dnsutils.DNSMessage{}
+			outChans := []chan *dnsutils.DNSMessageBatch{}
 
 			// Init the processor
 			userPrivacy := NewUserPrivacyTransform(config, logger.New(false), "test", 0, outChans)
@@ -115,7 +115,7 @@ func TestUserPrivacy_AnonymizeIP(t *testing.T) {
 	config.UserPrivacy.Enable = true
 	config.UserPrivacy.AnonymizeIP = true
 
-	outChans := []chan *dnsutils.DNSMessage{}
+	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// Init the processor
 	userPrivacy := NewUserPrivacyTransform(config, logger.New(false), "test", 0, outChans)
@@ -179,7 +179,7 @@ func TestUserPrivacy_AnonymizeIPRemove(t *testing.T) {
 	config.UserPrivacy.AnonymizeIPV6Bits = "::/0"
 
 	// Init the processor
-	userPrivacy := NewUserPrivacyTransform(config, logger.New(false), "test", 0, []chan *dnsutils.DNSMessage{})
+	userPrivacy := NewUserPrivacyTransform(config, logger.New(false), "test", 0, []chan *dnsutils.DNSMessageBatch{})
 	userPrivacy.GetTransforms()
 
 	// Define test cases

--- a/workers/clickhouse.go
+++ b/workers/clickhouse.go
@@ -32,9 +32,6 @@ type ClickhouseClient struct {
 
 func NewClickhouseClient(config *pkgconfig.Config, console *logger.Logger, name string) *ClickhouseClient {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.ClickhouseClient.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.ClickhouseClient.ChannelBufferSize
-	}
 	w := &ClickhouseClient{GenericWorker: NewGenericWorker(config, console, name, "clickhouse", bufSize, pkgconfig.DefaultMonitor)}
 	w.ReadConfig()
 	return w

--- a/workers/clickhouse.go
+++ b/workers/clickhouse.go
@@ -65,25 +65,28 @@ func (w *ClickhouseClient) StartCollect() {
 			w.ReadConfig()
 			subprocessors.ReloadConfig(&cfg.OutgoingTransformers)
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("input channel closed!")
 				return
 			}
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// apply transforms, init dns message with additional parts if necessary
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
+				// apply transforms, init dns message with additional parts if necessary
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
 
-			w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+				w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+			}
+			batch.Release()
 
 		}
 	}
@@ -99,40 +102,42 @@ func (w *ClickhouseClient) StartLogging() {
 			return
 
 			// incoming dns message to process
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
 			}
-			timensec := strconv.FormatInt(dm.DNSTap.Timestamp, 10)
-			data := ClickhouseData{
-				Identity:  dm.DNSTap.Identity,
-				QueryIP:   dm.NetworkInfo.GetQueryIP(),
-				QName:     dm.DNS.Qname,
-				Operation: dm.DNSTap.Operation,
-				Family:    dm.NetworkInfo.Family,
-				Protocol:  dm.NetworkInfo.Protocol,
-				QType:     dm.DNS.Qtype,
-				RCode:     dm.DNS.Rcode,
-				TimeNSec:  timensec,
-				TimeStamp: strconv.Itoa(int(int64(dm.DNSTap.TimeSec))),
-			}
-			url := w.GetConfig().Loggers.ClickhouseClient.URL + "?query=INSERT%20INTO%20"
-			url += w.GetConfig().Loggers.ClickhouseClient.Database + "." + w.GetConfig().Loggers.ClickhouseClient.Table
-			url += "(identity,queryip,qname,operation,family,protocol,qtype,rcode,timensec,timestamp)%20VALUES%20('" + data.Identity + separator
-			url += data.QueryIP + separator + data.QName + separator + data.Operation + separator + data.Family + separator + data.Protocol
-			url += separator + data.QType + separator + data.RCode + separator + data.TimeNSec + separator + data.TimeStamp + "')"
-			req, _ := http.NewRequest("POST", url, nil)
+			for _, dm := range batch.Messages {
+				timensec := strconv.FormatInt(dm.DNSTap.Timestamp, 10)
+				data := ClickhouseData{
+					Identity:  dm.DNSTap.Identity,
+					QueryIP:   dm.NetworkInfo.GetQueryIP(),
+					QName:     dm.DNS.Qname,
+					Operation: dm.DNSTap.Operation,
+					Family:    dm.NetworkInfo.Family,
+					Protocol:  dm.NetworkInfo.Protocol,
+					QType:     dm.DNS.Qtype,
+					RCode:     dm.DNS.Rcode,
+					TimeNSec:  timensec,
+					TimeStamp: strconv.Itoa(int(int64(dm.DNSTap.TimeSec))),
+				}
+				url := w.GetConfig().Loggers.ClickhouseClient.URL + "?query=INSERT%20INTO%20"
+				url += w.GetConfig().Loggers.ClickhouseClient.Database + "." + w.GetConfig().Loggers.ClickhouseClient.Table
+				url += "(identity,queryip,qname,operation,family,protocol,qtype,rcode,timensec,timestamp)%20VALUES%20('" + data.Identity + separator
+				url += data.QueryIP + separator + data.QName + separator + data.Operation + separator + data.Family + separator + data.Protocol
+				url += separator + data.QType + separator + data.RCode + separator + data.TimeNSec + separator + data.TimeStamp + "')"
+				req, _ := http.NewRequest("POST", url, nil)
 
-			req.Header.Add("Accept", "*/*")
-			req.Header.Add("X-ClickHouse-User", w.GetConfig().Loggers.ClickhouseClient.User)
-			req.Header.Add("X-ClickHouse-Key", w.GetConfig().Loggers.ClickhouseClient.Password)
+				req.Header.Add("Accept", "*/*")
+				req.Header.Add("X-ClickHouse-User", w.GetConfig().Loggers.ClickhouseClient.User)
+				req.Header.Add("X-ClickHouse-Key", w.GetConfig().Loggers.ClickhouseClient.Password)
 
-			_, errReq := http.DefaultClient.Do(req)
-			if errReq != nil {
-				w.LogError(errReq.Error())
+				_, errReq := http.DefaultClient.Do(req)
+				if errReq != nil {
+					w.LogError(errReq.Error())
+				}
 			}
-			dm.Release()
+			batch.Release()
 		}
 	}
 }

--- a/workers/clickhouse_test.go
+++ b/workers/clickhouse_test.go
@@ -42,7 +42,7 @@ func Test_ClickhouseClient(t *testing.T) {
 			go g.StartCollect()
 
 			dm := dnsutils.GetFakeDNSMessage()
-			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 			// accept conn
 			conn, err := fakeRcvr.Accept()
 			if err != nil {

--- a/workers/clickhouse_test.go
+++ b/workers/clickhouse_test.go
@@ -42,7 +42,7 @@ func Test_ClickhouseClient(t *testing.T) {
 			go g.StartCollect()
 
 			dm := dnsutils.GetFakeDNSMessage()
-			g.GetInputChannel() <- &dm
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 			// accept conn
 			conn, err := fakeRcvr.Accept()
 			if err != nil {

--- a/workers/devnull.go
+++ b/workers/devnull.go
@@ -1,6 +1,7 @@
 package workers
 
 import (
+	"github.com/dmachard/go-dnscollector/v2/dnsutils"
 	"github.com/dmachard/go-dnscollector/v2/pkgconfig"
 	"github.com/dmachard/go-logger"
 )
@@ -20,22 +21,10 @@ func (w *DevNull) StartCollect() {
 	w.LogInfo("starting data collection")
 	defer w.CollectDone()
 
-	// loop to process incoming messages
-	for {
-		select {
-		case <-w.OnStop():
-			return
-
-		case dm, opened := <-w.GetInputChannel():
-			if !opened {
-				w.LogInfo("run: input channel closed!")
-				return
-			}
-
-			// count global messages
+	w.RunBatchLoop(func(batch *dnsutils.DNSMessageBatch) {
+		for range batch.Messages {
 			w.CountIngressTraffic()
-			dm.Release()
-
 		}
-	}
+		batch.Release()
+	})
 }

--- a/workers/devnull.go
+++ b/workers/devnull.go
@@ -11,9 +11,6 @@ type DevNull struct {
 
 func NewDevNull(config *pkgconfig.Config, console *logger.Logger, name string) *DevNull {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.DevNull.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.DevNull.ChannelBufferSize
-	}
 	s := &DevNull{GenericWorker: NewGenericWorker(config, console, name, "devnull", bufSize, pkgconfig.DefaultMonitor)}
 	s.ReadConfig()
 	return s

--- a/workers/dnsmessage.go
+++ b/workers/dnsmessage.go
@@ -187,67 +187,70 @@ func (w *DNSMessage) StartCollect() {
 			w.SetConfig(cfg)
 			w.ReadConfig()
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("channel closed, exit")
 				return
 			}
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// matching enabled, filtering DNS messages ?
-			matched := true
-			matchedInclude := false
-			matchedExclude := false
+				// matching enabled, filtering DNS messages ?
+				matched := true
+				matchedInclude := false
+				matchedExclude := false
 
-			if len(w.GetConfig().Collectors.DNSMessage.Matching.Include) > 0 {
-				err, matchedInclude = dm.Matching(w.GetConfig().Collectors.DNSMessage.Matching.Include)
-				if err != nil {
-					w.LogError(err.Error())
+				if len(w.GetConfig().Collectors.DNSMessage.Matching.Include) > 0 {
+					err, matchedInclude = dm.Matching(w.GetConfig().Collectors.DNSMessage.Matching.Include)
+					if err != nil {
+						w.LogError(err.Error())
+					}
+					if matched && matchedInclude {
+						matched = true
+					} else {
+						matched = false
+					}
 				}
-				if matched && matchedInclude {
-					matched = true
-				} else {
-					matched = false
-				}
-			}
 
-			if len(w.GetConfig().Collectors.DNSMessage.Matching.Exclude) > 0 {
-				err, matchedExclude = dm.Matching(w.GetConfig().Collectors.DNSMessage.Matching.Exclude)
-				if err != nil {
-					w.LogError(err.Error())
+				if len(w.GetConfig().Collectors.DNSMessage.Matching.Exclude) > 0 {
+					err, matchedExclude = dm.Matching(w.GetConfig().Collectors.DNSMessage.Matching.Exclude)
+					if err != nil {
+						w.LogError(err.Error())
+					}
+					if matched && !matchedExclude {
+						matched = true
+					} else {
+						matched = false
+					}
 				}
-				if matched && !matchedExclude {
-					matched = true
-				} else {
-					matched = false
-				}
-			}
 
-			// count output packets
-			w.CountEgressTraffic()
+				// count output packets
+				w.CountEgressTraffic()
 
-			// apply transform on matched packets only
-			// init dns message with additional parts if necessary
-			if matched {
-				transformResult, err := subprocessors.ProcessMessage(dm)
-				if err != nil {
-					w.LogError(err.Error())
+				// apply transform on matched packets only
+				// init dns message with additional parts if necessary
+				if matched {
+					transformResult, err := subprocessors.ProcessMessage(dm)
+					if err != nil {
+						w.LogError(err.Error())
+					}
+					if transformResult == transformers.ReturnDrop {
+						w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+						continue
+					}
 				}
-				if transformResult == transformers.ReturnDrop {
+
+				// drop packet ?
+				if !matched {
 					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
 					continue
 				}
-			}
 
-			// drop packet ?
-			if !matched {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
+				// send to next
+				w.SendForwardedTo(defaultRoutes, defaultNames, dm)
 			}
-
-			// send to next
-			w.SendForwardedTo(defaultRoutes, defaultNames, dm)
+			batch.Release()
 		}
 	}
 }

--- a/workers/dnsmessage.go
+++ b/workers/dnsmessage.go
@@ -34,9 +34,6 @@ type DNSMessage struct {
 
 func NewDNSMessage(next []Worker, config *pkgconfig.Config, logger *logger.Logger, name string) *DNSMessage {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Collectors.DNSMessage.ChannelBufferSize > 0 {
-		bufSize = config.Collectors.DNSMessage.ChannelBufferSize
-	}
 	s := &DNSMessage{GenericWorker: NewGenericWorker(config, logger, name, "dnsmessage", bufSize, pkgconfig.DefaultMonitor)}
 	s.SetDefaultRoutes(next)
 	s.ReadConfig()

--- a/workers/dnsmessage_bench_test.go
+++ b/workers/dnsmessage_bench_test.go
@@ -29,7 +29,7 @@ func Benchmark_DNSMessageWorker_Passthrough(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		msg := dm
-		inChan <- &msg
+		inChan <- dnsutils.NewDNSMessageBatchFromMessage(&msg)
 	}
 }
 
@@ -58,7 +58,7 @@ func Benchmark_DNSMessageWorker_MatchingInclude(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		msg := dm
-		inChan <- &msg
+		inChan <- dnsutils.NewDNSMessageBatchFromMessage(&msg)
 	}
 }
 
@@ -88,6 +88,6 @@ func Benchmark_DNSMessageWorker_MatchingExclude(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		msg := dm
-		inChan <- &msg
+		inChan <- dnsutils.NewDNSMessageBatchFromMessage(&msg)
 	}
 }

--- a/workers/dnsmessage_bench_test.go
+++ b/workers/dnsmessage_bench_test.go
@@ -29,7 +29,7 @@ func Benchmark_DNSMessageWorker_Passthrough(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		msg := dm
-		inChan <- dnsutils.NewDNSMessageBatchFromMessage(&msg)
+		inChan <- dnsutils.NewDNSMessageBatch(&msg)
 	}
 }
 
@@ -58,7 +58,7 @@ func Benchmark_DNSMessageWorker_MatchingInclude(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		msg := dm
-		inChan <- dnsutils.NewDNSMessageBatchFromMessage(&msg)
+		inChan <- dnsutils.NewDNSMessageBatch(&msg)
 	}
 }
 
@@ -88,6 +88,6 @@ func Benchmark_DNSMessageWorker_MatchingExclude(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		msg := dm
-		inChan <- dnsutils.NewDNSMessageBatchFromMessage(&msg)
+		inChan <- dnsutils.NewDNSMessageBatch(&msg)
 	}
 }

--- a/workers/dnsmessage_bench_test.go
+++ b/workers/dnsmessage_bench_test.go
@@ -10,7 +10,7 @@ import (
 
 func Benchmark_DNSMessageWorker_Passthrough(b *testing.B) {
 	config := pkgconfig.GetDefaultConfig()
-	config.Collectors.DNSMessage.ChannelBufferSize = 65536
+	config.Global.Worker.ChannelBufferSize = 65536
 
 	devNull := NewDevNull(config, logger.New(false), "devnull")
 	go devNull.StartCollect()
@@ -35,7 +35,7 @@ func Benchmark_DNSMessageWorker_Passthrough(b *testing.B) {
 
 func Benchmark_DNSMessageWorker_MatchingInclude(b *testing.B) {
 	config := pkgconfig.GetDefaultConfig()
-	config.Collectors.DNSMessage.ChannelBufferSize = 65536
+	config.Global.Worker.ChannelBufferSize = 65536
 	config.Collectors.DNSMessage.Matching.Include = map[string]interface{}{
 		"dns.qname": "dns.collector",
 	}
@@ -64,7 +64,7 @@ func Benchmark_DNSMessageWorker_MatchingInclude(b *testing.B) {
 
 func Benchmark_DNSMessageWorker_MatchingExclude(b *testing.B) {
 	config := pkgconfig.GetDefaultConfig()
-	config.Collectors.DNSMessage.ChannelBufferSize = 65536
+	config.Global.Worker.ChannelBufferSize = 65536
 	config.Collectors.DNSMessage.Matching.Exclude = map[string]interface{}{
 		"dns.qname": "drop.me",
 	}

--- a/workers/dnsmessage_test.go
+++ b/workers/dnsmessage_test.go
@@ -33,22 +33,22 @@ func TestDnsMessage_RoutingPolicy(t *testing.T) {
 
 	// this message should be kept by the collector
 	dm1 := dnsutils.GetFakeDNSMessage()
-	c.GetInputChannel() <- &dm1
+	c.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm1)
 
 	// this message should dropped by the collector
 	dm2 := dnsutils.GetFakeDNSMessage()
 	dm2.DNS.Qname = "dropped.collector"
-	c.GetInputChannel() <- &dm2
+	c.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm2)
 
 	// the 1er message should be in th k worker
-	dmKept := <-kept.GetInputChannel()
-	if dmKept.DNS.Qname != "dns.collector" {
+	batchKept := <-kept.GetInputChannel()
+	if len(batchKept.Messages) == 0 || batchKept.Messages[0].DNS.Qname != "dns.collector" {
 		t.Errorf("invalid dns message with default routing policy")
 	}
 
 	// the 2nd message should be in the d worker
-	dmDropped := <-dropped.GetInputChannel()
-	if dmDropped.DNS.Qname != "dropped.collector" {
+	batchDropped := <-dropped.GetInputChannel()
+	if len(batchDropped.Messages) == 0 || batchDropped.Messages[0].DNS.Qname != "dropped.collector" {
 		t.Errorf("invalid dns message with dropped routing policy")
 	}
 
@@ -74,7 +74,7 @@ func TestDnsMessage_BufferLoggerIsFull(t *testing.T) {
 	// add a shot of dnsmessages to collector
 	for i := 0; i < 512; i++ {
 		dmIn := dnsutils.GetFakeDNSMessage()
-		c.GetInputChannel() <- &dmIn
+		c.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dmIn)
 	}
 
 	// waiting monitor to run in consumer
@@ -89,15 +89,15 @@ func TestDnsMessage_BufferLoggerIsFull(t *testing.T) {
 	}
 
 	// read dnsmessage from next logger
-	dmOut := <-nxt.GetInputChannel()
-	if dmOut.DNS.Qname != pkgconfig.ExpectedQname2 {
-		t.Errorf("invalid qname in dns message: %s", dmOut.DNS.Qname)
+	batchOut := <-nxt.GetInputChannel()
+	if len(batchOut.Messages) == 0 || batchOut.Messages[0].DNS.Qname != pkgconfig.ExpectedQname2 {
+		t.Errorf("invalid qname in dns message: %v", batchOut.Messages)
 	}
 
 	// send second shot of packets to consumer
 	for i := 0; i < 1024; i++ {
 		dmIn := dnsutils.GetFakeDNSMessage()
-		c.GetInputChannel() <- &dmIn
+		c.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dmIn)
 	}
 
 	// waiting monitor to run in consumer
@@ -111,9 +111,9 @@ func TestDnsMessage_BufferLoggerIsFull(t *testing.T) {
 		}
 	}
 	// read dnsmessage from next logger
-	dm2 := <-nxt.GetInputChannel()
-	if dm2.DNS.Qname != pkgconfig.ExpectedQname2 {
-		t.Errorf("invalid qname in dns message: %s", dm2.DNS.Qname)
+	batch2 := <-nxt.GetInputChannel()
+	if len(batch2.Messages) == 0 || batch2.Messages[0].DNS.Qname != pkgconfig.ExpectedQname2 {
+		t.Errorf("invalid qname in dns message: %v", batch2.Messages)
 	}
 
 	// stop all

--- a/workers/dnsmessage_test.go
+++ b/workers/dnsmessage_test.go
@@ -56,7 +56,7 @@ func TestDnsMessage_RoutingPolicy(t *testing.T) {
 
 func TestDnsMessage_BufferLoggerIsFull(t *testing.T) {
 	// redirect stdout output to bytes buffer
-	logsChan := make(chan logger.LogEntry, 50)
+	logsChan := make(chan logger.LogEntry, 512)
 	lg := logger.New(true)
 	lg.SetOutputChannel((logsChan))
 

--- a/workers/dnsmessage_test.go
+++ b/workers/dnsmessage_test.go
@@ -33,12 +33,12 @@ func TestDnsMessage_RoutingPolicy(t *testing.T) {
 
 	// this message should be kept by the collector
 	dm1 := dnsutils.GetFakeDNSMessage()
-	c.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm1)
+	c.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm1)
 
 	// this message should dropped by the collector
 	dm2 := dnsutils.GetFakeDNSMessage()
 	dm2.DNS.Qname = "dropped.collector"
-	c.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm2)
+	c.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm2)
 
 	// the 1er message should be in th k worker
 	batchKept := <-kept.GetInputChannel()
@@ -74,7 +74,7 @@ func TestDnsMessage_BufferLoggerIsFull(t *testing.T) {
 	// add a shot of dnsmessages to collector
 	for i := 0; i < 512; i++ {
 		dmIn := dnsutils.GetFakeDNSMessage()
-		c.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dmIn)
+		c.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dmIn)
 	}
 
 	// waiting monitor to run in consumer
@@ -97,7 +97,7 @@ func TestDnsMessage_BufferLoggerIsFull(t *testing.T) {
 	// send second shot of packets to consumer
 	for i := 0; i < 1024; i++ {
 		dmIn := dnsutils.GetFakeDNSMessage()
-		c.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dmIn)
+		c.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dmIn)
 	}
 
 	// waiting monitor to run in consumer

--- a/workers/dnsprocessor.go
+++ b/workers/dnsprocessor.go
@@ -40,78 +40,87 @@ func (w *DNSProcessor) StartCollect() {
 			transforms.Reset()
 			return
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("channel closed, exit")
 				return
 			}
-			// count global messages
-			w.CountIngressTraffic()
+			outBatch := dnsutils.AcquireDNSMessageBatch(len(batch.Messages))
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// compute timestamp
-			ts := time.Unix(int64(dm.DNSTap.TimeSec), int64(dm.DNSTap.TimeNsec))
-			dm.DNSTap.Timestamp = ts.UnixNano()
-			dm.DNSTap.TimestampRFC3339 = "-"
+				// compute timestamp
+				ts := time.Unix(int64(dm.DNSTap.TimeSec), int64(dm.DNSTap.TimeNsec))
+				dm.DNSTap.Timestamp = ts.UnixNano()
+				dm.DNSTap.TimestampRFC3339 = "-"
 
-			// decode the dns payload
-			dnsHeader, err := dnsutils.DecodeDNS(dm.DNS.Payload)
-			if err != nil {
-				dm.DNS.MalformedPacket = true
-				w.LogError("dns parser malformed packet: %s - %v+", err, dm)
-			}
-
-			// get number of questions and answers
-			dm.DNS.QdCount = dnsHeader.Qdcount
-			dm.DNS.AnCount = dnsHeader.Ancount
-			dm.DNS.ArCount = dnsHeader.Arcount
-			dm.DNS.NsCount = dnsHeader.Nscount
-
-			// dns reply ?
-			if dnsHeader.Qr == 1 {
-				dm.DNSTap.Operation = "CLIENT_RESPONSE"
-				dm.DNS.Type = dnsutils.DNSReply
-				qip := dm.NetworkInfo.QueryIP
-				qport := dm.NetworkInfo.QueryPort
-				qbuf := dm.NetworkInfo.QueryIPBuf
-				qlen := dm.NetworkInfo.QueryIPLen
-				dm.NetworkInfo.QueryIP = dm.NetworkInfo.ResponseIP
-				dm.NetworkInfo.QueryPort = dm.NetworkInfo.ResponsePort
-				dm.NetworkInfo.QueryIPBuf = dm.NetworkInfo.ResponseIPBuf
-				dm.NetworkInfo.QueryIPLen = dm.NetworkInfo.ResponseIPLen
-				dm.NetworkInfo.ResponseIP = qip
-				dm.NetworkInfo.ResponsePort = qport
-				dm.NetworkInfo.ResponseIPBuf = qbuf
-				dm.NetworkInfo.ResponseIPLen = qlen
-			} else {
-				dm.DNS.Type = dnsutils.DNSQuery
-				dm.DNSTap.Operation = dnsutils.DNSTapClientQuery
-			}
-
-			if err = dnsutils.DecodePayload(dm, &dnsHeader, w.GetConfig()); err != nil {
-				w.LogError("%v - %v", err, dm)
-			}
-
-			if dm.DNS.MalformedPacket {
-				if w.GetConfig().Global.Trace.LogMalformed {
-					w.LogInfo("payload: %v", dm.DNS.Payload)
+				// decode the dns payload
+				dnsHeader, err := dnsutils.DecodeDNS(dm.DNS.Payload)
+				if err != nil {
+					dm.DNS.MalformedPacket = true
+					w.LogError("dns parser malformed packet: %s - %v+", err, dm)
 				}
-			}
 
-			// count output packets
-			w.CountEgressTraffic()
+				// get number of questions and answers
+				dm.DNS.QdCount = dnsHeader.Qdcount
+				dm.DNS.AnCount = dnsHeader.Ancount
+				dm.DNS.ArCount = dnsHeader.Arcount
+				dm.DNS.NsCount = dnsHeader.Nscount
 
-			// apply all enabled transformers
-			transformResult, err := transforms.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
+				// dns reply ?
+				if dnsHeader.Qr == 1 {
+					dm.DNSTap.Operation = "CLIENT_RESPONSE"
+					dm.DNS.Type = dnsutils.DNSReply
+					qip := dm.NetworkInfo.QueryIP
+					qport := dm.NetworkInfo.QueryPort
+					qbuf := dm.NetworkInfo.QueryIPBuf
+					qlen := dm.NetworkInfo.QueryIPLen
+					dm.NetworkInfo.QueryIP = dm.NetworkInfo.ResponseIP
+					dm.NetworkInfo.QueryPort = dm.NetworkInfo.ResponsePort
+					dm.NetworkInfo.QueryIPBuf = dm.NetworkInfo.ResponseIPBuf
+					dm.NetworkInfo.QueryIPLen = dm.NetworkInfo.ResponseIPLen
+					dm.NetworkInfo.ResponseIP = qip
+					dm.NetworkInfo.ResponsePort = qport
+					dm.NetworkInfo.ResponseIPBuf = qbuf
+					dm.NetworkInfo.ResponseIPLen = qlen
+				} else {
+					dm.DNS.Type = dnsutils.DNSQuery
+					dm.DNSTap.Operation = dnsutils.DNSTapClientQuery
+				}
 
-			// dispatch dns message to all generators
-			w.SendForwardedTo(defaultRoutes, defaultNames, dm)
+				if err = dnsutils.DecodePayload(dm, &dnsHeader, w.GetConfig()); err != nil {
+					w.LogError("%v - %v", err, dm)
+				}
+
+				if dm.DNS.MalformedPacket {
+					if w.GetConfig().Global.Trace.LogMalformed {
+						w.LogInfo("payload: %v", dm.DNS.Payload)
+					}
+				}
+
+				// count output packets
+				w.CountEgressTraffic()
+
+				// apply all enabled transformers
+				transformResult, err := transforms.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
+
+				// append to output batch
+				outBatch.Messages = append(outBatch.Messages, dm)
+			}
+			if len(outBatch.Messages) > 0 {
+				w.SendForwardedBatchTo(defaultRoutes, defaultNames, outBatch)
+			} else {
+				outBatch.Release()
+			}
+			batch.Release()
 		}
 	}
 }

--- a/workers/dnsprocessor.go
+++ b/workers/dnsprocessor.go
@@ -113,6 +113,9 @@ func (w *DNSProcessor) StartCollect() {
 				}
 
 				// append to output batch
+				// Retain so the incoming batch's Release() does not zero dm
+				// while outBatch is still in flight to downstream routes.
+				dm.Retain(1)
 				outBatch.Messages = append(outBatch.Messages, dm)
 			}
 			if len(outBatch.Messages) > 0 {

--- a/workers/dnsprocessor_bench_test.go
+++ b/workers/dnsprocessor_bench_test.go
@@ -31,7 +31,7 @@ func Benchmark_DNSProcessor_Query(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		msg := dm
-		inChan <- &msg
+		inChan <- dnsutils.NewDNSMessageBatchFromMessage(&msg)
 	}
 }
 
@@ -60,7 +60,7 @@ func Benchmark_DNSProcessor_Response(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		msg := dm
-		inChan <- &msg
+		inChan <- dnsutils.NewDNSMessageBatchFromMessage(&msg)
 	}
 }
 
@@ -88,6 +88,6 @@ func Benchmark_DNSProcessor_Malformed(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		msg := dm
-		inChan <- &msg
+		inChan <- dnsutils.NewDNSMessageBatchFromMessage(&msg)
 	}
 }

--- a/workers/dnsprocessor_bench_test.go
+++ b/workers/dnsprocessor_bench_test.go
@@ -31,7 +31,7 @@ func Benchmark_DNSProcessor_Query(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		msg := dm
-		inChan <- dnsutils.NewDNSMessageBatchFromMessage(&msg)
+		inChan <- dnsutils.NewDNSMessageBatch(&msg)
 	}
 }
 
@@ -60,7 +60,7 @@ func Benchmark_DNSProcessor_Response(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		msg := dm
-		inChan <- dnsutils.NewDNSMessageBatchFromMessage(&msg)
+		inChan <- dnsutils.NewDNSMessageBatch(&msg)
 	}
 }
 
@@ -88,6 +88,6 @@ func Benchmark_DNSProcessor_Malformed(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		msg := dm
-		inChan <- dnsutils.NewDNSMessageBatchFromMessage(&msg)
+		inChan <- dnsutils.NewDNSMessageBatch(&msg)
 	}
 }

--- a/workers/dnsprocessor_test.go
+++ b/workers/dnsprocessor_test.go
@@ -81,7 +81,7 @@ func Test_DnsProcessor_DecodeCounters(t *testing.T) {
 
 func Test_DnsProcessor_BufferLoggerIsFull(t *testing.T) {
 	// redirect stdout output to bytes buffer
-	logsChan := make(chan logger.LogEntry, 10)
+	logsChan := make(chan logger.LogEntry, 512)
 	lg := logger.New(true)
 	lg.SetOutputChannel((logsChan))
 

--- a/workers/dnsprocessor_test.go
+++ b/workers/dnsprocessor_test.go
@@ -26,12 +26,12 @@ func Test_DnsProcessor(t *testing.T) {
 	go consumer.StartCollect()
 
 	dm := dnsutils.GetFakeDNSMessageWithPayload()
-	consumer.GetInputChannel() <- &dm
+	consumer.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 	// read dns message from dnstap consumer
-	dmOut := <-fl.GetInputChannel()
-	if dmOut.DNS.Qname != pkgconfig.ExpectedQname {
-		t.Errorf("invalid qname in dns message: %s", dm.DNS.Qname)
+	batchOut := <-fl.GetInputChannel()
+	if len(batchOut.Messages) == 0 || batchOut.Messages[0].DNS.Qname != pkgconfig.ExpectedQname {
+		t.Errorf("invalid qname in dns message: %v", batchOut.Messages)
 	}
 }
 
@@ -57,10 +57,14 @@ func Test_DnsProcessor_DecodeCounters(t *testing.T) {
 	dm.DNS.Length = len(responsePacket)
 
 	// send dm to consumer
-	consumer.GetInputChannel() <- &dm
+	consumer.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 	// read dns message from dnstap consumer
-	dmOut := <-fl.GetInputChannel()
+	batchOut := <-fl.GetInputChannel()
+	if len(batchOut.Messages) == 0 {
+		t.Fatalf("expected message in batch")
+	}
+	dmOut := batchOut.Messages[0]
 	if dmOut.DNS.QdCount != 1 {
 		t.Errorf("invalid number of questions in dns message: got %d expect 1", dmOut.DNS.QdCount)
 	}
@@ -91,7 +95,7 @@ func Test_DnsProcessor_BufferLoggerIsFull(t *testing.T) {
 	// add packets to consumer
 	for i := 0; i < 512; i++ {
 		dm := dnsutils.GetFakeDNSMessageWithPayload()
-		consumer.GetInputChannel() <- &dm
+		consumer.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 	}
 
 	// waiting monitor to run in consumer
@@ -105,16 +109,16 @@ func Test_DnsProcessor_BufferLoggerIsFull(t *testing.T) {
 		}
 	}
 
-	// read dns message from dnstap consumer
-	dmOut := <-fl.GetInputChannel()
-	if dmOut.DNS.Qname != pkgconfig.ExpectedQname {
-		t.Errorf("invalid qname in dns message: %s", dmOut.DNS.Qname)
+	// read dnsmessage from dnstap consumer
+	batchOut := <-fl.GetInputChannel()
+	if len(batchOut.Messages) == 0 || batchOut.Messages[0].DNS.Qname != pkgconfig.ExpectedQname {
+		t.Errorf("invalid qname in dns message: %v", batchOut.Messages)
 	}
 
 	// send second shot of packets to consumer
 	for i := 0; i < 1024; i++ {
 		dm := dnsutils.GetFakeDNSMessageWithPayload()
-		consumer.GetInputChannel() <- &dm
+		consumer.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 	}
 
 	// waiting monitor to run in consumer
@@ -128,9 +132,9 @@ func Test_DnsProcessor_BufferLoggerIsFull(t *testing.T) {
 		}
 	}
 
-	// read dns message from dnstap consumer
-	dm2 := <-fl.GetInputChannel()
-	if dm2.DNS.Qname != pkgconfig.ExpectedQname {
-		t.Errorf("invalid qname in second dns message: %s", dm2.DNS.Qname)
+	// read dnsmessage from dnstap consumer
+	batch2 := <-fl.GetInputChannel()
+	if len(batch2.Messages) == 0 || batch2.Messages[0].DNS.Qname != pkgconfig.ExpectedQname {
+		t.Errorf("invalid qname in second dns message: %v", batch2.Messages)
 	}
 }

--- a/workers/dnsprocessor_test.go
+++ b/workers/dnsprocessor_test.go
@@ -26,7 +26,7 @@ func Test_DnsProcessor(t *testing.T) {
 	go consumer.StartCollect()
 
 	dm := dnsutils.GetFakeDNSMessageWithPayload()
-	consumer.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+	consumer.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 	// read dns message from dnstap consumer
 	batchOut := <-fl.GetInputChannel()
@@ -57,7 +57,7 @@ func Test_DnsProcessor_DecodeCounters(t *testing.T) {
 	dm.DNS.Length = len(responsePacket)
 
 	// send dm to consumer
-	consumer.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+	consumer.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 	// read dns message from dnstap consumer
 	batchOut := <-fl.GetInputChannel()
@@ -95,7 +95,7 @@ func Test_DnsProcessor_BufferLoggerIsFull(t *testing.T) {
 	// add packets to consumer
 	for i := 0; i < 512; i++ {
 		dm := dnsutils.GetFakeDNSMessageWithPayload()
-		consumer.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+		consumer.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 	}
 
 	// waiting monitor to run in consumer
@@ -118,7 +118,7 @@ func Test_DnsProcessor_BufferLoggerIsFull(t *testing.T) {
 	// send second shot of packets to consumer
 	for i := 0; i < 1024; i++ {
 		dm := dnsutils.GetFakeDNSMessageWithPayload()
-		consumer.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+		consumer.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 	}
 
 	// waiting monitor to run in consumer

--- a/workers/dnstap_relay.go
+++ b/workers/dnstap_relay.go
@@ -21,9 +21,6 @@ type DnstapProxifier struct {
 
 func NewDnstapProxifier(next []Worker, config *pkgconfig.Config, logger *logger.Logger, name string) *DnstapProxifier {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Collectors.DnstapProxifier.ChannelBufferSize > 0 {
-		bufSize = config.Collectors.DnstapProxifier.ChannelBufferSize
-	}
 	s := &DnstapProxifier{GenericWorker: NewGenericWorker(config, logger, name, "dnstaprelay", bufSize, pkgconfig.DefaultMonitor)}
 	s.SetDefaultRoutes(next)
 	s.CheckConfig()
@@ -69,9 +66,6 @@ func (w *DnstapProxifier) HandleConn(conn net.Conn, connID uint64, forceClose ch
 	w.LogInfo("new connection from %s\n", peer)
 
 	bufSize := w.config.Global.Worker.ChannelBufferSize
-	if w.config.Collectors.DnstapProxifier.ChannelBufferSize > 0 {
-		bufSize = w.config.Collectors.DnstapProxifier.ChannelBufferSize
-	}
 
 	recvChan := make(chan []byte, bufSize)
 	defaultRoutes, _ := GetRoutes(w.GetDefaultRoutes())

--- a/workers/dnstap_relay.go
+++ b/workers/dnstap_relay.go
@@ -33,7 +33,7 @@ func (w *DnstapProxifier) CheckConfig() {
 	}
 }
 
-func (w *DnstapProxifier) HandleFrame(recvFrom chan []byte, sendTo []chan *dnsutils.DNSMessage) {
+func (w *DnstapProxifier) HandleFrame(recvFrom chan []byte, sendTo []chan *dnsutils.DNSMessageBatch) {
 	defer w.LogInfo("frame handler terminated")
 
 	for data := range recvFrom {
@@ -43,12 +43,15 @@ func (w *DnstapProxifier) HandleFrame(recvFrom chan []byte, sendTo []chan *dnsut
 		// register payload
 		dm.DNSTap.Payload = data
 
+		b := dnsutils.AcquireDNSMessageBatch(1)
+		b.Messages = append(b.Messages, dm)
+
 		if len(sendTo) > 1 {
-			dm.Retain(int32(len(sendTo) - 1))
+			b.Retain(int32(len(sendTo) - 1))
 		}
 		// forward to outputs
 		for i := range sendTo {
-			sendTo[i] <- dm
+			sendTo[i] <- b
 		}
 	}
 }

--- a/workers/dnstap_relay_test.go
+++ b/workers/dnstap_relay_test.go
@@ -96,8 +96,8 @@ func Test_DnstapRelay(t *testing.T) {
 			}
 
 			// waiting message in channel
-			msg := <-g.GetInputChannel()
-			if len(msg.DNSTap.Payload) == 0 {
+			batch := <-g.GetInputChannel()
+			if len(batch.Messages) == 0 || len(batch.Messages[0].DNSTap.Payload) == 0 {
 				t.Errorf("DNStap payload is empty")
 			}
 

--- a/workers/dnstapclient.go
+++ b/workers/dnstapclient.go
@@ -218,26 +218,29 @@ func (w *DnstapSender) StartCollect() {
 			w.ReadConfig()
 			subprocessors.ReloadConfig(&cfg.OutgoingTransformers)
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("input channel closed!")
 				return
 			}
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// apply transforms, init dns message with additional parts if necessary
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
+				// apply transforms, init dns message with additional parts if necessary
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
 
-			// send to output channel and forward
-			w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+				// send to output channel and forward
+				w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+			}
+			batch.Release()
 		}
 	}
 }
@@ -284,27 +287,30 @@ func (w *DnstapSender) StartLogging() {
 				w.LogInfo("framestream initialized with success")
 			}
 			// incoming dns message to process
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
 			}
 
-			// drop dns message if the connection is not ready to avoid memory leak or
-			// to block the channel
-			if !w.fsReady {
-				w.CountEgressDiscarded()
-				dm.Release()
-				continue
-			}
+			for _, dm := range batch.Messages {
+				// drop dns message if the connection is not ready to avoid memory leak or
+				// to block the channel
+				if !w.fsReady {
+					w.CountEgressDiscarded()
+					continue
+				}
 
-			// append dns message to buffer
-			bufferDm = append(bufferDm, dm)
+				dm.Retain(1)
+				// append dns message to buffer
+				bufferDm = append(bufferDm, dm)
 
-			// buffer is full ?
-			if len(bufferDm) >= w.GetConfig().Loggers.DNSTap.BufferSize {
-				w.FlushBuffer(&bufferDm)
+				// buffer is full ?
+				if len(bufferDm) >= w.GetConfig().Loggers.DNSTap.BufferSize {
+					w.FlushBuffer(&bufferDm)
+				}
 			}
+			batch.Release()
 
 		// flush the buffer
 		case <-flushTimer.C:

--- a/workers/dnstapclient.go
+++ b/workers/dnstapclient.go
@@ -27,9 +27,6 @@ type DnstapSender struct {
 
 func NewDnstapSender(config *pkgconfig.Config, logger *logger.Logger, name string) *DnstapSender {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.DNSTap.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.DNSTap.ChannelBufferSize
-	}
 	w := &DnstapSender{GenericWorker: NewGenericWorker(config, logger, name, "dnstap", bufSize, pkgconfig.DefaultMonitor)}
 	w.transportReady = make(chan bool)
 	w.transportReconnect = make(chan bool)

--- a/workers/dnstapclient_test.go
+++ b/workers/dnstapclient_test.go
@@ -85,7 +85,7 @@ func Test_DnstapClient(t *testing.T) {
 
 			// send fake dns message to logger
 			dm := dnsutils.GetFakeDNSMessage()
-			g.GetInputChannel() <- &dm
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 			// receive frame on server side ?, timeout 5s
 			var fs *framestream.Frame

--- a/workers/dnstapclient_test.go
+++ b/workers/dnstapclient_test.go
@@ -85,7 +85,7 @@ func Test_DnstapClient(t *testing.T) {
 
 			// send fake dns message to logger
 			dm := dnsutils.GetFakeDNSMessage()
-			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 			// receive frame on server side ?, timeout 5s
 			var fs *framestream.Frame

--- a/workers/dnstapserver.go
+++ b/workers/dnstapserver.go
@@ -161,7 +161,7 @@ func (w *DnstapServer) HandleConn(conn net.Conn, connID uint64, forceClose chan 
 			select {
 			case dnstapProcessor.GetDataChannel() <- frame.Data(): // Successful send to channel
 			default:
-				w.WorkerIsBusy("dnstap-processor")
+				w.WorkerIsBusy("dnstap-processor", 1)
 			}
 		} else {
 			// ignore first 4 bytes
@@ -181,7 +181,7 @@ func (w *DnstapServer) HandleConn(conn net.Conn, connID uint64, forceClose chan 
 				select {
 				case dnstapProcessor.GetDataChannel() <- data[:payloadSize]: // Successful send to channel
 				default:
-					w.WorkerIsBusy("dnstap-processor")
+					w.WorkerIsBusy("dnstap-processor", 1)
 				}
 
 				// continue for next

--- a/workers/dnstapserver.go
+++ b/workers/dnstapserver.go
@@ -30,9 +30,6 @@ type DnstapServer struct {
 
 func NewDnstapServer(next []Worker, config *pkgconfig.Config, logger *logger.Logger, name string) *DnstapServer {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Collectors.Dnstap.ChannelBufferSize > 0 {
-		bufSize = config.Collectors.Dnstap.ChannelBufferSize
-	}
 	w := &DnstapServer{GenericWorker: NewGenericWorker(config, logger, name, "dnstap", bufSize, pkgconfig.DefaultMonitor)}
 	w.SetDefaultRoutes(next)
 	w.CheckConfig()
@@ -60,9 +57,6 @@ func (w *DnstapServer) HandleConn(conn net.Conn, connID uint64, forceClose chan 
 
 	// start dnstap processor and run it
 	bufSize := w.GetConfig().Global.Worker.ChannelBufferSize
-	if w.GetConfig().Collectors.Dnstap.ChannelBufferSize > 0 {
-		bufSize = w.GetConfig().Collectors.Dnstap.ChannelBufferSize
-	}
 	dnstapProcessor := NewDNSTapProcessor(int(connID), peerName, w.GetConfig(), w.GetLogger(), w.GetName(), bufSize)
 	dnstapProcessor.SetMetrics(w.GetMetrics())
 	dnstapProcessor.SetDefaultRoutes(w.GetDefaultRoutes())

--- a/workers/dnstapserver.go
+++ b/workers/dnstapserver.go
@@ -336,7 +336,8 @@ func (w *DNSTapProcessor) StartCollect() {
 				edt := &dnsutils.ExtendedDnstap{}
 				fCache := &frameCache{}
 				transforms := transformers.NewTransforms(&w.GetConfig().IngoingTransformers, w.GetLogger(), w.GetName(), defaultRoutes, w.ConnID)
-
+				batchSize := w.GetBatchSize()
+				curBatch := dnsutils.AcquireDNSMessageBatch(batchSize)
 				for {
 					select {
 					case cfg := <-cChan:
@@ -344,10 +345,22 @@ func (w *DNSTapProcessor) StartCollect() {
 
 					case data, opened := <-w.GetDataChannel():
 						if !opened {
+							if len(curBatch.Messages) > 0 {
+								w.SendForwardedBatchTo(defaultRoutes, defaultNames, curBatch)
+							} else {
+								curBatch.Release()
+							}
 							transforms.Reset()
 							return
 						}
-						w.processFrame(data, dt, edt, &transforms, fCache, defaultRoutes, defaultNames, droppedRoutes, droppedNames)
+						dm, drop := w.processFrame(data, dt, edt, &transforms, fCache, droppedRoutes, droppedNames)
+						if dm != nil && !drop {
+							curBatch.Messages = append(curBatch.Messages, dm)
+							if len(curBatch.Messages) >= batchSize || len(w.GetDataChannel()) == 0 {
+								w.SendForwardedBatchTo(defaultRoutes, defaultNames, curBatch)
+								curBatch = dnsutils.AcquireDNSMessageBatch(batchSize)
+							}
+						}
 					}
 				}
 			}(cfgChan)
@@ -372,6 +385,8 @@ func (w *DNSTapProcessor) StartCollect() {
 		edt := &dnsutils.ExtendedDnstap{}
 		fCache := &frameCache{}
 		transforms := transformers.NewTransforms(&w.GetConfig().IngoingTransformers, w.GetLogger(), w.GetName(), defaultRoutes, w.ConnID)
+		batchSize := w.GetBatchSize()
+		curBatch := dnsutils.AcquireDNSMessageBatch(batchSize)
 
 		// read incoming dns message
 		for {
@@ -381,16 +396,33 @@ func (w *DNSTapProcessor) StartCollect() {
 				transforms.ReloadConfig(&cfg.IngoingTransformers)
 
 			case <-w.OnStop():
+				if len(curBatch.Messages) > 0 {
+					w.SendForwardedBatchTo(defaultRoutes, defaultNames, curBatch)
+				} else {
+					curBatch.Release()
+				}
 				transforms.Reset()
 				close(w.GetDataChannel())
 				return
 
 			case data, opened := <-w.GetDataChannel():
 				if !opened {
+					if len(curBatch.Messages) > 0 {
+						w.SendForwardedBatchTo(defaultRoutes, defaultNames, curBatch)
+					} else {
+						curBatch.Release()
+					}
 					w.LogInfo("channel closed, exit")
 					return
 				}
-				w.processFrame(data, dt, edt, &transforms, fCache, defaultRoutes, defaultNames, droppedRoutes, droppedNames)
+				dm, drop := w.processFrame(data, dt, edt, &transforms, fCache, droppedRoutes, droppedNames)
+				if dm != nil && !drop {
+					curBatch.Messages = append(curBatch.Messages, dm)
+					if len(curBatch.Messages) >= batchSize || len(w.GetDataChannel()) == 0 {
+						w.SendForwardedBatchTo(defaultRoutes, defaultNames, curBatch)
+						curBatch = dnsutils.AcquireDNSMessageBatch(batchSize)
+					}
+				}
 			}
 		}
 	}
@@ -409,11 +441,9 @@ func (w *DNSTapProcessor) processFrame(
 	edt *dnsutils.ExtendedDnstap,
 	transforms *transformers.Transforms,
 	fCache *frameCache,
-	defaultRoutes []chan *dnsutils.DNSMessage,
-	defaultNames []string,
-	droppedRoutes []chan *dnsutils.DNSMessage,
+	droppedRoutes []chan *dnsutils.DNSMessageBatch,
 	droppedNames []string,
-) {
+) (*dnsutils.DNSMessage, bool) {
 	// count global messages
 	w.CountIngressTraffic()
 
@@ -434,7 +464,7 @@ func (w *DNSTapProcessor) processFrame(
 	if !useFastDecoder {
 		err := proto.Unmarshal(data, dt)
 		if err != nil {
-			return
+			return nil, false
 		}
 	}
 
@@ -495,7 +525,7 @@ func (w *DNSTapProcessor) processFrame(
 		if w.GetConfig().Collectors.Dnstap.ExtendedSupport {
 			err := proto.Unmarshal(dt.GetExtra(), edt)
 			if err != nil {
-				return
+				return nil, false
 			}
 
 			// get original extra value
@@ -697,9 +727,8 @@ func (w *DNSTapProcessor) processFrame(
 	}
 	if transformResult == transformers.ReturnDrop {
 		w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-		return
+		return nil, true
 	}
 
-	// dispatch dns message to connected routes
-	w.SendForwardedTo(defaultRoutes, defaultNames, dm)
+	return dm, false
 }

--- a/workers/dnstapserver_bench_test.go
+++ b/workers/dnstapserver_bench_test.go
@@ -17,7 +17,7 @@ import (
 func benchmarkDNSTapProcessorWithWorkers(b *testing.B, numWorkers int) {
 	config := pkgconfig.GetDefaultConfig()
 	config.Collectors.Dnstap.DisableDNSParser = false
-	config.Collectors.Dnstap.ChannelBufferSize = 65536
+	config.Global.Worker.ChannelBufferSize = 65536
 	config.Collectors.Dnstap.NumWorkers = numWorkers
 
 	devNull := NewDevNull(config, logger.New(false), "devnull")
@@ -35,7 +35,7 @@ func benchmarkDNSTapProcessorWithWorkers(b *testing.B, numWorkers int) {
 		b.Fatalf("dnstap proto marshal error: %v", err)
 	}
 
-	proc := NewDNSTapProcessor(1, "bench-peer", config, logger.New(false), "bench-proc", config.Collectors.Dnstap.ChannelBufferSize)
+	proc := NewDNSTapProcessor(1, "bench-peer", config, logger.New(false), "bench-proc", config.Global.Worker.ChannelBufferSize)
 	proc.SetDefaultRoutes([]Worker{devNull})
 	go proc.StartCollect()
 	defer proc.Stop()
@@ -69,7 +69,7 @@ func Benchmark_DNSTapProcessor_WorkerPool_8(b *testing.B) {
 func Test_DNSTapProcessor_FramestreamBehavior(t *testing.T) {
 	config := pkgconfig.GetDefaultConfig()
 	config.Collectors.Dnstap.DisableDNSParser = false
-	config.Collectors.Dnstap.ChannelBufferSize = 1000
+	config.Global.Worker.ChannelBufferSize = 1000
 
 	devNull := NewDevNull(config, logger.New(false), "devnull")
 	go devNull.StartCollect()
@@ -114,7 +114,7 @@ func benchmarkDnstapServerReadBuf(b *testing.B, readBufSize int) {
 	config := pkgconfig.GetDefaultConfig()
 	config.Collectors.Dnstap.ListenPort = 6001
 	config.Collectors.Dnstap.ReadBufferSize = readBufSize
-	config.Collectors.Dnstap.ChannelBufferSize = 100000
+	config.Global.Worker.ChannelBufferSize = 100000
 
 	devNull := NewDevNull(config, logger.New(false), "devnull")
 	go devNull.StartCollect()

--- a/workers/dnstapserver_test.go
+++ b/workers/dnstapserver_test.go
@@ -134,9 +134,9 @@ func Test_DnstapCollector(t *testing.T) {
 			}
 
 			// waiting message in channel
-			msg := <-g.GetInputChannel()
-			if msg.DNSTap.Operation != tc.operation {
-				t.Errorf("want %s, got %s", tc.operation, msg.DNSTap.Operation)
+			batch := <-g.GetInputChannel()
+			if len(batch.Messages) == 0 || batch.Messages[0].DNSTap.Operation != tc.operation {
+				t.Errorf("want %s, got %v", tc.operation, batch.Messages)
 			}
 
 			c.Stop()
@@ -235,9 +235,9 @@ func Test_DnstapProcessor_toDNSMessage(t *testing.T) {
 	consumer.GetDataChannel() <- data
 
 	// read dns message from dnstap consumer
-	dm := <-fl.GetInputChannel()
-	if dm.DNS.Qname != pkgconfig.ExpectedQname {
-		t.Errorf("invalid qname in dns message: %s", dm.DNS.Qname)
+	batch := <-fl.GetInputChannel()
+	if len(batch.Messages) == 0 || batch.Messages[0].DNS.Qname != pkgconfig.ExpectedQname {
+		t.Errorf("invalid qname in dns message: %v", batch.Messages)
 	}
 }
 
@@ -273,7 +273,11 @@ func Test_DnstapProcessor_DecodeDNSCounters(t *testing.T) {
 	consumer.GetDataChannel() <- data
 
 	// read dns message from dnstap consumer
-	dm := <-fl.GetInputChannel()
+	batch := <-fl.GetInputChannel()
+	if len(batch.Messages) == 0 {
+		t.Fatalf("expected message in batch")
+	}
+	dm := batch.Messages[0]
 	if dm.DNS.QdCount != 1 {
 		t.Errorf("invalid number of questions in dns message: got %d expect 1", dm.DNS.QdCount)
 	}
@@ -320,8 +324,8 @@ func Test_DnstapProcessor_MalformedDnsHeader(t *testing.T) {
 	consumer.GetDataChannel() <- data
 
 	// read dns message from dnstap consumer
-	dm := <-fl.GetInputChannel()
-	if dm.DNS.MalformedPacket == false {
+	batch := <-fl.GetInputChannel()
+	if len(batch.Messages) == 0 || batch.Messages[0].DNS.MalformedPacket == false {
 		t.Errorf("malformed packet not detected")
 	}
 }
@@ -357,8 +361,8 @@ func Test_DnstapProcessor_MalformedDnsQuestion(t *testing.T) {
 	consumer.GetDataChannel() <- data
 
 	// read dns message from dnstap consumer
-	dm := <-fl.GetInputChannel()
-	if dm.DNS.MalformedPacket == false {
+	batch := <-fl.GetInputChannel()
+	if len(batch.Messages) == 0 || batch.Messages[0].DNS.MalformedPacket == false {
 		t.Errorf("malformed packet not detected")
 	}
 }
@@ -395,8 +399,8 @@ func Test_DnstapProcessor_MalformedDnsAnswer(t *testing.T) {
 	consumer.GetDataChannel() <- data
 
 	// read dns message from dnstap consumer
-	dm := <-fl.GetInputChannel()
-	if dm.DNS.MalformedPacket == false {
+	batch := <-fl.GetInputChannel()
+	if len(batch.Messages) == 0 || batch.Messages[0].DNS.MalformedPacket == false {
 		t.Errorf("malformed packet not detected")
 	}
 }
@@ -427,8 +431,8 @@ func Test_DnstapProcessor_EmptyDnsPayload(t *testing.T) {
 	consumer.GetDataChannel() <- data
 
 	// read dns message from dnstap consumer
-	dm := <-fl.GetInputChannel()
-	if dm.DNS.MalformedPacket == true {
+	batch := <-fl.GetInputChannel()
+	if len(batch.Messages) == 0 || batch.Messages[0].DNS.MalformedPacket == true {
 		t.Errorf("malformed packet detected, should not with empty payload")
 	}
 }
@@ -468,9 +472,9 @@ func Test_DnstapProcessor_DisableDNSParser(t *testing.T) {
 	consumer.GetDataChannel() <- data
 
 	// read dns message from dnstap consumer
-	dm := <-fl.GetInputChannel()
-	if dm.DNS.ID != 0 {
-		t.Errorf("DNS ID should be equal to zero: %d", dm.DNS.ID)
+	batch := <-fl.GetInputChannel()
+	if len(batch.Messages) == 0 || batch.Messages[0].DNS.ID != 0 {
+		t.Errorf("DNS ID should be equal to zero: %v", batch.Messages)
 	}
 }
 
@@ -528,7 +532,11 @@ func Test_DnstapProcessor_Extended(t *testing.T) {
 	consumer.GetDataChannel() <- data
 
 	// read dns message from dnstap consumer
-	dm := <-fl.GetInputChannel()
+	batch := <-fl.GetInputChannel()
+	if len(batch.Messages) == 0 {
+		t.Fatalf("expected message in batch")
+	}
+	dm := batch.Messages[0]
 	if dm.DNSTap.Extra != "originalextrafield" {
 		t.Errorf("invalid extra field: %s", dm.DNSTap.Extra)
 	}
@@ -596,9 +604,9 @@ func Test_DnstapProcessor_BufferLoggerIsFull(t *testing.T) {
 	}
 
 	// read dns message from dnstap consumer
-	dm := <-fl.GetInputChannel()
-	if dm.DNS.Qname != pkgconfig.ExpectedQname {
-		t.Errorf("invalid qname in dns message: %s", dm.DNS.Qname)
+	batch := <-fl.GetInputChannel()
+	if len(batch.Messages) == 0 || batch.Messages[0].DNS.Qname != pkgconfig.ExpectedQname {
+		t.Errorf("invalid qname in dns message: %v", batch.Messages)
 	}
 
 	// send second shot of packets to consumer
@@ -618,9 +626,9 @@ func Test_DnstapProcessor_BufferLoggerIsFull(t *testing.T) {
 	}
 
 	// read dns message from dnstap consumer
-	dm2 := <-fl.GetInputChannel()
-	if dm2.DNS.Qname != pkgconfig.ExpectedQname {
-		t.Errorf("invalid qname in second dns message: %s", dm2.DNS.Qname)
+	batch2 := <-fl.GetInputChannel()
+	if len(batch2.Messages) == 0 || batch2.Messages[0].DNS.Qname != pkgconfig.ExpectedQname {
+		t.Errorf("invalid qname in second dns message: %v", batch2.Messages)
 	}
 }
 

--- a/workers/dnstapserver_test.go
+++ b/workers/dnstapserver_test.go
@@ -560,12 +560,14 @@ func Test_DnstapProcessor_BufferLoggerIsFull(t *testing.T) {
 	fl := GetWorkerForTest(pkgconfig.DefaultBufferOne)
 
 	// redirect stdout output to bytes buffer
-	logsChan := make(chan logger.LogEntry, 30)
+	logsChan := make(chan logger.LogEntry, 512)
 	lg := logger.New(true)
 	lg.SetOutputChannel((logsChan))
 
 	// init the dnstap consumer
-	consumer := NewDNSTapProcessor(0, "peertest", pkgconfig.GetDefaultConfig(), lg, "test", 512)
+	cfg := pkgconfig.GetDefaultConfig()
+	cfg.Global.Worker.BatchSize = 1
+	consumer := NewDNSTapProcessor(0, "peertest", cfg, lg, "test", 512)
 	consumer.AddDefaultRoute(fl)
 	consumer.AddDroppedRoute(fl)
 

--- a/workers/elasticsearch.go
+++ b/workers/elasticsearch.go
@@ -109,25 +109,28 @@ func (w *ElasticSearchClient) StartCollect() {
 			w.ReadConfig()
 			subprocessors.ReloadConfig(&cfg.OutgoingTransformers)
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("input channel closed!")
 				return
 			}
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// apply transforms, init dns message with additional parts if necessary
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
+				// apply transforms, init dns message with additional parts if necessary
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
 
-			w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+				w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+			}
+			batch.Release()
 		}
 	}
 }
@@ -160,42 +163,43 @@ func (w *ElasticSearchClient) StartLogging() {
 			return
 
 			// incoming dns message to process
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
 			}
 
-			if dm.Relabeling != nil {
-				flat, err := dm.Flatten()
-				if err != nil {
-					w.LogError("flattening DNS message failed: %e", err)
-					w.CountEgressDiscarded()
-					dm.Release()
-					continue
+			for _, dm := range batch.Messages {
+				if dm.Relabeling != nil {
+					flat, err := dm.Flatten()
+					if err != nil {
+						w.LogError("flattening DNS message failed: %e", err)
+						w.CountEgressDiscarded()
+						continue
+					}
+					buffer.WriteString("{ \"create\" : {}}\n")
+					encoder.Encode(flat)
+				} else {
+					buffer.WriteString("{ \"create\" : {}}\n")
+					dm.GetTimestampRFC3339()
+					dm.EncodeFlatJSON(buffer)
+					buffer.WriteByte('\n')
 				}
-				buffer.WriteString("{ \"create\" : {}}\n")
-				encoder.Encode(flat)
-			} else {
-				buffer.WriteString("{ \"create\" : {}}\n")
-				dm.GetTimestampRFC3339()
-				dm.EncodeFlatJSON(buffer)
-				buffer.WriteByte('\n')
-			}
 
-			// Send data and reset buffer
-			if buffer.Len() >= w.GetConfig().Loggers.ElasticSearchClient.BulkSize {
-				bufCopy := make([]byte, buffer.Len())
-				copy(bufCopy, buffer.Bytes())
-				buffer.Reset()
+				// Send data and reset buffer
+				if buffer.Len() >= w.GetConfig().Loggers.ElasticSearchClient.BulkSize {
+					bufCopy := make([]byte, buffer.Len())
+					copy(bufCopy, buffer.Bytes())
+					buffer.Reset()
 
-				select {
-				case dataBuffer <- bufCopy:
-				default:
-					w.LogWarning("Send buffer is full, bulk dropped")
+					select {
+					case dataBuffer <- bufCopy:
+					default:
+						w.LogWarning("Send buffer is full, bulk dropped")
+					}
 				}
 			}
-			dm.Release()
+			batch.Release()
 
 		// flush the buffer every ?
 		case <-ticker.C:

--- a/workers/elasticsearch.go
+++ b/workers/elasticsearch.go
@@ -25,9 +25,6 @@ type ElasticSearchClient struct {
 
 func NewElasticSearchClient(config *pkgconfig.Config, console *logger.Logger, name string) *ElasticSearchClient {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.ElasticSearchClient.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.ElasticSearchClient.ChannelBufferSize
-	}
 	w := &ElasticSearchClient{GenericWorker: NewGenericWorker(config, console, name, "elasticsearch", bufSize, pkgconfig.DefaultMonitor)}
 	w.httpClient = &http.Client{Timeout: 5 * time.Second}
 	w.ReadConfig()

--- a/workers/elasticsearch_test.go
+++ b/workers/elasticsearch_test.go
@@ -92,7 +92,7 @@ func Test_ElasticSearchClient_BulkSize_Exceeded(t *testing.T) {
 
 			for i := 0; i < tc.inputSize; i++ {
 				dm := dnsutils.GetFakeDNSMessage()
-				g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+				g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 			}
 
 			try := 0
@@ -148,7 +148,7 @@ func Test_ElasticSearchClient_FlushInterval_Exceeded(t *testing.T) {
 			// send DNSmessage
 			for i := 0; i < tc.inputSize; i++ {
 				dm := dnsutils.GetFakeDNSMessage()
-				g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+				g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 			}
 			time.Sleep(6 * time.Second)
 

--- a/workers/elasticsearch_test.go
+++ b/workers/elasticsearch_test.go
@@ -92,7 +92,7 @@ func Test_ElasticSearchClient_BulkSize_Exceeded(t *testing.T) {
 
 			for i := 0; i < tc.inputSize; i++ {
 				dm := dnsutils.GetFakeDNSMessage()
-				g.GetInputChannel() <- &dm
+				g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 			}
 
 			try := 0
@@ -148,7 +148,7 @@ func Test_ElasticSearchClient_FlushInterval_Exceeded(t *testing.T) {
 			// send DNSmessage
 			for i := 0; i < tc.inputSize; i++ {
 				dm := dnsutils.GetFakeDNSMessage()
-				g.GetInputChannel() <- &dm
+				g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 			}
 			time.Sleep(6 * time.Second)
 

--- a/workers/falco.go
+++ b/workers/falco.go
@@ -17,9 +17,6 @@ type FalcoClient struct {
 
 func NewFalcoClient(config *pkgconfig.Config, console *logger.Logger, name string) *FalcoClient {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.FalcoClient.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.FalcoClient.ChannelBufferSize
-	}
 	w := &FalcoClient{GenericWorker: NewGenericWorker(config, console, name, "falco", bufSize, pkgconfig.DefaultMonitor)}
 	w.ReadConfig()
 	return w

--- a/workers/falco.go
+++ b/workers/falco.go
@@ -49,25 +49,27 @@ func (w *FalcoClient) StartCollect() {
 			w.ReadConfig()
 			subprocessors.ReloadConfig(&cfg.OutgoingTransformers)
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("input channel closed!")
 				return
 			}
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// apply transforms, init dns message with additional parts if necessary
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
+				// apply transforms, init dns message with additional parts if necessary
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
+				w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
 			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
-
-			w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+			batch.Release()
 		}
 	}
 }
@@ -84,28 +86,29 @@ func (w *FalcoClient) StartLogging() {
 			return
 
 		// incoming dns message to process
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
 			}
+			for _, dm := range batch.Messages {
+				// encode
+				json.NewEncoder(buffer).Encode(dm)
 
-			// encode
-			json.NewEncoder(buffer).Encode(dm)
+				req, _ := http.NewRequest("POST", w.GetConfig().Loggers.FalcoClient.URL, buffer)
+				req.Header.Set("Content-Type", "application/json")
+				client := &http.Client{
+					Timeout: 5 * time.Second,
+				}
+				_, err := client.Do(req)
+				if err != nil {
+					w.LogError(err.Error())
+				}
 
-			req, _ := http.NewRequest("POST", w.GetConfig().Loggers.FalcoClient.URL, buffer)
-			req.Header.Set("Content-Type", "application/json")
-			client := &http.Client{
-				Timeout: 5 * time.Second,
+				// finally reset the buffer for next iter
+				buffer.Reset()
 			}
-			_, err := client.Do(req)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-
-			// finally reset the buffer for next iter
-			buffer.Reset()
-			dm.Release()
+			batch.Release()
 		}
 	}
 }

--- a/workers/falco_test.go
+++ b/workers/falco_test.go
@@ -39,7 +39,7 @@ func Test_FalcoClient(t *testing.T) {
 			go g.StartCollect()
 
 			dm := dnsutils.GetFakeDNSMessage()
-			g.GetInputChannel() <- &dm
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 			// accept conn
 			conn, err := fakeRcvr.Accept()

--- a/workers/falco_test.go
+++ b/workers/falco_test.go
@@ -39,7 +39,7 @@ func Test_FalcoClient(t *testing.T) {
 			go g.StartCollect()
 
 			dm := dnsutils.GetFakeDNSMessage()
-			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 			// accept conn
 			conn, err := fakeRcvr.Accept()

--- a/workers/file_ingestor.go
+++ b/workers/file_ingestor.go
@@ -156,7 +156,9 @@ func (w *FileIngestor) ProcessPcap(filePath string) {
 				nbPackets++
 
 				// send DNS message to DNS processor
-				w.dnsProcessor.GetInputChannel() <- dm
+				b := dnsutils.AcquireDNSMessageBatch(1)
+				b.Messages = append(b.Messages, dm)
+				w.dnsProcessor.GetInputChannel() <- b
 			case <-time.After(10 * time.Second):
 				elapsed := time.Since(lastReceivedTime)
 				if elapsed >= 10*time.Second {

--- a/workers/file_ingestor.go
+++ b/workers/file_ingestor.go
@@ -43,9 +43,6 @@ type FileIngestor struct {
 
 func NewFileIngestor(next []Worker, config *pkgconfig.Config, logger *logger.Logger, name string) *FileIngestor {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Collectors.FileIngestor.ChannelBufferSize > 0 {
-		bufSize = config.Collectors.FileIngestor.ChannelBufferSize
-	}
 	w := &FileIngestor{
 		GenericWorker: NewGenericWorker(config, logger, name, "fileingestor", bufSize, pkgconfig.DefaultMonitor),
 		watcherTimers: make(map[string]*time.Timer)}
@@ -314,9 +311,6 @@ func (w *FileIngestor) StartCollect() {
 	defer w.CollectDone()
 
 	bufSize := w.GetConfig().Global.Worker.ChannelBufferSize
-	if w.GetConfig().Collectors.FileIngestor.ChannelBufferSize > 0 {
-		bufSize = w.GetConfig().Collectors.FileIngestor.ChannelBufferSize
-	}
 
 	dnsProcessor := NewDNSProcessor(w.GetConfig(), w.GetLogger(), w.GetName(), bufSize)
 	dnsProcessor.SetDefaultRoutes(w.GetDefaultRoutes())

--- a/workers/file_ingestor_test.go
+++ b/workers/file_ingestor_test.go
@@ -42,10 +42,10 @@ func Test_FileIngestor(t *testing.T) {
 			// waiting message in channel
 			for {
 				// read dns message from channel
-				msg := <-g.GetInputChannel()
+				batch := <-g.GetInputChannel()
 
 				// check qname
-				if msg.DNSTap.Operation == dnsutils.DNSTapClientQuery {
+				if len(batch.Messages) > 0 && batch.Messages[0].DNSTap.Operation == dnsutils.DNSTapClientQuery {
 					break
 				}
 			}

--- a/workers/file_tail.go
+++ b/workers/file_tail.go
@@ -53,6 +53,8 @@ func (w *Tail) StartCollect() {
 	defaultRoutes, defaultNames := GetRoutes(w.GetDefaultRoutes())
 	droppedRoutes, droppedNames := GetRoutes(w.GetDroppedRoutes())
 	subprocessors := transformers.NewTransforms(&w.GetConfig().IngoingTransformers, w.GetLogger(), w.GetName(), defaultRoutes, 0)
+	batchSize := w.GetBatchSize()
+	curBatch := dnsutils.AcquireDNSMessageBatch(batchSize)
 
 	// init dns message
 	dm := dnsutils.DNSMessage{}
@@ -75,10 +77,23 @@ func (w *Tail) StartCollect() {
 
 		case <-w.OnStop():
 			w.LogInfo("stopping...")
+			if len(curBatch.Messages) > 0 {
+				w.SendForwardedBatchTo(defaultRoutes, defaultNames, curBatch)
+			} else {
+				curBatch.Release()
+			}
 			subprocessors.Reset()
 			return
 
-		case line := <-w.tailf.Lines:
+		case line, opened := <-w.tailf.Lines:
+			if !opened {
+				if len(curBatch.Messages) > 0 {
+					w.SendForwardedBatchTo(defaultRoutes, defaultNames, curBatch)
+				} else {
+					curBatch.Release()
+				}
+				return
+			}
 			dm := dnsutils.AcquireDNSMessage()
 			dm.Init()
 
@@ -232,8 +247,12 @@ func (w *Tail) StartCollect() {
 				continue
 			}
 
-			// send to next ?
-			w.SendForwardedTo(defaultRoutes, defaultNames, dm)
+			// append to batch and dispatch
+			curBatch.Messages = append(curBatch.Messages, dm)
+			if len(curBatch.Messages) >= batchSize || len(w.tailf.Lines) == 0 {
+				w.SendForwardedBatchTo(defaultRoutes, defaultNames, curBatch)
+				curBatch = dnsutils.AcquireDNSMessageBatch(batchSize)
+			}
 		}
 	}
 }

--- a/workers/file_tail.go
+++ b/workers/file_tail.go
@@ -24,9 +24,6 @@ type Tail struct {
 
 func NewTail(next []Worker, config *pkgconfig.Config, logger *logger.Logger, name string) *Tail {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Collectors.Tail.ChannelBufferSize > 0 {
-		bufSize = config.Collectors.Tail.ChannelBufferSize
-	}
 	w := &Tail{GenericWorker: NewGenericWorker(config, logger, name, "tail", bufSize, pkgconfig.DefaultMonitor)}
 	w.SetDefaultRoutes(next)
 	return w

--- a/workers/file_tail_test.go
+++ b/workers/file_tail_test.go
@@ -43,8 +43,8 @@ func TestTailRun(t *testing.T) {
 	w.Flush()
 
 	// waiting message in channel
-	msg := <-g.GetInputChannel()
-	if msg.DNS.Qname != "www.google.org" {
-		t.Errorf("want www.google.org, got %s", msg.DNS.Qname)
+	batch := <-g.GetInputChannel()
+	if len(batch.Messages) == 0 || batch.Messages[0].DNS.Qname != "www.google.org" {
+		t.Errorf("want www.google.org, got %v", batch.Messages)
 	}
 }

--- a/workers/fluentd.go
+++ b/workers/fluentd.go
@@ -24,9 +24,6 @@ type FluentdClient struct {
 
 func NewFluentdClient(config *pkgconfig.Config, logger *logger.Logger, name string) *FluentdClient {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.Fluentd.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.Fluentd.ChannelBufferSize
-	}
 	w := &FluentdClient{GenericWorker: NewGenericWorker(config, logger, name, "fluentd", bufSize, pkgconfig.DefaultMonitor)}
 	w.transportReady = make(chan bool)
 	w.transportReconnect = make(chan bool)

--- a/workers/fluentd.go
+++ b/workers/fluentd.go
@@ -192,25 +192,28 @@ func (w *FluentdClient) StartCollect() {
 			w.ReadConfig()
 			subprocessors.ReloadConfig(&cfg.OutgoingTransformers)
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("input channel closed!")
 				return
 			}
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// apply transforms, init dns message with additional parts if necessary
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
+				// apply transforms, init dns message with additional parts if necessary
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
 
-			w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+				w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+			}
+			batch.Release()
 		}
 	}
 }
@@ -236,27 +239,30 @@ func (w *FluentdClient) StartLogging() {
 			w.writerReady = true
 
 			// incoming dns message to process
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
 			}
 
-			// drop dns message if the connection is not ready to avoid memory leak or
-			// to block the channel
-			if !w.writerReady {
-				w.CountEgressDiscarded()
-				dm.Release()
-				continue
-			}
+			for _, dm := range batch.Messages {
+				// drop dns message if the connection is not ready to avoid memory leak or
+				// to block the channel
+				if !w.writerReady {
+					w.CountEgressDiscarded()
+					continue
+				}
 
-			// append dns message to buffer
-			bufferDm = append(bufferDm, dm)
+				dm.Retain(1)
+				// append dns message to buffer
+				bufferDm = append(bufferDm, dm)
 
-			// buffer is full ?
-			if len(bufferDm) >= w.GetConfig().Loggers.Fluentd.BufferSize {
-				w.FlushBuffer(&bufferDm)
+				// buffer is full ?
+				if len(bufferDm) >= w.GetConfig().Loggers.Fluentd.BufferSize {
+					w.FlushBuffer(&bufferDm)
+				}
 			}
+			batch.Release()
 
 		// flush the buffer
 		case <-flushTimer.C:

--- a/workers/fluentd_test.go
+++ b/workers/fluentd_test.go
@@ -60,7 +60,7 @@ func Test_FluentdClient(t *testing.T) {
 			maxDm := 256
 			for i := 0; i < maxDm; i++ {
 				dm := dnsutils.GetFakeDNSMessage()
-				g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+				g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 			}
 			time.Sleep(time.Second)
 

--- a/workers/fluentd_test.go
+++ b/workers/fluentd_test.go
@@ -60,7 +60,7 @@ func Test_FluentdClient(t *testing.T) {
 			maxDm := 256
 			for i := 0; i < maxDm; i++ {
 				dm := dnsutils.GetFakeDNSMessage()
-				g.GetInputChannel() <- &dm
+				g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 			}
 			time.Sleep(time.Second)
 

--- a/workers/influxdb.go
+++ b/workers/influxdb.go
@@ -20,9 +20,6 @@ type InfluxDBClient struct {
 
 func NewInfluxDBClient(config *pkgconfig.Config, logger *logger.Logger, name string) *InfluxDBClient {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.InfluxDB.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.InfluxDB.ChannelBufferSize
-	}
 	w := &InfluxDBClient{GenericWorker: NewGenericWorker(config, logger, name, "influxdb", bufSize, pkgconfig.DefaultMonitor)}
 	w.ReadConfig()
 	return w

--- a/workers/influxdb.go
+++ b/workers/influxdb.go
@@ -53,25 +53,28 @@ func (w *InfluxDBClient) StartCollect() {
 			w.ReadConfig()
 			subprocessors.ReloadConfig(&cfg.OutgoingTransformers)
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("input channel closed!")
 				return
 			}
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// apply transforms, init dns message with additional parts if necessary
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
+				// apply transforms, init dns message with additional parts if necessary
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
 
-			w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+				w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+			}
+			batch.Release()
 		}
 	}
 }
@@ -124,26 +127,28 @@ func (w *InfluxDBClient) StartLogging() {
 			return
 
 			// incoming dns message to process
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
 			}
 
-			p := influxdb2.NewPointWithMeasurement("dns").
-				AddTag("Identity", dm.DNSTap.Identity).
-				AddTag("QueryIP", dm.NetworkInfo.GetQueryIP()).
-				AddTag("Qname", dm.DNS.Qname).
-				AddField("Operation", dm.DNSTap.Operation).
-				AddField("Family", dm.NetworkInfo.Family).
-				AddField("Protocol", dm.NetworkInfo.Protocol).
-				AddField("Qtype", dm.DNS.Qtype).
-				AddField("Rcode", dm.DNS.Rcode).
-				SetTime(time.Unix(int64(dm.DNSTap.TimeSec), int64(dm.DNSTap.TimeNsec)))
+			for _, dm := range batch.Messages {
+				p := influxdb2.NewPointWithMeasurement("dns").
+					AddTag("Identity", dm.DNSTap.Identity).
+					AddTag("QueryIP", dm.NetworkInfo.GetQueryIP()).
+					AddTag("Qname", dm.DNS.Qname).
+					AddField("Operation", dm.DNSTap.Operation).
+					AddField("Family", dm.NetworkInfo.Family).
+					AddField("Protocol", dm.NetworkInfo.Protocol).
+					AddField("Qtype", dm.DNS.Qtype).
+					AddField("Rcode", dm.DNS.Rcode).
+					SetTime(time.Unix(int64(dm.DNSTap.TimeSec), int64(dm.DNSTap.TimeNsec)))
 
-			// write asynchronously
-			w.writeAPI.WritePoint(p)
-			dm.Release()
+				// write asynchronously
+				w.writeAPI.WritePoint(p)
+			}
+			batch.Release()
 		}
 	}
 }

--- a/workers/influxdb_test.go
+++ b/workers/influxdb_test.go
@@ -29,7 +29,7 @@ func Test_InfluxDB(t *testing.T) {
 
 	// send fake dns message to logger
 	dm := dnsutils.GetFakeDNSMessage()
-	g.GetInputChannel() <- &dm
+	g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 	// accept conn
 	conn, err := fakeRcvr.Accept()

--- a/workers/influxdb_test.go
+++ b/workers/influxdb_test.go
@@ -29,7 +29,7 @@ func Test_InfluxDB(t *testing.T) {
 
 	// send fake dns message to logger
 	dm := dnsutils.GetFakeDNSMessage()
-	g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+	g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 	// accept conn
 	conn, err := fakeRcvr.Accept()

--- a/workers/kafkaproducer.go
+++ b/workers/kafkaproducer.go
@@ -450,25 +450,28 @@ func (w *KafkaProducer) StartCollect() {
 			w.ReadConfig()
 			subprocessors.ReloadConfig(&cfg.OutgoingTransformers)
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("input channel closed!")
 				return
 			}
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// apply transforms, init dns message with additional parts if necessary
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
+				// apply transforms, init dns message with additional parts if necessary
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
 
-			w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+				w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+			}
+			batch.Release()
 		}
 	}
 }
@@ -526,7 +529,7 @@ func (w *KafkaProducer) StartLogging() {
 			}
 
 		// incoming dns message to process
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
@@ -536,21 +539,24 @@ func (w *KafkaProducer) StartLogging() {
 			connected := w.kafkaConnected
 			w.connMutex.RUnlock()
 
-			// drop dns message if the connection is not ready to avoid memory leak or
-			// to block the channel
-			if !connected {
-				w.CountEgressDiscarded()
-				dm.Release()
-				continue
-			}
+			for _, dm := range batch.Messages {
+				// drop dns message if the connection is not ready to avoid memory leak or
+				// to block the channel
+				if !connected {
+					w.CountEgressDiscarded()
+					continue
+				}
 
-			// append dns message to buffer
-			bufferDm = append(bufferDm, dm)
+				dm.Retain(1)
+				// append dns message to buffer
+				bufferDm = append(bufferDm, dm)
 
-			// buffer is full ?
-			if len(bufferDm) >= w.GetConfig().Loggers.KafkaProducer.BatchSize {
-				w.FlushBuffer(&bufferDm)
+				// buffer is full ?
+				if len(bufferDm) >= w.GetConfig().Loggers.KafkaProducer.BatchSize {
+					w.FlushBuffer(&bufferDm)
+				}
 			}
+			batch.Release()
 
 		// flush the buffer
 		case <-flushTimer.C:

--- a/workers/kafkaproducer.go
+++ b/workers/kafkaproducer.go
@@ -45,9 +45,6 @@ type KafkaProducer struct {
 
 func NewKafkaProducer(config *pkgconfig.Config, logger *logger.Logger, name string) *KafkaProducer {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.KafkaProducer.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.KafkaProducer.ChannelBufferSize
-	}
 	w := &KafkaProducer{
 		GenericWorker: NewGenericWorker(config, logger, name, "kafka", bufSize, pkgconfig.DefaultMonitor),
 		// kafkaReady:     make(chan bool),

--- a/workers/kafkaproducer_test.go
+++ b/workers/kafkaproducer_test.go
@@ -99,7 +99,7 @@ func Test_KafkaProducer_Send(t *testing.T) {
 
 			time.Sleep(1 * time.Second)
 			dm := dnsutils.GetFakeDNSMessage()
-			producer.GetInputChannel() <- &dm
+			producer.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 			time.Sleep(1 * time.Second)
 
 			if count := countProduceRequests(broker); count == 0 {
@@ -127,7 +127,7 @@ func Test_KafkaProducer_MultipleAddresses(t *testing.T) {
 
 	// Send a fake DNS message
 	dm := dnsutils.GetFakeDNSMessage()
-	producer.GetInputChannel() <- &dm
+	producer.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 	time.Sleep(1 * time.Second)
 
 	if count := countProduceRequests(broker); count == 0 {
@@ -147,7 +147,7 @@ func Test_KafkaProducer_Reconnect(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 	dm1 := dnsutils.GetFakeDNSMessage()
-	producer.GetInputChannel() <- &dm1
+	producer.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm1)
 	time.Sleep(1 * time.Second)
 
 	if count := countProduceRequests(broker1); count == 0 {
@@ -169,10 +169,10 @@ func Test_KafkaProducer_Reconnect(t *testing.T) {
 
 	// Send another fake DNS message after reconnect
 	dm2 := dnsutils.GetFakeDNSMessage()
-	producer.GetInputChannel() <- &dm2
+	producer.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm2)
 	time.Sleep(3 * time.Second)
 	dm3 := dnsutils.GetFakeDNSMessage()
-	producer.GetInputChannel() <- &dm3
+	producer.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm3)
 	time.Sleep(3 * time.Second)
 
 	// Verify that the new broker received ProduceRequests

--- a/workers/kafkaproducer_test.go
+++ b/workers/kafkaproducer_test.go
@@ -99,7 +99,7 @@ func Test_KafkaProducer_Send(t *testing.T) {
 
 			time.Sleep(1 * time.Second)
 			dm := dnsutils.GetFakeDNSMessage()
-			producer.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+			producer.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 			time.Sleep(1 * time.Second)
 
 			if count := countProduceRequests(broker); count == 0 {
@@ -127,7 +127,7 @@ func Test_KafkaProducer_MultipleAddresses(t *testing.T) {
 
 	// Send a fake DNS message
 	dm := dnsutils.GetFakeDNSMessage()
-	producer.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+	producer.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 	time.Sleep(1 * time.Second)
 
 	if count := countProduceRequests(broker); count == 0 {
@@ -147,7 +147,7 @@ func Test_KafkaProducer_Reconnect(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 	dm1 := dnsutils.GetFakeDNSMessage()
-	producer.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm1)
+	producer.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm1)
 	time.Sleep(1 * time.Second)
 
 	if count := countProduceRequests(broker1); count == 0 {
@@ -169,10 +169,10 @@ func Test_KafkaProducer_Reconnect(t *testing.T) {
 
 	// Send another fake DNS message after reconnect
 	dm2 := dnsutils.GetFakeDNSMessage()
-	producer.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm2)
+	producer.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm2)
 	time.Sleep(3 * time.Second)
 	dm3 := dnsutils.GetFakeDNSMessage()
-	producer.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm3)
+	producer.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm3)
 	time.Sleep(3 * time.Second)
 
 	// Verify that the new broker received ProduceRequests

--- a/workers/logfile.go
+++ b/workers/logfile.go
@@ -529,26 +529,29 @@ func (w *LogFile) StartCollect() {
 			w.ReadConfig()
 			subprocessors.ReloadConfig(&cfg.OutgoingTransformers)
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("input channel closed!")
 				return
 			}
 
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// apply transforms, init dns message with additional parts if necessary
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
+				// apply transforms, init dns message with additional parts if necessary
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
 
-			w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+				w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+			}
+			batch.Release()
 		}
 	}
 }
@@ -597,120 +600,117 @@ func (w *LogFile) StartLogging() {
 
 			return
 
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
 			}
 
-			// Process the message based on the configured mode
-			switch w.GetConfig().Loggers.LogFile.Mode {
+			for _, dm := range batch.Messages {
+				// Process the message based on the configured mode
+				switch w.GetConfig().Loggers.LogFile.Mode {
 
-			// with basic text mode
-			case pkgconfig.ModeText:
-				// get a text buffer from pool
-				buf := w.GetTextBuffer()
-				buf.Reset()
+				// with basic text mode
+				case pkgconfig.ModeText:
+					// get a text buffer from pool
+					buf := w.GetTextBuffer()
+					buf.Reset()
 
-				// encode to text line the dns message
-				var err error
-				if w.textFormatter != nil {
-					err = w.textFormatter.Format(dm, buf)
-				} else {
-					err = dm.ToTextLine(
-						w.textFormat,
-						w.GetConfig().Global.TextFormatDelimiter,
-						w.GetConfig().Global.TextFormatBoundary,
-						buf,
-					)
-				}
-				if err != nil {
-					w.CountEgressDiscarded()
-					w.LogError("logfile: could not encode to text format: %s", err)
-					w.PutTextBuffer(buf)
-					dm.Release()
-					break
-				}
-
-				// ensure it ends in a \n
-				data := buf.Bytes()
-				if len(data) == 0 || data[len(data)-1] != '\n' {
-					buf.WriteByte('\n')
-				}
-
-				// write and return text buffer to pool
-				w.WriteToPlain(buf.Bytes())
-				w.PutTextBuffer(buf)
-
-			// with custom text mode
-			case pkgconfig.ModeJinja:
-				textLine, err := dm.ToTextTemplate(w.jinjaFormat)
-				if err != nil {
-					w.CountEgressDiscarded()
-					w.LogError("jinja template: %s", err)
-					dm.Release()
-					continue
-				}
-				data := []byte(textLine)
-				if len(data) > 0 && data[len(data)-1] != '\n' {
-					data = append(data, '\n')
-				}
-				w.WriteToPlain(data)
-
-			// with json mode
-			case pkgconfig.ModeJSON, pkgconfig.ModeFlatJSON:
-				buf := w.GetTextBuffer()
-				buf.Reset()
-
-				if w.GetConfig().Loggers.LogFile.Mode == pkgconfig.ModeFlatJSON {
-					if dm.Relabeling != nil {
-						flat, err := dm.Flatten()
-						if err != nil {
-							w.CountEgressDiscarded()
-							w.LogError("flattening DNS message failed: %e", err)
-							w.PutTextBuffer(buf)
-							dm.Release()
-							continue
-						}
-						json.NewEncoder(buf).Encode(flat)
+					// encode to text line the dns message
+					var err error
+					if w.textFormatter != nil {
+						err = w.textFormatter.Format(dm, buf)
 					} else {
-						dm.GetTimestampRFC3339()
-						dm.EncodeFlatJSON(buf)
+						err = dm.ToTextLine(
+							w.textFormat,
+							w.GetConfig().Global.TextFormatDelimiter,
+							w.GetConfig().Global.TextFormatBoundary,
+							buf,
+						)
+					}
+					if err != nil {
+						w.CountEgressDiscarded()
+						w.LogError("logfile: could not encode to text format: %s", err)
+						w.PutTextBuffer(buf)
+						continue
+					}
+
+					// ensure it ends in a \n
+					data := buf.Bytes()
+					if len(data) == 0 || data[len(data)-1] != '\n' {
 						buf.WriteByte('\n')
 					}
-				} else {
-					json.NewEncoder(buf).Encode(dm)
+
+					// write and return text buffer to pool
+					w.WriteToPlain(buf.Bytes())
+					w.PutTextBuffer(buf)
+
+				// with custom text mode
+				case pkgconfig.ModeJinja:
+					textLine, err := dm.ToTextTemplate(w.jinjaFormat)
+					if err != nil {
+						w.CountEgressDiscarded()
+						w.LogError("jinja template: %s", err)
+						continue
+					}
+					data := []byte(textLine)
+					if len(data) > 0 && data[len(data)-1] != '\n' {
+						data = append(data, '\n')
+					}
+					w.WriteToPlain(data)
+
+				// with json mode
+				case pkgconfig.ModeJSON, pkgconfig.ModeFlatJSON:
+					buf := w.GetTextBuffer()
+					buf.Reset()
+
+					if w.GetConfig().Loggers.LogFile.Mode == pkgconfig.ModeFlatJSON {
+						if dm.Relabeling != nil {
+							flat, err := dm.Flatten()
+							if err != nil {
+								w.CountEgressDiscarded()
+								w.LogError("flattening DNS message failed: %e", err)
+								w.PutTextBuffer(buf)
+								continue
+							}
+							json.NewEncoder(buf).Encode(flat)
+						} else {
+							dm.GetTimestampRFC3339()
+							dm.EncodeFlatJSON(buf)
+							buf.WriteByte('\n')
+						}
+					} else {
+						json.NewEncoder(buf).Encode(dm)
+					}
+
+					// send to file and return buffer to pool
+					w.WriteToPlain(buf.Bytes())
+					w.PutTextBuffer(buf)
+
+				// with dnstap mode
+				case pkgconfig.ModeDNSTap:
+					data, err := dm.ToDNSTap(w.GetConfig().Loggers.LogFile.ExtendedSupport)
+					if err != nil {
+						w.CountEgressDiscarded()
+						w.LogError("failed to encode to DNStap protobuf: %s", err)
+						continue
+					}
+					w.WriteToDnstap(data)
+
+				// with pcap mode
+				case pkgconfig.ModePCAP:
+					pkt, err := dm.ToPacketLayer(w.GetConfig().Loggers.LogFile.OverwriteDNSPortPcap)
+					if err != nil {
+						w.CountEgressDiscarded()
+						w.LogError("failed to encode to packet layer: %s", err)
+						continue
+					}
+
+					// write the packet
+					w.WriteToPcap(dm, pkt)
 				}
-
-				// send to file and return buffer to pool
-				w.WriteToPlain(buf.Bytes())
-				w.PutTextBuffer(buf)
-
-			// with dnstap mode
-			case pkgconfig.ModeDNSTap:
-				data, err := dm.ToDNSTap(w.GetConfig().Loggers.LogFile.ExtendedSupport)
-				if err != nil {
-					w.CountEgressDiscarded()
-					w.LogError("failed to encode to DNStap protobuf: %s", err)
-					dm.Release()
-					continue
-				}
-				w.WriteToDnstap(data)
-
-			// with pcap mode
-			case pkgconfig.ModePCAP:
-				pkt, err := dm.ToPacketLayer(w.GetConfig().Loggers.LogFile.OverwriteDNSPortPcap)
-				if err != nil {
-					w.CountEgressDiscarded()
-					w.LogError("failed to encode to packet layer: %s", err)
-					dm.Release()
-					continue
-				}
-
-				// write the packet
-				w.WriteToPcap(dm, pkt)
 			}
-			dm.Release()
+			batch.Release()
 
 		case <-flushTicker.C:
 			w.FlushWriters()

--- a/workers/logfile.go
+++ b/workers/logfile.go
@@ -66,9 +66,6 @@ type LogFile struct {
 
 func NewLogFile(config *pkgconfig.Config, logger *logger.Logger, name string) *LogFile {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.LogFile.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.LogFile.ChannelBufferSize
-	}
 	w := &LogFile{
 		GenericWorker: NewGenericWorker(config, logger, name, "file", bufSize, pkgconfig.DefaultMonitor),
 		compressQueue: make(chan string, 1),

--- a/workers/logfile_bench_test.go
+++ b/workers/logfile_bench_test.go
@@ -33,7 +33,7 @@ func benchmarkLogFileMode(b *testing.B, mode string) {
 
 	for i := 0; i < b.N; i++ {
 		msg := dm
-		inChan <- dnsutils.NewDNSMessageBatchFromMessage(&msg)
+		inChan <- dnsutils.NewDNSMessageBatch(&msg)
 	}
 	b.StopTimer()
 

--- a/workers/logfile_bench_test.go
+++ b/workers/logfile_bench_test.go
@@ -17,7 +17,7 @@ func benchmarkLogFileMode(b *testing.B, mode string) {
 	config := pkgconfig.GetDefaultConfig()
 	config.Loggers.LogFile.FilePath = filePath
 	config.Loggers.LogFile.Mode = mode
-	config.Loggers.LogFile.ChannelBufferSize = 65536
+	config.Global.Worker.ChannelBufferSize = 65536
 	config.Loggers.LogFile.FlushInterval = 0
 
 	g := NewLogFile(config, logger.New(false), "bench-logfile")

--- a/workers/logfile_bench_test.go
+++ b/workers/logfile_bench_test.go
@@ -33,7 +33,7 @@ func benchmarkLogFileMode(b *testing.B, mode string) {
 
 	for i := 0; i < b.N; i++ {
 		msg := dm
-		inChan <- &msg
+		inChan <- dnsutils.NewDNSMessageBatchFromMessage(&msg)
 	}
 	b.StopTimer()
 

--- a/workers/logfile_test.go
+++ b/workers/logfile_test.go
@@ -60,7 +60,7 @@ func Test_LogFileText(t *testing.T) {
 			// send fake dns message to logger
 			dm := dnsutils.GetFakeDNSMessage()
 			dm.DNSTap.Identity = dnsutils.DNSTapIdentityTest
-			g.GetInputChannel() <- &dm
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 			time.Sleep(time.Second)
 			g.Stop()
@@ -113,7 +113,7 @@ func Test_LogFilePcap_ContentVerification(t *testing.T) {
 		0x00, 0x01, // Type: A
 		0x00, 0x01, // Class: IN
 	}
-	g.GetInputChannel() <- &dm
+	g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 	// stop worker
 	time.Sleep(time.Second)
@@ -228,7 +228,7 @@ func Test_LogFileRotation(t *testing.T) {
 				for i := 0; i < tc.queries; i++ {
 					dm := dnsutils.GetFakeDNSMessage()
 					dm.DNS.Qname = strings.Repeat("a", 1000) // Adds 1KB per message
-					w.GetInputChannel() <- &dm
+					w.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 				}
 
 				// Ensure we wait enough for the timer-based rotations
@@ -279,7 +279,7 @@ func Test_LogFileBatchProcessing(t *testing.T) {
 	for i := range numMessages {
 		dm := dnsutils.GetFakeDNSMessage()
 		dm.DNS.Qname = fmt.Sprintf("message-%d.batch.test", i)
-		g.GetInputChannel() <- &dm
+		g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 	}
 
 	// wait to ensure all messages are processed

--- a/workers/logfile_test.go
+++ b/workers/logfile_test.go
@@ -60,7 +60,7 @@ func Test_LogFileText(t *testing.T) {
 			// send fake dns message to logger
 			dm := dnsutils.GetFakeDNSMessage()
 			dm.DNSTap.Identity = dnsutils.DNSTapIdentityTest
-			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 			time.Sleep(time.Second)
 			g.Stop()
@@ -113,7 +113,7 @@ func Test_LogFilePcap_ContentVerification(t *testing.T) {
 		0x00, 0x01, // Type: A
 		0x00, 0x01, // Class: IN
 	}
-	g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+	g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 	// stop worker
 	time.Sleep(time.Second)
@@ -228,7 +228,7 @@ func Test_LogFileRotation(t *testing.T) {
 				for i := 0; i < tc.queries; i++ {
 					dm := dnsutils.GetFakeDNSMessage()
 					dm.DNS.Qname = strings.Repeat("a", 1000) // Adds 1KB per message
-					w.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+					w.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 				}
 
 				// Ensure we wait enough for the timer-based rotations
@@ -279,7 +279,7 @@ func Test_LogFileBatchProcessing(t *testing.T) {
 	for i := range numMessages {
 		dm := dnsutils.GetFakeDNSMessage()
 		dm.DNS.Qname = fmt.Sprintf("message-%d.batch.test", i)
-		g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+		g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 	}
 
 	// wait to ensure all messages are processed

--- a/workers/logfile_test.go
+++ b/workers/logfile_test.go
@@ -208,7 +208,7 @@ func Test_LogFileRotation(t *testing.T) {
 				config.Loggers.LogFile.MaxSize = tc.maxSize
 				config.Loggers.LogFile.MaxFiles = tc.maxFiles
 				config.Loggers.LogFile.RotationInterval = tc.rotationInterval
-				config.Loggers.LogFile.ChannelBufferSize = 1
+				config.Global.Worker.ChannelBufferSize = 1
 
 				t.Logf("\n[Rotation Config - %s]\n"+
 					" ├─ Interval (s): %d\n"+

--- a/workers/lokiclient.go
+++ b/workers/lokiclient.go
@@ -165,25 +165,28 @@ func (w *LokiClient) StartCollect() {
 			w.ReadConfig()
 			subprocessors.ReloadConfig(&cfg.OutgoingTransformers)
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("input channel closed!")
 				return
 			}
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// apply transforms, init dns message with additional parts if necessary
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
+				// apply transforms, init dns message with additional parts if necessary
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
 
-			w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+				w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+			}
+			batch.Release()
 		}
 	}
 }
@@ -206,170 +209,167 @@ func (w *LokiClient) StartLogging() {
 			return
 
 		// incoming dns message to process
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
 			}
 
-			lbls := labels.FromStrings(
-				"identity", dm.DNSTap.Identity,
-				"job", w.GetConfig().Loggers.LokiClient.JobName,
-			)
-			var err error
-			var flat map[string]interface{}
-			if len(w.GetConfig().Loggers.LokiClient.RelabelConfigs) > 0 {
-				finalSet := []labels.Label{
-					{Name: "identity", Value: dm.DNSTap.Identity},
-					{Name: "job", Value: w.GetConfig().Loggers.LokiClient.JobName},
-				}
-				// flatten dns message
-				flat, err = dm.Flatten()
-				if err != nil {
-					w.LogError("flattening DNS message failed: %e", err)
-					w.CountEgressDiscarded()
-					dm.Release()
-					continue
-				}
-				for k, v := range flat {
-					cleanKey := strings.ReplaceAll(strings.ReplaceAll(k, ".", "_"), "-", "_")
-					key := fmt.Sprintf("__%s", cleanKey)
-					finalSet = append(finalSet, labels.Label{Name: key, Value: fmt.Sprint(v)})
-				}
-
-				// Apply relabeling
-				ls := labels.New(finalSet...)
-				sb := labels.NewBuilder(ls)
-
-				// to support prometheus > 3.0.7
-				configs := w.GetConfig().Loggers.LokiClient.RelabelConfigs
-				for _, cfg := range configs {
-					if cfg.NameValidationScheme == 0 {
-						cfg.NameValidationScheme = model.LegacyValidation
-					}
-				}
-
-				keep := relabel.ProcessBuilder(sb, configs...)
-				if !keep {
-					w.LogInfo("dropping %v because of relabel config", dm)
-					w.CountEgressDiscarded()
-					dm.Release()
-					continue
-				}
-
-				// remove internal labels
-				sb.Range(func(l labels.Label) {
-					if strings.HasPrefix(l.Name, "__") {
-						sb.Del(l.Name)
-					}
-				})
-
-				lbls = sb.Labels()
-				if lbls.Len() == 0 {
-					w.LogInfo("dropping %v since it has no labels", dm)
-					w.CountEgressDiscarded()
-					dm.Release()
-					continue
-				}
-			}
-
-			// prepare entry
-			entry := logproto.Entry{}
-			entry.Timestamp = time.Unix(int64(dm.DNSTap.TimeSec), int64(dm.DNSTap.TimeNsec))
-
-			switch w.GetConfig().Loggers.LokiClient.Mode {
-			case pkgconfig.ModeText:
-				// get buffer from pool
-				buf := w.GetTextBuffer()
-				buf.Reset()
-
-				// write the DNSMessage to the buffer
+			for _, dm := range batch.Messages {
+				lbls := labels.FromStrings(
+					"identity", dm.DNSTap.Identity,
+					"job", w.GetConfig().Loggers.LokiClient.JobName,
+				)
 				var err error
-				if w.textFormatter != nil {
-					err = w.textFormatter.Format(dm, buf)
-				} else {
-					err = dm.ToTextLine(
-						w.textFormat,
-						w.GetConfig().Global.TextFormatDelimiter,
-						w.GetConfig().Global.TextFormatBoundary,
-						buf,
-					)
-				}
-				if err != nil {
-					w.CountEgressDiscarded()
-					w.LogError("process: could not encode to text format: %s", err)
-					w.PutTextBuffer(buf)
-					dm.Release()
-					continue
-				}
-
-				// assign buffer content to Loki entry
-				entry.Line = buf.String()
-
-				// return buffer to pool
-				w.PutTextBuffer(buf)
-
-			case pkgconfig.ModeJSON:
-				json.NewEncoder(buffer).Encode(dm)
-				entry.Line = buffer.String()
-				buffer.Reset()
-			case pkgconfig.ModeFlatJSON:
-				switch {
-				case len(flat) > 0:
-					json.NewEncoder(buffer).Encode(flat)
-					entry.Line = buffer.String()
-					buffer.Reset()
-				case dm.Relabeling != nil:
+				var flat map[string]interface{}
+				if len(w.GetConfig().Loggers.LokiClient.RelabelConfigs) > 0 {
+					finalSet := []labels.Label{
+						{Name: "identity", Value: dm.DNSTap.Identity},
+						{Name: "job", Value: w.GetConfig().Loggers.LokiClient.JobName},
+					}
+					// flatten dns message
 					flat, err = dm.Flatten()
 					if err != nil {
 						w.LogError("flattening DNS message failed: %e", err)
 						w.CountEgressDiscarded()
-						dm.Release()
 						continue
 					}
-					json.NewEncoder(buffer).Encode(flat)
-					entry.Line = buffer.String()
-					buffer.Reset()
-				default:
-					buffer.Reset()
-					dm.GetTimestampRFC3339()
-					dm.EncodeFlatJSON(buffer)
-					buffer.WriteByte('\n')
-					entry.Line = buffer.String()
-					buffer.Reset()
+					for k, v := range flat {
+						cleanKey := strings.ReplaceAll(strings.ReplaceAll(k, ".", "_"), "-", "_")
+						key := fmt.Sprintf("__%s", cleanKey)
+						finalSet = append(finalSet, labels.Label{Name: key, Value: fmt.Sprint(v)})
+					}
+
+					// Apply relabeling
+					ls := labels.New(finalSet...)
+					sb := labels.NewBuilder(ls)
+
+					// to support prometheus > 3.0.7
+					configs := w.GetConfig().Loggers.LokiClient.RelabelConfigs
+					for _, cfg := range configs {
+						if cfg.NameValidationScheme == 0 {
+							cfg.NameValidationScheme = model.LegacyValidation
+						}
+					}
+
+					keep := relabel.ProcessBuilder(sb, configs...)
+					if !keep {
+						w.LogInfo("dropping %v because of relabel config", dm)
+						w.CountEgressDiscarded()
+						continue
+					}
+
+					// remove internal labels
+					sb.Range(func(l labels.Label) {
+						if strings.HasPrefix(l.Name, "__") {
+							sb.Del(l.Name)
+						}
+					})
+
+					lbls = sb.Labels()
+					if lbls.Len() == 0 {
+						w.LogInfo("dropping %v since it has no labels", dm)
+						w.CountEgressDiscarded()
+						continue
+					}
 				}
-			}
-			key := string(lbls.Bytes(byteBuffer))
-			ls, ok := w.streams[key]
-			if !ok {
-				ls = &LokiStream{config: w.GetConfig(), logger: w.GetLogger(), labels: lbls}
-				ls.Init()
-				w.streams[key] = ls
-			}
-			ls.sizeentries += len(entry.Line)
 
-			// append entry to the stream
-			ls.stream.Entries = append(ls.stream.Entries, entry)
+				// prepare entry
+				entry := logproto.Entry{}
+				entry.Timestamp = time.Unix(int64(dm.DNSTap.TimeSec), int64(dm.DNSTap.TimeNsec))
 
-			// flush ?
-			if ls.sizeentries >= w.GetConfig().Loggers.LokiClient.BatchSize {
-				// encode log entries
-				buf, err := ls.Encode2Proto()
-				if err != nil {
-					w.LogError("error encoding log entries - %v", err)
-					// reset push request and entries
+				switch w.GetConfig().Loggers.LokiClient.Mode {
+				case pkgconfig.ModeText:
+					// get buffer from pool
+					buf := w.GetTextBuffer()
+					buf.Reset()
+
+					// write the DNSMessage to the buffer
+					var err error
+					if w.textFormatter != nil {
+						err = w.textFormatter.Format(dm, buf)
+					} else {
+						err = dm.ToTextLine(
+							w.textFormat,
+							w.GetConfig().Global.TextFormatDelimiter,
+							w.GetConfig().Global.TextFormatBoundary,
+							buf,
+						)
+					}
+					if err != nil {
+						w.CountEgressDiscarded()
+						w.LogError("process: could not encode to text format: %s", err)
+						w.PutTextBuffer(buf)
+						continue
+					}
+
+					// assign buffer content to Loki entry
+					entry.Line = buf.String()
+
+					// return buffer to pool
+					w.PutTextBuffer(buf)
+
+				case pkgconfig.ModeJSON:
+					json.NewEncoder(buffer).Encode(dm)
+					entry.Line = buffer.String()
+					buffer.Reset()
+				case pkgconfig.ModeFlatJSON:
+					switch {
+					case len(flat) > 0:
+						json.NewEncoder(buffer).Encode(flat)
+						entry.Line = buffer.String()
+						buffer.Reset()
+					case dm.Relabeling != nil:
+						flat, err = dm.Flatten()
+						if err != nil {
+							w.LogError("flattening DNS message failed: %e", err)
+							w.CountEgressDiscarded()
+							continue
+						}
+						json.NewEncoder(buffer).Encode(flat)
+						entry.Line = buffer.String()
+						buffer.Reset()
+					default:
+						buffer.Reset()
+						dm.GetTimestampRFC3339()
+						dm.EncodeFlatJSON(buffer)
+						buffer.WriteByte('\n')
+						entry.Line = buffer.String()
+						buffer.Reset()
+					}
+				}
+				key := string(lbls.Bytes(byteBuffer))
+				ls, ok := w.streams[key]
+				if !ok {
+					ls = &LokiStream{config: w.GetConfig(), logger: w.GetLogger(), labels: lbls}
+					ls.Init()
+					w.streams[key] = ls
+				}
+				ls.sizeentries += len(entry.Line)
+
+				// append entry to the stream
+				ls.stream.Entries = append(ls.stream.Entries, entry)
+
+				// flush ?
+				if ls.sizeentries >= w.GetConfig().Loggers.LokiClient.BatchSize {
+					// encode log entries
+					buf, err := ls.Encode2Proto()
+					if err != nil {
+						w.LogError("error encoding log entries - %v", err)
+						// reset push request and entries
+						ls.ResetEntries()
+						w.CountEgressDiscarded()
+						return
+					}
+
+					// send all entries
+					w.SendEntries(buf)
+
+					// reset entries and push request
 					ls.ResetEntries()
-					w.CountEgressDiscarded()
-					return
 				}
-
-				// send all entries
-				w.SendEntries(buf)
-
-				// reset entries and push request
-				ls.ResetEntries()
 			}
-			dm.Release()
+			batch.Release()
 
 		case <-tflush.C:
 			for _, s := range w.streams {

--- a/workers/lokiclient.go
+++ b/workers/lokiclient.go
@@ -76,9 +76,6 @@ type LokiClient struct {
 
 func NewLokiClient(config *pkgconfig.Config, logger *logger.Logger, name string) *LokiClient {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.LokiClient.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.LokiClient.ChannelBufferSize
-	}
 	w := &LokiClient{GenericWorker: NewGenericWorker(config, logger, name, "loki", bufSize, pkgconfig.DefaultMonitor)}
 	w.streams = make(map[string]*LokiStream)
 	w.ReadConfig()

--- a/workers/lokiclient_test.go
+++ b/workers/lokiclient_test.go
@@ -57,7 +57,7 @@ func Test_LokiClientRun(t *testing.T) {
 			// send fake dns message to logger
 			dm := dnsutils.GetFakeDNSMessage()
 			dm.DNSTap.Identity = dnsutils.DNSTapIdentityTest
-			g.GetInputChannel() <- &dm
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 			// accept conn
 			conn, err := fakeRcvr.Accept()
@@ -164,7 +164,7 @@ func Test_LokiClientRelabel(t *testing.T) {
 				// send fake dns message to logger
 				dm := dnsutils.GetFakeDNSMessage()
 				dm.DNSTap.Identity = dnsutils.DNSTapIdentityTest
-				g.GetInputChannel() <- &dm
+				g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 				// accept conn
 				conn, err := fakeRcvr.Accept()

--- a/workers/lokiclient_test.go
+++ b/workers/lokiclient_test.go
@@ -57,7 +57,7 @@ func Test_LokiClientRun(t *testing.T) {
 			// send fake dns message to logger
 			dm := dnsutils.GetFakeDNSMessage()
 			dm.DNSTap.Identity = dnsutils.DNSTapIdentityTest
-			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 			// accept conn
 			conn, err := fakeRcvr.Accept()
@@ -164,7 +164,7 @@ func Test_LokiClientRelabel(t *testing.T) {
 				// send fake dns message to logger
 				dm := dnsutils.GetFakeDNSMessage()
 				dm.DNSTap.Identity = dnsutils.DNSTapIdentityTest
-				g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+				g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 				// accept conn
 				conn, err := fakeRcvr.Accept()

--- a/workers/mqtt.go
+++ b/workers/mqtt.go
@@ -309,24 +309,27 @@ func (w *MQTT) StartCollect() {
 			w.ReadConfig()
 			subprocessors.ReloadConfig(&cfg.OutgoingTransformers)
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("input channel closed!")
 				return
 			}
 
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				w.CountIngressTraffic()
 
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
 
-			w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+				w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+			}
+			batch.Release()
 		}
 	}
 }
@@ -351,23 +354,26 @@ func (w *MQTT) StartLogging() {
 		case <-w.mqttReady:
 			w.LogInfo("mqtt client connected with success")
 
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
 			}
 
-			if !w.writerReady {
-				w.CountEgressDiscarded()
-				dm.Release()
-				continue
-			}
+			for _, dm := range batch.Messages {
+				if !w.writerReady {
+					w.CountEgressDiscarded()
+					continue
+				}
 
-			bufferDm = append(bufferDm, dm)
+				dm.Retain(1)
+				bufferDm = append(bufferDm, dm)
 
-			if len(bufferDm) >= w.GetConfig().Loggers.MQTT.BufferSize {
-				w.FlushBuffer(&bufferDm)
+				if len(bufferDm) >= w.GetConfig().Loggers.MQTT.BufferSize {
+					w.FlushBuffer(&bufferDm)
+				}
 			}
+			batch.Release()
 
 		case <-flushTimer.C:
 			if !w.writerReady {

--- a/workers/mqtt.go
+++ b/workers/mqtt.go
@@ -32,9 +32,6 @@ type MQTT struct {
 
 func NewMQTT(config *pkgconfig.Config, logger *logger.Logger, name string) *MQTT {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.MQTT.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.MQTT.ChannelBufferSize
-	}
 	w := &MQTT{
 		GenericWorker: NewGenericWorker(config, logger, name, "mqtt", bufSize, pkgconfig.DefaultMonitor),
 		mqttReady:     make(chan bool),

--- a/workers/nsq.go
+++ b/workers/nsq.go
@@ -82,23 +82,29 @@ func (w *NsqClient) StartLogging() {
 			w.Disconnect()
 			return
 
-		case msg, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
 			}
 
-			encoded, err := json.Marshal(msg)
-			if err != nil {
-				w.LogError("json encoding error: %v", err)
-				w.CountEgressDiscarded()
-				continue
-			}
+			for _, dm := range batch.Messages {
+				encoded, err := json.Marshal(dm)
+				if err != nil {
+					w.LogError("json encoding error: %v", err)
+					w.CountEgressDiscarded()
+					continue
+				}
 
-			err = w.nsqProducer.Publish(topic, encoded)
-			if err != nil {
-				w.LogError("failed to publish to NSQ: %v", err)
+				err = w.nsqProducer.Publish(topic, encoded)
+				if err != nil {
+					w.LogError("failed to publish to NSQ: %v", err)
+					w.CountEgressDiscarded()
+					continue
+				}
+				w.CountEgressTraffic()
 			}
+			batch.Release()
 		}
 	}
 }

--- a/workers/nsq.go
+++ b/workers/nsq.go
@@ -21,10 +21,7 @@ type NsqClient struct {
 }
 
 func NewNsqClient(config *pkgconfig.Config, console *logger.Logger, name string) *NsqClient {
-	bufferSize := config.Loggers.Nsq.ChannelBufferSize
-	if bufferSize == 0 {
-		bufferSize = config.Global.Worker.ChannelBufferSize
-	}
+	bufferSize := config.Global.Worker.ChannelBufferSize
 
 	s := &NsqClient{
 		GenericWorker: NewGenericWorker(config, console, name, "nsq", bufferSize, pkgconfig.DefaultMonitor),

--- a/workers/nsq_test.go
+++ b/workers/nsq_test.go
@@ -70,7 +70,7 @@ func Test_NSQ_ClientAndPublishing(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	dm := dnsutils.GetFakeDNSMessage()
-	nsqClient.GetInputChannel() <- &dm
+	nsqClient.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 	// Wait for message to be processed
 	time.Sleep(200 * time.Millisecond)

--- a/workers/nsq_test.go
+++ b/workers/nsq_test.go
@@ -70,7 +70,7 @@ func Test_NSQ_ClientAndPublishing(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	dm := dnsutils.GetFakeDNSMessage()
-	nsqClient.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+	nsqClient.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 	// Wait for message to be processed
 	time.Sleep(200 * time.Millisecond)

--- a/workers/otel.go
+++ b/workers/otel.go
@@ -31,9 +31,6 @@ type OpenTelemetryClient struct {
 
 func NewOpenTelemetryClient(config *pkgconfig.Config, console *logger.Logger, name string) *OpenTelemetryClient {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.OpenTelemetryClient.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.OpenTelemetryClient.ChannelBufferSize
-	}
 
 	w := &OpenTelemetryClient{
 		GenericWorker:   NewGenericWorker(config, console, name, "opentelemetry", bufSize, pkgconfig.DefaultMonitor),

--- a/workers/otel.go
+++ b/workers/otel.go
@@ -94,28 +94,33 @@ func (w *OpenTelemetryClient) StartCollect() {
 			w.ReadConfig()
 			subprocessors.ReloadConfig(&cfg.OutgoingTransformers)
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("input channel closed!")
 				return
 			}
 
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// apply transforms, init dns message with additional parts if necessary
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
+				// apply transforms, init dns message with additional parts if necessary
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
 
-			// send to output channel
-			w.CountEgressTraffic()
-			w.GetOutputChannel() <- dm
+				// send to output channel
+				w.CountEgressTraffic()
+				b := dnsutils.AcquireDNSMessageBatch(1)
+				b.Messages = append(b.Messages, dm)
+				w.GetOutputChannel() <- b
+			}
+			batch.Release()
 		}
 	}
 }
@@ -140,43 +145,45 @@ func (w *OpenTelemetryClient) StartLogging() {
 			return
 
 		// incoming dns message to process
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
 			}
 
-			var timestamp time.Time
-			if dm.DNSTap.Timestamp > 0 {
-				timestamp = time.Unix(0, dm.DNSTap.Timestamp)
-			} else {
-				var err error
-				timestamp, err = time.Parse(time.RFC3339, dm.GetTimestampRFC3339())
-				if err != nil {
-					w.LogWarning("invalid timestamp: %v", err)
-					w.CountEgressDiscarded()
-					dm.Release()
-					continue
+			for _, dm := range batch.Messages {
+				var timestamp time.Time
+				if dm.DNSTap.Timestamp > 0 {
+					timestamp = time.Unix(0, dm.DNSTap.Timestamp)
+				} else {
+					var err error
+					timestamp, err = time.Parse(time.RFC3339, dm.GetTimestampRFC3339())
+					if err != nil {
+						w.LogWarning("invalid timestamp: %v", err)
+						w.CountEgressDiscarded()
+						continue
+					}
 				}
+				tracer := w.getTracer(dm.DNSTap.Identity)
+
+				// ini opentelemetry with default values
+				dm.OpenTelemetry = &dnsutils.LoggerOpenTelemetry{}
+
+				switch dm.DNSTap.Operation {
+				case "CLIENT_QUERY":
+					w.handleClientQuery(&requestorSpans, &messageSpans, tracer, dm, timestamp)
+				case "CLIENT_RESPONSE":
+					w.handleClientResponse(&requestorSpans, &messageSpans, dm, timestamp)
+				case "RESOLVER_QUERY":
+					w.handleResolverQuery(&messageSpans, &resolverSpans, tracer, dm, timestamp)
+				case "RESOLVER_RESPONSE":
+					w.handleResolverResponse(&resolverSpans, dm, timestamp)
+				}
+
+				// send to next ?
+				w.SendForwardedTo(defaultRoutes, defaultNames, dm)
 			}
-			tracer := w.getTracer(dm.DNSTap.Identity)
-
-			// ini opentelemetry with default values
-			dm.OpenTelemetry = &dnsutils.LoggerOpenTelemetry{}
-
-			switch dm.DNSTap.Operation {
-			case "CLIENT_QUERY":
-				w.handleClientQuery(&requestorSpans, &messageSpans, tracer, dm, timestamp)
-			case "CLIENT_RESPONSE":
-				w.handleClientResponse(&requestorSpans, &messageSpans, dm, timestamp)
-			case "RESOLVER_QUERY":
-				w.handleResolverQuery(&messageSpans, &resolverSpans, tracer, dm, timestamp)
-			case "RESOLVER_RESPONSE":
-				w.handleResolverResponse(&resolverSpans, dm, timestamp)
-			}
-
-			// send to next ?
-			w.SendForwardedTo(defaultRoutes, defaultNames, dm)
+			batch.Release()
 		}
 	}
 }

--- a/workers/powerdns.go
+++ b/workers/powerdns.go
@@ -29,9 +29,6 @@ type PdnsServer struct {
 
 func NewPdnsServer(next []Worker, config *pkgconfig.Config, logger *logger.Logger, name string) *PdnsServer {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Collectors.PowerDNS.ChannelBufferSize > 0 {
-		bufSize = config.Collectors.PowerDNS.ChannelBufferSize
-	}
 	w := &PdnsServer{GenericWorker: NewGenericWorker(config, logger, name, "powerdns", bufSize, pkgconfig.DefaultMonitor)}
 	w.SetDefaultRoutes(next)
 	w.CheckConfig()
@@ -59,9 +56,6 @@ func (w *PdnsServer) HandleConn(conn net.Conn, connID uint64, forceClose chan bo
 
 	// start protobuf subprocessor
 	bufSize := w.GetConfig().Global.Worker.ChannelBufferSize
-	if w.GetConfig().Collectors.PowerDNS.ChannelBufferSize > 0 {
-		bufSize = w.GetConfig().Collectors.PowerDNS.ChannelBufferSize
-	}
 	pdnsProcessor := NewPdnsProcessor(int(connID), peerName, w.GetConfig(), w.GetLogger(), w.GetName(), bufSize)
 	pdnsProcessor.SetMetrics(w.GetMetrics())
 	pdnsProcessor.SetDefaultRoutes(w.GetDefaultRoutes())

--- a/workers/powerdns.go
+++ b/workers/powerdns.go
@@ -119,7 +119,7 @@ func (w *PdnsServer) HandleConn(conn net.Conn, connID uint64, forceClose chan bo
 		select {
 		case pdnsProcessor.GetDataChannel() <- payload.Data(): // Successful send
 		default:
-			w.WorkerIsBusy("dnstap-processor")
+			w.WorkerIsBusy("dnstap-processor", 1)
 		}
 	}
 }

--- a/workers/powerdns.go
+++ b/workers/powerdns.go
@@ -225,6 +225,8 @@ func (w *PdnsProcessor) StartCollect() {
 
 	// prepare enabled transformers
 	transforms := transformers.NewTransforms(&w.GetConfig().IngoingTransformers, w.GetLogger(), w.GetName(), defaultRoutes, w.ConnID)
+	batchSize := w.GetBatchSize()
+	curBatch := dnsutils.AcquireDNSMessageBatch(batchSize)
 
 	// read incoming dns message
 	for {
@@ -234,12 +236,22 @@ func (w *PdnsProcessor) StartCollect() {
 			transforms.ReloadConfig(&cfg.IngoingTransformers)
 
 		case <-w.OnStop():
+			if len(curBatch.Messages) > 0 {
+				w.SendForwardedBatchTo(defaultRoutes, defaultNames, curBatch)
+			} else {
+				curBatch.Release()
+			}
 			transforms.Reset()
 			close(w.GetDataChannel())
 			return
 
 		case data, opened := <-w.GetDataChannel():
 			if !opened {
+				if len(curBatch.Messages) > 0 {
+					w.SendForwardedBatchTo(defaultRoutes, defaultNames, curBatch)
+				} else {
+					curBatch.Release()
+				}
 				w.LogInfo("channel closed, exit")
 				return
 			}
@@ -476,8 +488,12 @@ func (w *PdnsProcessor) StartCollect() {
 				continue
 			}
 
-			// dispatch dns messages to connected loggers
-			w.SendForwardedTo(defaultRoutes, defaultNames, dm)
+			// append to batch and dispatch
+			curBatch.Messages = append(curBatch.Messages, dm)
+			if len(curBatch.Messages) >= batchSize || len(w.GetDataChannel()) == 0 {
+				w.SendForwardedBatchTo(defaultRoutes, defaultNames, curBatch)
+				curBatch = dnsutils.AcquireDNSMessageBatch(batchSize)
+			}
 		}
 	}
 }

--- a/workers/powerdns_bench_test.go
+++ b/workers/powerdns_bench_test.go
@@ -60,7 +60,7 @@ func getFakePowerDNSResponse() []byte {
 
 func Benchmark_PdnsProcessor_Query(b *testing.B) {
 	config := pkgconfig.GetDefaultConfig()
-	config.Collectors.PowerDNS.ChannelBufferSize = 65536
+	config.Global.Worker.ChannelBufferSize = 65536
 
 	devNull := NewDevNull(config, logger.New(false), "devnull")
 	go devNull.StartCollect()
@@ -84,7 +84,7 @@ func Benchmark_PdnsProcessor_Query(b *testing.B) {
 
 func Benchmark_PdnsProcessor_Response(b *testing.B) {
 	config := pkgconfig.GetDefaultConfig()
-	config.Collectors.PowerDNS.ChannelBufferSize = 65536
+	config.Global.Worker.ChannelBufferSize = 65536
 
 	devNull := NewDevNull(config, logger.New(false), "devnull")
 	go devNull.StartCollect()
@@ -108,7 +108,7 @@ func Benchmark_PdnsProcessor_Response(b *testing.B) {
 
 func Benchmark_PdnsProcessor_AddDNSPayload(b *testing.B) {
 	config := pkgconfig.GetDefaultConfig()
-	config.Collectors.PowerDNS.ChannelBufferSize = 65536
+	config.Global.Worker.ChannelBufferSize = 65536
 	config.Collectors.PowerDNS.AddDNSPayload = true
 
 	devNull := NewDevNull(config, logger.New(false), "devnull")

--- a/workers/powerdns_test.go
+++ b/workers/powerdns_test.go
@@ -252,12 +252,13 @@ func Test_PowerDNSProcessor_BufferLoggerIsFull(t *testing.T) {
 	fl := GetWorkerForTest(pkgconfig.DefaultBufferOne)
 
 	// redirect stdout output to bytes buffer
-	logsChan := make(chan logger.LogEntry, 10)
+	logsChan := make(chan logger.LogEntry, 512)
 	lg := logger.New(true)
 	lg.SetOutputChannel((logsChan))
 
 	// init the dnstap consumer
 	cfg := pkgconfig.GetDefaultConfig()
+	cfg.Global.Worker.BatchSize = 1
 	consumer := NewPdnsProcessor(0, "peername", cfg, lg, "test", 512)
 	consumer.AddDefaultRoute(fl)
 	consumer.AddDroppedRoute(fl)

--- a/workers/powerdns_test.go
+++ b/workers/powerdns_test.go
@@ -59,9 +59,9 @@ func Test_PowerDNSProcessor(t *testing.T) {
 	consumer.GetDataChannel() <- data
 
 	// read dns message from dnstap consumer
-	msg := <-fl.GetInputChannel()
-	if msg.DNSTap.Identity != pkgconfig.ExpectedIdentity {
-		t.Errorf("invalid identity in dns message: %s", msg.DNSTap.Identity)
+	batch := <-fl.GetInputChannel()
+	if len(batch.Messages) == 0 || batch.Messages[0].DNSTap.Identity != pkgconfig.ExpectedIdentity {
+		t.Errorf("invalid identity in dns message: %v", batch.Messages)
 	}
 }
 
@@ -97,9 +97,11 @@ func Test_PowerDNSProcessor_AddDNSPayload_Valid(t *testing.T) {
 	consumer.GetDataChannel() <- data
 
 	// read dns message
-	msg := <-fl.GetInputChannel()
-
-	// checks
+	batch := <-fl.GetInputChannel()
+	if len(batch.Messages) == 0 {
+		t.Fatalf("expected message in batch")
+	}
+	msg := batch.Messages[0]
 	if msg.DNS.Length == 0 {
 		t.Errorf("invalid length got %d", msg.DNS.Length)
 	}
@@ -151,8 +153,8 @@ func Test_PowerDNSProcessor_AddDNSPayload_InvalidLabelLength(t *testing.T) {
 	consumer.GetDataChannel() <- data
 
 	// read dns message from dnstap consumer
-	msg := <-fl.GetInputChannel()
-	if !msg.DNS.MalformedPacket {
+	batch := <-fl.GetInputChannel()
+	if len(batch.Messages) == 0 || !batch.Messages[0].DNS.MalformedPacket {
 		t.Errorf("DNS message should malformed")
 	}
 }
@@ -189,8 +191,8 @@ func Test_PowerDNSProcessor_AddDNSPayload_QnameTooLongDomain(t *testing.T) {
 	consumer.GetDataChannel() <- data
 
 	// read dns message from dnstap consumer
-	msg := <-fl.GetInputChannel()
-	if !msg.DNS.MalformedPacket {
+	batch := <-fl.GetInputChannel()
+	if len(batch.Messages) == 0 || !batch.Messages[0].DNS.MalformedPacket {
 		t.Errorf("DNS message should malformed because of qname too long")
 	}
 }
@@ -238,10 +240,8 @@ func Test_PowerDNSProcessor_AddDNSPayload_AnswersTooLongDomain(t *testing.T) {
 	consumer.GetDataChannel() <- data
 
 	// read dns message from dnstap consumer
-	msg := <-fl.GetInputChannel()
-
-	// tests verifications
-	if !msg.DNS.MalformedPacket {
+	batch := <-fl.GetInputChannel()
+	if len(batch.Messages) == 0 || !batch.Messages[0].DNS.MalformedPacket {
 		t.Errorf("DNS message is not malformed")
 	}
 }
@@ -295,9 +295,9 @@ func Test_PowerDNSProcessor_BufferLoggerIsFull(t *testing.T) {
 	}
 
 	// read dns message from dnstap consumer
-	msg := <-fl.GetInputChannel()
-	if msg.DNSTap.Identity != pkgconfig.ExpectedIdentity {
-		t.Errorf("invalid identity in dns message: %s", msg.DNSTap.Identity)
+	batch := <-fl.GetInputChannel()
+	if len(batch.Messages) == 0 || batch.Messages[0].DNSTap.Identity != pkgconfig.ExpectedIdentity {
+		t.Errorf("invalid identity in dns message: %v", batch.Messages)
 	}
 
 	// send second shot of packets to consumer
@@ -316,8 +316,8 @@ func Test_PowerDNSProcessor_BufferLoggerIsFull(t *testing.T) {
 	}
 
 	// read just one dns message from dnstap consumer
-	msg2 := <-fl.GetInputChannel()
-	if msg2.DNSTap.Identity != pkgconfig.ExpectedIdentity {
-		t.Errorf("invalid identity in second dns message: %s", msg2.DNSTap.Identity)
+	batch2 := <-fl.GetInputChannel()
+	if len(batch2.Messages) == 0 || batch2.Messages[0].DNSTap.Identity != pkgconfig.ExpectedIdentity {
+		t.Errorf("invalid identity in second dns message: %v", batch2.Messages)
 	}
 }

--- a/workers/prometheus.go
+++ b/workers/prometheus.go
@@ -829,9 +829,6 @@ func CreateSystemCatalogue(w *Prometheus) ([]string, *PromCounterCatalogueContai
 
 func NewPrometheus(config *pkgconfig.Config, logger *logger.Logger, name string) *Prometheus {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.Prometheus.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.Prometheus.ChannelBufferSize
-	}
 	w := &Prometheus{GenericWorker: NewGenericWorker(config, logger, name, "prometheus", bufSize, pkgconfig.DefaultMonitor)}
 	w.doneAPI = make(chan bool)
 	w.promRegistry = prometheus.NewPedanticRegistry()

--- a/workers/prometheus.go
+++ b/workers/prometheus.go
@@ -1274,25 +1274,28 @@ func (w *Prometheus) StartCollect() {
 			w.ReadConfig()
 			subprocessors.ReloadConfig(&cfg.OutgoingTransformers)
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("input channel closed!")
 				return
 			}
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// apply transforms, init dns message with additional parts if necessary
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
+				// apply transforms, init dns message with additional parts if necessary
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
 
-			w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+				w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+			}
+			batch.Release()
 		}
 	}
 }
@@ -1310,15 +1313,17 @@ func (w *Prometheus) StartLogging() {
 		case <-w.OnLoggerStopped():
 			return
 
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
 			}
 
-			// record the dnstap message
-			w.Record(dm)
-			dm.Release()
+			for _, dm := range batch.Messages {
+				// record the dnstap message
+				w.Record(dm)
+			}
+			batch.Release()
 
 		case <-t1.C:
 			// compute eps each second

--- a/workers/redispub.go
+++ b/workers/redispub.go
@@ -255,25 +255,28 @@ func (w *RedisPub) StartCollect() {
 			w.ReadConfig()
 			subprocessors.ReloadConfig(&cfg.OutgoingTransformers)
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("input channel closed!")
 				return
 			}
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// apply transforms, init dns message with additional parts if necessary
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
+				// apply transforms, init dns message with additional parts if necessary
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
 
-			w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+				w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+			}
+			batch.Release()
 		}
 	}
 }
@@ -307,27 +310,30 @@ func (w *RedisPub) StartLogging() {
 			go w.ReadFromConnection()
 
 			// incoming dns message to process
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
 			}
 
-			// drop dns message if the connection is not ready to avoid memory leak or
-			// to block the channel
-			if !w.writerReady {
-				w.CountEgressDiscarded()
-				dm.Release()
-				continue
-			}
+			for _, dm := range batch.Messages {
+				// drop dns message if the connection is not ready to avoid memory leak or
+				// to block the channel
+				if !w.writerReady {
+					w.CountEgressDiscarded()
+					continue
+				}
 
-			// append dns message to buffer
-			bufferDm = append(bufferDm, dm)
+				dm.Retain(1)
+				// append dns message to buffer
+				bufferDm = append(bufferDm, dm)
 
-			// buffer is full ?
-			if len(bufferDm) >= w.GetConfig().Loggers.RedisPub.BufferSize {
-				w.FlushBuffer(&bufferDm)
+				// buffer is full ?
+				if len(bufferDm) >= w.GetConfig().Loggers.RedisPub.BufferSize {
+					w.FlushBuffer(&bufferDm)
+				}
 			}
+			batch.Release()
 
 		// flush the buffer
 		case <-flushTimer.C:

--- a/workers/redispub.go
+++ b/workers/redispub.go
@@ -33,9 +33,6 @@ type RedisPub struct {
 
 func NewRedisPub(config *pkgconfig.Config, logger *logger.Logger, name string) *RedisPub {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.RedisPub.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.RedisPub.ChannelBufferSize
-	}
 	w := &RedisPub{GenericWorker: NewGenericWorker(config, logger, name, "redispub", bufSize, pkgconfig.DefaultMonitor)}
 	w.stopRead = make(chan bool)
 	w.doneRead = make(chan bool)

--- a/workers/redispub_test.go
+++ b/workers/redispub_test.go
@@ -64,7 +64,7 @@ func Test_RedisPubRun(t *testing.T) {
 
 			// send fake dns message to logger
 			dm := dnsutils.GetFakeDNSMessage()
-			g.GetInputChannel() <- &dm
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 			// read data on server side and decode-it
 			reader := bufio.NewReader(conn)

--- a/workers/redispub_test.go
+++ b/workers/redispub_test.go
@@ -64,7 +64,7 @@ func Test_RedisPubRun(t *testing.T) {
 
 			// send fake dns message to logger
 			dm := dnsutils.GetFakeDNSMessage()
-			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 			// read data on server side and decode-it
 			reader := bufio.NewReader(conn)

--- a/workers/restapi.go
+++ b/workers/restapi.go
@@ -66,9 +66,6 @@ type RestAPI struct {
 
 func NewRestAPI(config *pkgconfig.Config, logger *logger.Logger, name string) *RestAPI {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.RestAPI.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.RestAPI.ChannelBufferSize
-	}
 	w := &RestAPI{GenericWorker: NewGenericWorker(config, logger, name, "restapi", bufSize, pkgconfig.DefaultMonitor)}
 	w.HitsStream = HitsStream{
 		Streams: make(map[string]SearchBy),

--- a/workers/restapi.go
+++ b/workers/restapi.go
@@ -673,26 +673,29 @@ func (w *RestAPI) StartCollect() {
 			w.ReadConfig()
 			subprocessors.ReloadConfig(&cfg.OutgoingTransformers)
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("input channel closed!")
 				return
 			}
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// apply transforms, init dns message with additional parts if necessary
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
+				// apply transforms, init dns message with additional parts if necessary
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
 
-			// send to output channel and forward
-			w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+				// send to output channel and forward
+				w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+			}
+			batch.Release()
 		}
 	}
 }
@@ -706,14 +709,16 @@ func (w *RestAPI) StartLogging() {
 		case <-w.OnLoggerStopped():
 			return
 
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
 			}
-			// record the dnstap message
-			w.RecordDNSMessage(dm)
-			dm.Release()
+			for _, dm := range batch.Messages {
+				// record the dnstap message
+				w.RecordDNSMessage(dm)
+			}
+			batch.Release()
 		}
 	}
 }

--- a/workers/scalyr.go
+++ b/workers/scalyr.go
@@ -158,25 +158,28 @@ func (w *ScalyrClient) StartCollect() {
 			w.ReadConfig()
 			subprocessors.ReloadConfig(&cfg.OutgoingTransformers)
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("input channel closed!")
 				return
 			}
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// apply transforms, init dns message with additional parts if necessary
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
+				// apply transforms, init dns message with additional parts if necessary
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
 
-			w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+				w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+			}
+			batch.Release()
 		}
 	}
 }
@@ -223,64 +226,64 @@ func (w *ScalyrClient) StartLogging() {
 			return
 
 			// incoming dns message to process
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
 			}
 
-			switch w.mode {
-			case pkgconfig.ModeText:
-				buf := w.GetTextBuffer() // get buffer from pool
-				var err error
-				if w.textFormatter != nil {
-					err = w.textFormatter.Format(dm, buf)
-				} else {
-					err = dm.ToTextLine(
-						w.textFormat,
-						w.GetConfig().Global.TextFormatDelimiter,
-						w.GetConfig().Global.TextFormatBoundary,
-						buf,
-					)
-				}
-				if err != nil {
-					w.CountEgressDiscarded()
-					w.LogError("could not encode to text format: %s", err)
-					w.PutTextBuffer(buf)
-					dm.Release()
-					continue
-				}
+			for _, dm := range batch.Messages {
+				switch w.mode {
+				case pkgconfig.ModeText:
+					buf := w.GetTextBuffer() // get buffer from pool
+					var err error
+					if w.textFormatter != nil {
+						err = w.textFormatter.Format(dm, buf)
+					} else {
+						err = dm.ToTextLine(
+							w.textFormat,
+							w.GetConfig().Global.TextFormatDelimiter,
+							w.GetConfig().Global.TextFormatBoundary,
+							buf,
+						)
+					}
+					if err != nil {
+						w.CountEgressDiscarded()
+						w.LogError("could not encode to text format: %s", err)
+						w.PutTextBuffer(buf)
+						continue
+					}
 
-				attrs["message"] = buf.String() // assign buffer content
-				w.PutTextBuffer(buf)            // return buffer to pool
-			case pkgconfig.ModeJSON:
-				attrs["message"] = dm
-			case pkgconfig.ModeFlatJSON:
-				var err error
-				if attrs, err = dm.Flatten(); err != nil {
-					w.LogError("unable to flatten: %e", err)
-					dm.Release()
-					break
-				}
-				// Add user's attrs without overwriting flattened ones
-				for k, v := range w.GetConfig().Loggers.ScalyrClient.Attrs {
-					if _, ok := attrs[k]; !ok {
-						attrs[k] = v
+					attrs["message"] = buf.String() // assign buffer content
+					w.PutTextBuffer(buf)            // return buffer to pool
+				case pkgconfig.ModeJSON:
+					attrs["message"] = dm
+				case pkgconfig.ModeFlatJSON:
+					var err error
+					if attrs, err = dm.Flatten(); err != nil {
+						w.LogError("unable to flatten: %e", err)
+						continue
+					}
+					// Add user's attrs without overwriting flattened ones
+					for k, v := range w.GetConfig().Loggers.ScalyrClient.Attrs {
+						if _, ok := attrs[k]; !ok {
+							attrs[k] = v
+						}
 					}
 				}
+				events = append(events, event{
+					TS:    strconv.FormatInt(time.Unix(int64(dm.DNSTap.TimeSec), int64(dm.DNSTap.TimeNsec)).UnixNano(), 10),
+					Sev:   SeverityInfo,
+					Attrs: attrs,
+				})
+				if len(events) >= 400 {
+					// Maximum size of a POST is 6MB. 400 events would mean that each dnstap entry
+					// can be a little over 15 kB in JSON, which should be plenty.
+					w.submitEventRecord(sInfo, events)
+					events = []event{}
+				}
 			}
-			events = append(events, event{
-				TS:    strconv.FormatInt(time.Unix(int64(dm.DNSTap.TimeSec), int64(dm.DNSTap.TimeNsec)).UnixNano(), 10),
-				Sev:   SeverityInfo,
-				Attrs: attrs,
-			})
-			dm.Release()
-			if len(events) >= 400 {
-				// Maximum size of a POST is 6MB. 400 events would mean that each dnstap entry
-				// can be a little over 15 kB in JSON, which should be plenty.
-				w.submitEventRecord(sInfo, events)
-				events = []event{}
-			}
+			batch.Release()
 		case <-w.flush.C:
 			if len(events) > 0 {
 				w.submitEventRecord(sInfo, events)

--- a/workers/scalyr.go
+++ b/workers/scalyr.go
@@ -46,9 +46,6 @@ type ScalyrClient struct {
 
 func NewScalyrClient(config *pkgconfig.Config, console *logger.Logger, name string) *ScalyrClient {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.ScalyrClient.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.ScalyrClient.ChannelBufferSize
-	}
 	w := &ScalyrClient{GenericWorker: NewGenericWorker(config, console, name, "scalyr", bufSize, pkgconfig.DefaultMonitor)}
 	w.mode = pkgconfig.ModeText
 	w.endpoint = makeEndpoint("app.scalyr.com")

--- a/workers/sniffer_afpacket.go
+++ b/workers/sniffer_afpacket.go
@@ -13,9 +13,6 @@ type AfpacketSniffer struct {
 
 func NewAfpacketSniffer(next []Worker, config *pkgconfig.Config, logger *logger.Logger, name string) *AfpacketSniffer {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Collectors.AfpacketLiveCapture.ChannelBufferSize > 0 {
-		bufSize = config.Collectors.AfpacketLiveCapture.ChannelBufferSize
-	}
 	w := &AfpacketSniffer{GenericWorker: NewGenericWorker(config, logger, name, "AFPACKET sniffer", bufSize, pkgconfig.DefaultMonitor)}
 	w.SetDefaultRoutes(next)
 	w.ReadConfig()

--- a/workers/sniffer_afpacket_linux.go
+++ b/workers/sniffer_afpacket_linux.go
@@ -27,9 +27,6 @@ type AfpacketSniffer struct {
 
 func NewAfpacketSniffer(next []Worker, config *pkgconfig.Config, logger *logger.Logger, name string) *AfpacketSniffer {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Collectors.AfpacketLiveCapture.ChannelBufferSize > 0 {
-		bufSize = config.Collectors.AfpacketLiveCapture.ChannelBufferSize
-	}
 	w := &AfpacketSniffer{GenericWorker: NewGenericWorker(config, logger, name, "afpacket sniffer", bufSize, pkgconfig.DefaultMonitor)}
 	w.SetDefaultRoutes(next)
 	return w
@@ -99,9 +96,6 @@ func (w *AfpacketSniffer) StartCollect() {
 	}
 
 	bufSize := w.GetConfig().Global.Worker.ChannelBufferSize
-	if w.GetConfig().Collectors.AfpacketLiveCapture.ChannelBufferSize > 0 {
-		bufSize = w.GetConfig().Collectors.AfpacketLiveCapture.ChannelBufferSize
-	}
 	dnsProcessor := NewDNSProcessor(w.GetConfig(), w.GetLogger(), w.GetName(), bufSize)
 	dnsProcessor.SetDefaultRoutes(w.GetDefaultRoutes())
 	dnsProcessor.SetDefaultDropped(w.GetDroppedRoutes())

--- a/workers/sniffer_afpacket_linux.go
+++ b/workers/sniffer_afpacket_linux.go
@@ -293,7 +293,9 @@ func (w *AfpacketSniffer) StartCollect() {
 			dm.DNSTap.TimeNsec = int(timestamp - seconds*int64(time.Second)*int64(time.Nanosecond))
 
 			// send DNS message to DNS processor
-			dnsProcessor.GetInputChannel() <- dm
+			b := dnsutils.AcquireDNSMessageBatch(1)
+			b.Messages = append(b.Messages, dm)
+			dnsProcessor.GetInputChannel() <- b
 		}
 	}
 }

--- a/workers/sniffer_afpacket_test.go
+++ b/workers/sniffer_afpacket_test.go
@@ -25,8 +25,8 @@ func TestAfpacketSnifferRun(t *testing.T) {
 
 	// waiting message in channel
 	for {
-		msg := <-g.GetInputChannel()
-		if msg.DNSTap.Operation == dnsutils.DNSTapClientQuery && msg.DNS.Qname == pkgconfig.ProgQname {
+		batch := <-g.GetInputChannel()
+		if len(batch.Messages) > 0 && batch.Messages[0].DNSTap.Operation == dnsutils.DNSTapClientQuery && batch.Messages[0].DNS.Qname == pkgconfig.ProgQname {
 			break
 		}
 	}

--- a/workers/sniffer_xdp.go
+++ b/workers/sniffer_xdp.go
@@ -202,7 +202,9 @@ func (w *XDPSniffer) StartCollect() {
 			// update identity with config ?
 			dm.DNSTap.Identity = w.GetConfig().GetServerIdentity()
 
-			dnsProcessor.GetInputChannel() <- dm
+			b := dnsutils.AcquireDNSMessageBatch(1)
+			b.Messages = append(b.Messages, dm)
+			dnsProcessor.GetInputChannel() <- b
 		}
 	}
 }

--- a/workers/sniffer_xdp.go
+++ b/workers/sniffer_xdp.go
@@ -25,9 +25,6 @@ type XDPSniffer struct {
 
 func NewXDPSniffer(next []Worker, config *pkgconfig.Config, logger *logger.Logger, name string) *XDPSniffer {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Collectors.XdpLiveCapture.ChannelBufferSize > 0 {
-		bufSize = config.Collectors.XdpLiveCapture.ChannelBufferSize
-	}
 	w := &XDPSniffer{GenericWorker: NewGenericWorker(config, logger, name, "xdp sniffer", bufSize, pkgconfig.DefaultMonitor)}
 	w.SetDefaultRoutes(next)
 	return w
@@ -39,9 +36,6 @@ func (w *XDPSniffer) StartCollect() {
 
 	// init dns processor
 	bufSize := w.GetConfig().Global.Worker.ChannelBufferSize
-	if w.GetConfig().Collectors.XdpLiveCapture.ChannelBufferSize > 0 {
-		bufSize = w.GetConfig().Collectors.XdpLiveCapture.ChannelBufferSize
-	}
 	dnsProcessor := NewDNSProcessor(w.GetConfig(), w.GetLogger(), w.GetName(), bufSize)
 	dnsProcessor.SetDefaultRoutes(w.GetDefaultRoutes())
 	dnsProcessor.SetDefaultDropped(w.GetDroppedRoutes())

--- a/workers/sniffer_xdp_windows.go
+++ b/workers/sniffer_xdp_windows.go
@@ -13,9 +13,6 @@ type XDPSniffer struct {
 
 func NewXDPSniffer(next []Worker, config *pkgconfig.Config, logger *logger.Logger, name string) *XDPSniffer {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Collectors.XdpLiveCapture.ChannelBufferSize > 0 {
-		bufSize = config.Collectors.XdpLiveCapture.ChannelBufferSize
-	}
 	w := &XDPSniffer{GenericWorker: NewGenericWorker(config, logger, name, "xdp sniffer", bufSize, pkgconfig.DefaultMonitor)}
 	w.SetDefaultRoutes(next)
 	w.ReadConfig()

--- a/workers/statsd.go
+++ b/workers/statsd.go
@@ -36,9 +36,6 @@ type StatsdClient struct {
 
 func NewStatsdClient(config *pkgconfig.Config, logger *logger.Logger, name string) *StatsdClient {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.Statsd.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.Statsd.ChannelBufferSize
-	}
 	w := &StatsdClient{GenericWorker: NewGenericWorker(config, logger, name, "statsd", bufSize, pkgconfig.DefaultMonitor)}
 	w.Stats = StreamStats{Streams: make(map[string]*StatsPerStream)}
 	w.ReadConfig()

--- a/workers/statsd.go
+++ b/workers/statsd.go
@@ -175,25 +175,28 @@ func (w *StatsdClient) StartCollect() {
 			w.ReadConfig()
 			subprocessors.ReloadConfig(&cfg.OutgoingTransformers)
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("input channel closed!")
 				return
 			}
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// apply transforms, init dns message with additional parts if necessary
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
+				// apply transforms, init dns message with additional parts if necessary
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
 
-			w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+				w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+			}
+			batch.Release()
 		}
 	}
 }
@@ -212,15 +215,17 @@ func (w *StatsdClient) StartLogging() {
 			return
 
 		// incoming dns message to process
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
 			}
 
-			// record the dnstap message
-			w.RecordDNSMessage(dm)
-			dm.Release()
+			for _, dm := range batch.Messages {
+				// record the dnstap message
+				w.RecordDNSMessage(dm)
+			}
+			batch.Release()
 
 		case <-t2.C:
 			address := w.GetConfig().Loggers.Statsd.RemoteAddress + ":" + strconv.Itoa(w.GetConfig().Loggers.Statsd.RemotePort)

--- a/workers/statsd_test.go
+++ b/workers/statsd_test.go
@@ -29,7 +29,7 @@ func TestStatsdRun(t *testing.T) {
 
 	// send fake dns message to logger
 	dm := dnsutils.GetFakeDNSMessage()
-	g.GetInputChannel() <- &dm
+	g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 	// read data on fake server side
 	buf := make([]byte, 4096)

--- a/workers/statsd_test.go
+++ b/workers/statsd_test.go
@@ -29,7 +29,7 @@ func TestStatsdRun(t *testing.T) {
 
 	// send fake dns message to logger
 	dm := dnsutils.GetFakeDNSMessage()
-	g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+	g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 	// read data on fake server side
 	buf := make([]byte, 4096)

--- a/workers/stdout.go
+++ b/workers/stdout.go
@@ -121,26 +121,29 @@ func (w *StdOut) StartCollect() {
 			w.ReadConfig()
 			subprocessors.ReloadConfig(&cfg.OutgoingTransformers)
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("run: input channel closed!")
 				return
 			}
 
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// apply transforms, init dns message with additional parts if necessary
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
+				// apply transforms, init dns message with additional parts if necessary
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
 
-			w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+				w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+			}
+			batch.Release()
 		}
 	}
 }
@@ -177,113 +180,109 @@ func (w *StdOut) StartLogging() {
 		case <-flushTicker.C:
 			w.writerRaw.Flush()
 
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("process: output channel closed!")
 				return
 			}
 
-			switch w.GetConfig().Loggers.Stdout.Mode {
-			case pkgconfig.ModePCAP:
-				if len(dm.DNS.Payload) == 0 {
-					w.CountEgressDiscarded()
-					w.LogError("process: no dns payload to encode, drop it")
-					dm.Release()
-					continue
-				}
-
-				pkt, err := dm.ToPacketLayer(w.GetConfig().Loggers.Stdout.OverwriteDNSPortPcap)
-				if err != nil {
-					w.CountEgressDiscarded()
-					w.LogError("process: unable to pack layer: %s", err)
-					dm.Release()
-					continue
-				}
-
-				buf := gopacket.NewSerializeBuffer()
-				opts := gopacket.SerializeOptions{
-					FixLengths:       true,
-					ComputeChecksums: true,
-				}
-				for _, l := range pkt {
-					l.SerializeTo(buf, opts)
-				}
-
-				bufSize := len(buf.Bytes())
-				ci := gopacket.CaptureInfo{
-					Timestamp:     time.Unix(int64(dm.DNSTap.TimeSec), int64(dm.DNSTap.TimeNsec)),
-					CaptureLength: bufSize,
-					Length:        bufSize,
-				}
-
-				w.writerPcap.WritePacket(ci, buf.Bytes())
-
-			case pkgconfig.ModeText:
-				// get buffer from pool
-				buf := w.GetTextBuffer()
-				buf.Reset()
-
-				var err error
-				if w.textFormatter != nil {
-					err = w.textFormatter.Format(dm, buf)
-				} else {
-					err = dm.ToTextLine(w.textFormat, w.GetConfig().Global.TextFormatDelimiter, w.GetConfig().Global.TextFormatBoundary, buf)
-				}
-				if err == nil {
-					w.writerRaw.Write(buf.Bytes())
-					w.writerRaw.WriteByte('\n')
-				}
-
-				// return buffer to pool
-				w.PutTextBuffer(buf)
-
-			case pkgconfig.ModeJinja:
-				textLine, err := dm.ToTextTemplate(w.jinjaFormat)
-				if err != nil {
-					w.CountEgressDiscarded()
-					w.LogError("process: unable to update template: %s", err)
-					dm.Release()
-					continue
-				}
-				w.writerRaw.WriteString(textLine)
-				w.writerRaw.WriteByte('\n')
-
-			case pkgconfig.ModeJSON:
-				err := jsonEncoder.Encode(dm)
-				if err != nil {
-					w.CountEgressDiscarded()
-					w.LogError("process: unable to encode json: %s", err)
-					dm.Release()
-					continue
-				}
-
-			case pkgconfig.ModeFlatJSON:
-				if dm.Relabeling != nil {
-					flat, err := dm.Flatten()
-					if err != nil {
+			for _, dm := range batch.Messages {
+				switch w.GetConfig().Loggers.Stdout.Mode {
+				case pkgconfig.ModePCAP:
+					if len(dm.DNS.Payload) == 0 {
 						w.CountEgressDiscarded()
-						w.LogError("process: flattening DNS message failed: %e", err)
-						dm.Release()
+						w.LogError("process: no dns payload to encode, drop it")
 						continue
 					}
-					err = jsonEncoder.Encode(flat)
+
+					pkt, err := dm.ToPacketLayer(w.GetConfig().Loggers.Stdout.OverwriteDNSPortPcap)
 					if err != nil {
 						w.CountEgressDiscarded()
-						w.LogError("process: unable to encode flat json: %s", err)
-						dm.Release()
+						w.LogError("process: unable to pack layer: %s", err)
 						continue
 					}
-				} else {
+
+					buf := gopacket.NewSerializeBuffer()
+					opts := gopacket.SerializeOptions{
+						FixLengths:       true,
+						ComputeChecksums: true,
+					}
+					for _, l := range pkt {
+						l.SerializeTo(buf, opts)
+					}
+
+					bufSize := len(buf.Bytes())
+					ci := gopacket.CaptureInfo{
+						Timestamp:     time.Unix(int64(dm.DNSTap.TimeSec), int64(dm.DNSTap.TimeNsec)),
+						CaptureLength: bufSize,
+						Length:        bufSize,
+					}
+
+					w.writerPcap.WritePacket(ci, buf.Bytes())
+
+				case pkgconfig.ModeText:
+					// get buffer from pool
 					buf := w.GetTextBuffer()
 					buf.Reset()
-					dm.GetTimestampRFC3339()
-					dm.EncodeFlatJSON(buf)
-					buf.WriteByte('\n')
-					w.writerRaw.Write(buf.Bytes())
+
+					var err error
+					if w.textFormatter != nil {
+						err = w.textFormatter.Format(dm, buf)
+					} else {
+						err = dm.ToTextLine(w.textFormat, w.GetConfig().Global.TextFormatDelimiter, w.GetConfig().Global.TextFormatBoundary, buf)
+					}
+					if err == nil {
+						w.writerRaw.Write(buf.Bytes())
+						w.writerRaw.WriteByte('\n')
+					}
+
+					// return buffer to pool
 					w.PutTextBuffer(buf)
+
+				case pkgconfig.ModeJinja:
+					textLine, err := dm.ToTextTemplate(w.jinjaFormat)
+					if err != nil {
+						w.CountEgressDiscarded()
+						w.LogError("process: unable to update template: %s", err)
+						continue
+					}
+					w.writerRaw.WriteString(textLine)
+					w.writerRaw.WriteByte('\n')
+
+				case pkgconfig.ModeJSON:
+					err := jsonEncoder.Encode(dm)
+					if err != nil {
+						w.CountEgressDiscarded()
+						w.LogError("process: unable to encode json: %s", err)
+						continue
+					}
+
+				case pkgconfig.ModeFlatJSON:
+					if dm.Relabeling != nil {
+						flat, err := dm.Flatten()
+						if err != nil {
+							w.CountEgressDiscarded()
+							w.LogError("process: flattening DNS message failed: %e", err)
+							continue
+						}
+						err = jsonEncoder.Encode(flat)
+						if err != nil {
+							w.CountEgressDiscarded()
+							w.LogError("process: unable to encode flat json: %s", err)
+							continue
+						}
+					} else {
+						buf := w.GetTextBuffer()
+						buf.Reset()
+						dm.GetTimestampRFC3339()
+						dm.EncodeFlatJSON(buf)
+						buf.WriteByte('\n')
+						w.writerRaw.Write(buf.Bytes())
+						w.PutTextBuffer(buf)
+					}
 				}
 			}
-			dm.Release()
+			batch.Release()
 		}
 	}
 }

--- a/workers/stdout.go
+++ b/workers/stdout.go
@@ -41,9 +41,6 @@ type StdOut struct {
 
 func NewStdOut(config *pkgconfig.Config, console *logger.Logger, name string) *StdOut {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.Stdout.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.Stdout.ChannelBufferSize
-	}
 	w := &StdOut{GenericWorker: NewGenericWorker(config, console, name, "stdout", bufSize, pkgconfig.DefaultMonitor)}
 
 	// init writers with buffer to minimize syscalls

--- a/workers/stdout_bench_test.go
+++ b/workers/stdout_bench_test.go
@@ -33,7 +33,7 @@ func benchmarkStdoutMode(b *testing.B, mode string) {
 
 	for i := 0; i < b.N; i++ {
 		msg := dm
-		inChan <- &msg
+		inChan <- dnsutils.NewDNSMessageBatchFromMessage(&msg)
 	}
 }
 

--- a/workers/stdout_bench_test.go
+++ b/workers/stdout_bench_test.go
@@ -12,7 +12,7 @@ import (
 func benchmarkStdoutMode(b *testing.B, mode string) {
 	config := pkgconfig.GetDefaultConfig()
 	config.Loggers.Stdout.Mode = mode
-	config.Loggers.Stdout.ChannelBufferSize = 65536
+	config.Global.Worker.ChannelBufferSize = 65536
 
 	stdout := NewStdOut(config, logger.New(false), "stdout")
 	if mode == pkgconfig.ModePCAP {

--- a/workers/stdout_bench_test.go
+++ b/workers/stdout_bench_test.go
@@ -33,7 +33,7 @@ func benchmarkStdoutMode(b *testing.B, mode string) {
 
 	for i := 0; i < b.N; i++ {
 		msg := dm
-		inChan <- dnsutils.NewDNSMessageBatchFromMessage(&msg)
+		inChan <- dnsutils.NewDNSMessageBatch(&msg)
 	}
 }
 

--- a/workers/stdout_test.go
+++ b/workers/stdout_test.go
@@ -79,7 +79,7 @@ func Test_StdoutTextMode(t *testing.T) {
 			// print dns message to stdout buffer
 			dm := dnsutils.GetFakeDNSMessage()
 			dm.DNS.Qname = tc.qname
-			g.GetInputChannel() <- &dm
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 			// stop logger
 			time.Sleep(time.Second)
@@ -122,7 +122,7 @@ func Test_StdoutJsonMode(t *testing.T) {
 
 			// print dns message to stdout buffer
 			dm := dnsutils.GetFakeDNSMessage()
-			g.GetInputChannel() <- &dm
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 			// stop logger
 			time.Sleep(time.Second)
@@ -153,7 +153,7 @@ func Test_StdoutPcapMode(t *testing.T) {
 
 	// send DNSMessage to channel
 	dm := dnsutils.GetFakeDNSMessageWithPayload()
-	g.GetInputChannel() <- &dm
+	g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 	// stop logger
 	time.Sleep(time.Second)
@@ -194,7 +194,7 @@ func Test_StdoutPcapMode_NoDNSPayload(t *testing.T) {
 
 	// send DNSMessage to channel
 	dm := dnsutils.GetFakeDNSMessage()
-	g.GetInputChannel() <- &dm
+	g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 	// stop logger
 	time.Sleep(time.Second)
@@ -232,7 +232,7 @@ func Test_StdoutBufferLoggerIsFull(t *testing.T) {
 	// add a shot of dnsmessages to collector
 	for range 512 {
 		dmIn := dnsutils.GetFakeDNSMessage()
-		g.GetInputChannel() <- &dmIn
+		g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dmIn)
 	}
 
 	// waiting monitor to run in consumer
@@ -247,15 +247,15 @@ func Test_StdoutBufferLoggerIsFull(t *testing.T) {
 	}
 
 	// read dns message from dnstap consumer
-	dmOut := <-nxt.GetInputChannel()
-	if dmOut.DNS.Qname != pkgconfig.ExpectedQname2 {
-		t.Errorf("invalid qname in dns message: %s", dmOut.DNS.Qname)
+	batchOut := <-nxt.GetInputChannel()
+	if len(batchOut.Messages) == 0 || batchOut.Messages[0].DNS.Qname != pkgconfig.ExpectedQname2 {
+		t.Errorf("invalid qname in dns message: %v", batchOut.Messages)
 	}
 
 	// send second shot of packets to consumer
 	for range 1024 {
 		dmIn := dnsutils.GetFakeDNSMessage()
-		g.GetInputChannel() <- &dmIn
+		g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dmIn)
 	}
 
 	// waiting monitor to run in consumer
@@ -269,9 +269,9 @@ func Test_StdoutBufferLoggerIsFull(t *testing.T) {
 	}
 
 	// read dns message from dnstap consumer
-	dmOut2 := <-nxt.GetInputChannel()
-	if dmOut2.DNS.Qname != pkgconfig.ExpectedQname2 {
-		t.Errorf("invalid qname in second dns message: %s", dmOut2.DNS.Qname)
+	batchOut2 := <-nxt.GetInputChannel()
+	if len(batchOut2.Messages) == 0 || batchOut2.Messages[0].DNS.Qname != pkgconfig.ExpectedQname2 {
+		t.Errorf("invalid qname in second dns message: %v", batchOut2.Messages)
 	}
 
 	// stop loggers
@@ -292,7 +292,7 @@ func Test_StdoutTextMode_Batching(t *testing.T) {
 
 	for range 5 {
 		dm := dnsutils.GetFakeDNSMessage()
-		g.GetInputChannel() <- &dm
+		g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 	}
 
 	// wait for flush 2s > to the default 1s flush interval

--- a/workers/stdout_test.go
+++ b/workers/stdout_test.go
@@ -212,7 +212,7 @@ func Test_StdoutPcapMode_NoDNSPayload(t *testing.T) {
 // test for issue https://github.com/dmachard/go-dnscollector/v2/issues/568
 func Test_StdoutBufferLoggerIsFull(t *testing.T) {
 	// redirect stdout output to bytes buffer
-	logsChan := make(chan logger.LogEntry, 10)
+	logsChan := make(chan logger.LogEntry, 512)
 	lg := logger.New(true)
 	lg.SetOutputChannel((logsChan))
 

--- a/workers/stdout_test.go
+++ b/workers/stdout_test.go
@@ -79,7 +79,7 @@ func Test_StdoutTextMode(t *testing.T) {
 			// print dns message to stdout buffer
 			dm := dnsutils.GetFakeDNSMessage()
 			dm.DNS.Qname = tc.qname
-			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 			// stop logger
 			time.Sleep(time.Second)
@@ -122,7 +122,7 @@ func Test_StdoutJsonMode(t *testing.T) {
 
 			// print dns message to stdout buffer
 			dm := dnsutils.GetFakeDNSMessage()
-			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 			// stop logger
 			time.Sleep(time.Second)
@@ -153,7 +153,7 @@ func Test_StdoutPcapMode(t *testing.T) {
 
 	// send DNSMessage to channel
 	dm := dnsutils.GetFakeDNSMessageWithPayload()
-	g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+	g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 	// stop logger
 	time.Sleep(time.Second)
@@ -194,7 +194,7 @@ func Test_StdoutPcapMode_NoDNSPayload(t *testing.T) {
 
 	// send DNSMessage to channel
 	dm := dnsutils.GetFakeDNSMessage()
-	g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+	g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 	// stop logger
 	time.Sleep(time.Second)
@@ -232,7 +232,7 @@ func Test_StdoutBufferLoggerIsFull(t *testing.T) {
 	// add a shot of dnsmessages to collector
 	for range 512 {
 		dmIn := dnsutils.GetFakeDNSMessage()
-		g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dmIn)
+		g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dmIn)
 	}
 
 	// waiting monitor to run in consumer
@@ -255,7 +255,7 @@ func Test_StdoutBufferLoggerIsFull(t *testing.T) {
 	// send second shot of packets to consumer
 	for range 1024 {
 		dmIn := dnsutils.GetFakeDNSMessage()
-		g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dmIn)
+		g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dmIn)
 	}
 
 	// waiting monitor to run in consumer
@@ -292,7 +292,7 @@ func Test_StdoutTextMode_Batching(t *testing.T) {
 
 	for range 5 {
 		dm := dnsutils.GetFakeDNSMessage()
-		g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+		g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 	}
 
 	// wait for flush 2s > to the default 1s flush interval

--- a/workers/syslog.go
+++ b/workers/syslog.go
@@ -29,9 +29,6 @@ type Syslog struct {
 
 func NewSyslog(config *pkgconfig.Config, console *logger.Logger, name string) *Syslog {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.Syslog.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.Syslog.ChannelBufferSize
-	}
 	w := &Syslog{GenericWorker: NewGenericWorker(config, console, name, "syslog", bufSize, pkgconfig.DefaultMonitor)}
 	w.transportReady = make(chan bool)
 	w.transportReconnect = make(chan bool)
@@ -262,9 +259,11 @@ func (w *Syslog) FlushBuffer(buf *[]*dnsutils.DNSMessage) {
 			// because the NULL is at end of log in syslog
 			nullReplace := w.GetConfig().Loggers.Syslog.ReplaceNullChar
 			data := buf.Bytes()
-			for i := 0; i < len(data); i++ {
-				if data[i] == 0 {
-					data[i] = nullReplace[0]
+			if len(nullReplace) > 0 {
+				for i := 0; i < len(data); i++ {
+					if data[i] == 0 {
+						data[i] = nullReplace[0]
+					}
 				}
 			}
 

--- a/workers/syslog.go
+++ b/workers/syslog.go
@@ -197,25 +197,28 @@ func (w *Syslog) StartCollect() {
 			w.ReadConfig()
 			subprocessors.ReloadConfig(&cfg.OutgoingTransformers)
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("input channel closed!")
 				return
 			}
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// apply transforms, init dns message with additional parts if necessary
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
+				// apply transforms, init dns message with additional parts if necessary
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
 
-			w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+				w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+			}
+			batch.Release()
 		}
 	}
 }
@@ -355,25 +358,29 @@ func (w *Syslog) StartLogging() {
 			w.syslogReady = true
 
 			// incoming dns message to process
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
 			}
 
-			// discard dns message if the connection is not ready
-			if !w.syslogReady {
-				w.CountEgressDiscarded()
-				dm.Release()
-				continue
-			}
-			// append dns message to buffer
-			bufferDm = append(bufferDm, dm)
+			for _, dm := range batch.Messages {
+				// discard dns message if the connection is not ready
+				if !w.syslogReady {
+					w.CountEgressDiscarded()
+					continue
+				}
 
-			// buffer is full ?
-			if len(bufferDm) >= w.GetConfig().Loggers.Syslog.BufferSize {
-				w.FlushBuffer(&bufferDm)
+				dm.Retain(1)
+				// append dns message to buffer
+				bufferDm = append(bufferDm, dm)
+
+				// buffer is full ?
+				if len(bufferDm) >= w.GetConfig().Loggers.Syslog.BufferSize {
+					w.FlushBuffer(&bufferDm)
+				}
 			}
+			batch.Release()
 
 			// flush the buffer
 		case <-flushTimer.C:

--- a/workers/syslog_test.go
+++ b/workers/syslog_test.go
@@ -88,7 +88,7 @@ func Test_SyslogRunUdp(t *testing.T) {
 			// send fake dns message to logger
 			time.Sleep(time.Second)
 			dm := dnsutils.GetFakeDNSMessage()
-			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 			// read data on fake server side
 			buf := make([]byte, 4096)
@@ -191,7 +191,7 @@ func Test_SyslogRunTcp(t *testing.T) {
 			// send fake dns message to logger
 			time.Sleep(time.Second)
 			dm := dnsutils.GetFakeDNSMessage()
-			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 			// read data on server side and decode-it
 			reader := bufio.NewReader(conn)
@@ -235,7 +235,7 @@ func Test_SyslogRun_RemoveNullCharacter(t *testing.T) {
 	time.Sleep(time.Second)
 	dm := dnsutils.GetFakeDNSMessage()
 	dm.DNS.Qname = "null\x00char.com"
-	g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+	g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 	// read data on fake server side
 	buf := make([]byte, (500))

--- a/workers/syslog_test.go
+++ b/workers/syslog_test.go
@@ -88,7 +88,7 @@ func Test_SyslogRunUdp(t *testing.T) {
 			// send fake dns message to logger
 			time.Sleep(time.Second)
 			dm := dnsutils.GetFakeDNSMessage()
-			g.GetInputChannel() <- &dm
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 			// read data on fake server side
 			buf := make([]byte, 4096)
@@ -191,7 +191,7 @@ func Test_SyslogRunTcp(t *testing.T) {
 			// send fake dns message to logger
 			time.Sleep(time.Second)
 			dm := dnsutils.GetFakeDNSMessage()
-			g.GetInputChannel() <- &dm
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 			// read data on server side and decode-it
 			reader := bufio.NewReader(conn)
@@ -235,7 +235,7 @@ func Test_SyslogRun_RemoveNullCharacter(t *testing.T) {
 	time.Sleep(time.Second)
 	dm := dnsutils.GetFakeDNSMessage()
 	dm.DNS.Qname = "null\x00char.com"
-	g.GetInputChannel() <- &dm
+	g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 	// read data on fake server side
 	buf := make([]byte, (500))

--- a/workers/tcpclient.go
+++ b/workers/tcpclient.go
@@ -252,25 +252,28 @@ func (w *TCPClient) StartCollect() {
 			w.ReadConfig()
 			subprocessors.ReloadConfig(&cfg.OutgoingTransformers)
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("input channel closed!")
 				return
 			}
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// apply transforms, init dns message with additional parts if necessary
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
+				// apply transforms, init dns message with additional parts if necessary
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
 
-			w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+				w.SendToOutputAndForward(defaultRoutes, defaultNames, dm)
+			}
+			batch.Release()
 		}
 	}
 }
@@ -306,27 +309,30 @@ func (w *TCPClient) StartLogging() {
 			go w.ReadFromConnection()
 
 		// incoming dns message to process
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
 			}
 
-			// drop dns message if the connection is not ready to avoid memory leak or
-			// to block the channel
-			if !w.writerReady {
-				w.CountEgressDiscarded()
-				dm.Release()
-				continue
-			}
+			for _, dm := range batch.Messages {
+				// drop dns message if the connection is not ready to avoid memory leak or
+				// to block the channel
+				if !w.writerReady {
+					w.CountEgressDiscarded()
+					continue
+				}
 
-			// append dns message to buffer
-			bufferDm = append(bufferDm, dm)
+				dm.Retain(1)
+				// append dns message to buffer
+				bufferDm = append(bufferDm, dm)
 
-			// buffer is full ?
-			if len(bufferDm) >= w.GetConfig().Loggers.TCPClient.BufferSize {
-				w.FlushBuffer(&bufferDm)
+				// buffer is full ?
+				if len(bufferDm) >= w.GetConfig().Loggers.TCPClient.BufferSize {
+					w.FlushBuffer(&bufferDm)
+				}
 			}
+			batch.Release()
 
 		// flush the buffer
 		case <-flushTimer.C:

--- a/workers/tcpclient.go
+++ b/workers/tcpclient.go
@@ -32,9 +32,6 @@ type TCPClient struct {
 
 func NewTCPClient(config *pkgconfig.Config, logger *logger.Logger, name string) *TCPClient {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Loggers.TCPClient.ChannelBufferSize > 0 {
-		bufSize = config.Loggers.TCPClient.ChannelBufferSize
-	}
 	w := &TCPClient{GenericWorker: NewGenericWorker(config, logger, name, "tcpclient", bufSize, pkgconfig.DefaultMonitor)}
 	w.transportReady = make(chan bool)
 	w.transportReconnect = make(chan bool)

--- a/workers/tcpclient_test.go
+++ b/workers/tcpclient_test.go
@@ -65,7 +65,7 @@ func Test_TcpClientRun(t *testing.T) {
 
 			// send fake dns message to logger
 			dm := dnsutils.GetFakeDNSMessage()
-			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 			// read data on server side and decode-it
 			reader := bufio.NewReader(conn)
@@ -124,7 +124,7 @@ func Test_TcpClient_ConnectionAttempt(t *testing.T) {
 
 	// send fake dns message to logger
 	dm := dnsutils.GetFakeDNSMessage()
-	g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+	g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 	// read data on server side and decode-it
 	reader := bufio.NewReader(conn)

--- a/workers/tcpclient_test.go
+++ b/workers/tcpclient_test.go
@@ -65,7 +65,7 @@ func Test_TcpClientRun(t *testing.T) {
 
 			// send fake dns message to logger
 			dm := dnsutils.GetFakeDNSMessage()
-			g.GetInputChannel() <- &dm
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 			// read data on server side and decode-it
 			reader := bufio.NewReader(conn)
@@ -124,7 +124,7 @@ func Test_TcpClient_ConnectionAttempt(t *testing.T) {
 
 	// send fake dns message to logger
 	dm := dnsutils.GetFakeDNSMessage()
-	g.GetInputChannel() <- &dm
+	g.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
 	// read data on server side and decode-it
 	reader := bufio.NewReader(conn)

--- a/workers/tzsp_linux.go
+++ b/workers/tzsp_linux.go
@@ -218,7 +218,9 @@ func (w *TZSPSniffer) StartCollect() {
 						continue
 					}
 
-					dnsProcessor.GetInputChannel() <- dm
+					b := dnsutils.AcquireDNSMessageBatch(1)
+					b.Messages = append(b.Messages, dm)
+					dnsProcessor.GetInputChannel() <- b
 				} else {
 					dm.Release()
 				}

--- a/workers/tzsp_linux.go
+++ b/workers/tzsp_linux.go
@@ -30,9 +30,6 @@ type TZSPSniffer struct {
 
 func NewTZSP(next []Worker, config *pkgconfig.Config, logger *logger.Logger, name string) *TZSPSniffer {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Collectors.Tzsp.ChannelBufferSize > 0 {
-		bufSize = config.Collectors.Tzsp.ChannelBufferSize
-	}
 	s := &TZSPSniffer{GenericWorker: NewGenericWorker(config, logger, name, "tzsp", bufSize, pkgconfig.DefaultMonitor)}
 	s.SetDefaultRoutes(next)
 	return s
@@ -85,7 +82,7 @@ func (w *TZSPSniffer) StartCollect() {
 	}
 
 	// init dns processor
-	dnsProcessor := NewDNSProcessor(w.GetConfig(), w.GetLogger(), w.GetName(), w.GetConfig().Collectors.Tzsp.ChannelBufferSize)
+	dnsProcessor := NewDNSProcessor(w.GetConfig(), w.GetLogger(), w.GetName(), w.GetConfig().Global.Worker.ChannelBufferSize)
 	dnsProcessor.SetDefaultRoutes(w.GetDefaultRoutes())
 	dnsProcessor.SetDefaultDropped(w.GetDroppedRoutes())
 	go dnsProcessor.StartCollect()

--- a/workers/webhook.go
+++ b/workers/webhook.go
@@ -79,28 +79,34 @@ func (w *Webhook) StartCollect() {
 			w.SetConfig(cfg)
 			w.ReadConfig()
 
-		case dm, opened := <-w.GetInputChannel():
+		case batch, opened := <-w.GetInputChannel():
 			if !opened {
 				w.LogInfo("channel closed, exit")
 				cancel()
 				return
 			}
-			// count global messages
-			w.CountIngressTraffic()
+			for _, dm := range batch.Messages {
+				// count global messages
+				w.CountIngressTraffic()
 
-			// apply transforms, init dns message with additional parts if necessary
-			transformResult, err := subprocessors.ProcessMessage(dm)
-			if err != nil {
-				w.LogError(err.Error())
-			}
-			if transformResult == transformers.ReturnDrop {
-				w.SendDroppedTo(droppedRoutes, droppedNames, dm)
-				continue
-			}
-			// count output packets
-			w.CountEgressTraffic()
+				// apply transforms, init dns message with additional parts if necessary
+				transformResult, err := subprocessors.ProcessMessage(dm)
+				if err != nil {
+					w.LogError(err.Error())
+				}
+				if transformResult == transformers.ReturnDrop {
+					w.SendDroppedTo(droppedRoutes, droppedNames, dm)
+					continue
+				}
+				// count output packets
+				w.CountEgressTraffic()
 
-			w.GetOutputChannel() <- dm
+				dm.Retain(1)
+				b := dnsutils.AcquireDNSMessageBatch(1)
+				b.Messages = append(b.Messages, dm)
+				w.GetOutputChannel() <- b
+			}
+			batch.Release()
 		}
 	}
 }
@@ -116,17 +122,20 @@ func (w *Webhook) StartLogging(threadnum int, ctx context.Context) {
 		case <-ctx.Done():
 			return
 
-		case dm, opened := <-w.GetOutputChannel():
+		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
 				return
 			}
 
-			// enrich dm with HTTP data
-			w.Request(dm)
+			for _, dm := range batch.Messages {
+				// enrich dm with HTTP data
+				w.Request(dm)
 
-			// send to next
-			w.SendForwardedTo(defaultRoutes, defaultNames, dm)
+				// send to next
+				w.SendForwardedTo(defaultRoutes, defaultNames, dm)
+			}
+			batch.Release()
 		}
 	}
 }

--- a/workers/webhook.go
+++ b/workers/webhook.go
@@ -25,9 +25,6 @@ type Webhook struct {
 
 func NewWebhook(next []Worker, config *pkgconfig.Config, logger *logger.Logger, name string) *Webhook {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	if config.Collectors.Webhook.ChannelBufferSize > 0 {
-		bufSize = config.Collectors.Webhook.ChannelBufferSize
-	}
 	w := &Webhook{GenericWorker: NewGenericWorker(config, logger, name, "webhook", bufSize, pkgconfig.DefaultMonitor)}
 	w.SetDefaultRoutes(next)
 	w.ReadConfig()

--- a/workers/webhook_test.go
+++ b/workers/webhook_test.go
@@ -52,7 +52,7 @@ func Test_Webhook(t *testing.T) {
 
 	// send fake dns message to logger
 	dm := dnsutils.GetFakeDNSMessage()
-	c.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
+	c.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 
 	batchOut := <-kept.GetInputChannel()
 	if len(batchOut.Messages) == 0 {

--- a/workers/webhook_test.go
+++ b/workers/webhook_test.go
@@ -52,9 +52,13 @@ func Test_Webhook(t *testing.T) {
 
 	// send fake dns message to logger
 	dm := dnsutils.GetFakeDNSMessage()
-	c.GetInputChannel() <- &dm
+	c.GetInputChannel() <- dnsutils.NewDNSMessageBatchFromMessage(&dm)
 
-	dmOut := <-kept.GetInputChannel()
+	batchOut := <-kept.GetInputChannel()
+	if len(batchOut.Messages) == 0 {
+		t.Fatalf("expected message in batch")
+	}
+	dmOut := batchOut.Messages[0]
 
 	// check results
 	if dmOut.Rest.Failed != false {

--- a/workers/worker.go
+++ b/workers/worker.go
@@ -39,9 +39,12 @@ type GenericWorker struct {
 	logger                                                               *logger.Logger
 	name, descr                                                          string
 	droppedRoutes, defaultRoutes                                         []Worker
-	droppedWorker                                                        chan string
-	droppedWorkerCount                                                   map[string]int
-	dnsMessageIn, dnsMessageOut                                          chan *dnsutils.DNSMessageBatch
+	// droppedWorkerCounts maps route-name -> atomic dropped message count.
+	// Using a sync.Map of *atomic.Int64 avoids starvation that a channel-based
+	// accumulator can cause when the monitor ticker competes with a high-volume
+	// drop stream inside a single select.
+	droppedWorkerCounts         sync.Map // map[string]*atomic.Int64
+	dnsMessageIn, dnsMessageOut chan *dnsutils.DNSMessageBatch
 
 	metrics                                                                 atomic.Pointer[telemetry.PrometheusCollector]
 	totalIngress, totalEgress, totalForwarded, totalDropped, totalDiscarded atomic.Uint64
@@ -52,21 +55,19 @@ type GenericWorker struct {
 func NewGenericWorker(config *pkgconfig.Config, logger *logger.Logger, name string, descr string, bufferSize int, monitor bool) *GenericWorker {
 	logger.Info(pkgconfig.PrefixLogWorker+"[%s] %s - enabled", name, descr)
 	w := &GenericWorker{
-		config:             config,
-		configChan:         make(chan *pkgconfig.Config),
-		logger:             logger,
-		name:               name,
-		descr:              descr,
-		doneRun:            make(chan bool),
-		doneMonitor:        make(chan bool),
-		doneProcess:        make(chan bool),
-		stopRun:            make(chan bool),
-		stopMonitor:        make(chan bool),
-		stopProcess:        make(chan bool),
-		droppedWorker:      make(chan string),
-		droppedWorkerCount: map[string]int{},
-		dnsMessageIn:       make(chan *dnsutils.DNSMessageBatch, bufferSize),
-		dnsMessageOut:      make(chan *dnsutils.DNSMessageBatch, bufferSize),
+		config:        config,
+		configChan:    make(chan *pkgconfig.Config),
+		logger:        logger,
+		name:          name,
+		descr:         descr,
+		doneRun:       make(chan bool),
+		doneMonitor:   make(chan bool),
+		doneProcess:   make(chan bool),
+		stopRun:       make(chan bool),
+		stopMonitor:   make(chan bool),
+		stopProcess:   make(chan bool),
+		dnsMessageIn:  make(chan *dnsutils.DNSMessageBatch, bufferSize),
+		dnsMessageOut: make(chan *dnsutils.DNSMessageBatch, bufferSize),
 		TextBufferPool: &sync.Pool{
 			New: func() interface{} { return new(bytes.Buffer) },
 		},
@@ -219,24 +220,18 @@ func (w *GenericWorker) Monitor() {
 
 	for {
 		select {
-		case loggerName := <-w.droppedWorker:
-			if _, ok := w.droppedWorkerCount[loggerName]; !ok {
-				w.droppedWorkerCount[loggerName] = 1
-			} else {
-				w.droppedWorkerCount[loggerName]++
-			}
-
 		case <-w.stopMonitor:
-			close(w.droppedWorker)
 			return
 
 		case <-ticker.C:
-			for v, k := range w.droppedWorkerCount {
-				if k > 0 {
-					w.LogWarning("worker[%s] buffer is full, %d dnsmessage(s) dropped", v, k)
-					w.droppedWorkerCount[v] = 0
+			// Log dropped counts accumulated since last tick.
+			w.droppedWorkerCounts.Range(func(key, val any) bool {
+				counter := val.(*atomic.Int64)
+				if k := counter.Swap(0); k > 0 {
+					w.LogWarning("worker[%s] buffer is full, %d dnsmessage(s) dropped", key.(string), k)
 				}
-			}
+				return true
+			})
 
 			// send to telemetry?
 			metrics := w.metrics.Load()
@@ -262,8 +257,18 @@ func (w *GenericWorker) Monitor() {
 	}
 }
 
-func (w *GenericWorker) WorkerIsBusy(name string) {
-	w.droppedWorker <- name
+func (w *GenericWorker) WorkerIsBusy(name string, count int) {
+	// Load-or-store an *atomic.Int64 for this route name, then add atomically.
+	// This is lock-free and cannot starve the Monitor ticker.
+	var counter *atomic.Int64
+	if v, ok := w.droppedWorkerCounts.Load(name); ok {
+		counter = v.(*atomic.Int64)
+	} else {
+		new := &atomic.Int64{}
+		actual, _ := w.droppedWorkerCounts.LoadOrStore(name, new)
+		counter = actual.(*atomic.Int64)
+	}
+	counter.Add(int64(count))
 }
 
 func (w *GenericWorker) StartCollect() {
@@ -315,11 +320,12 @@ func (w *GenericWorker) sendBatch(routes []chan *dnsutils.DNSMessageBatch, route
 				}
 			}
 		default:
+			droppedCount := len(b.Messages)
 			b.Release()
 			if w.config.Global.Telemetry.Enabled {
-				w.totalDiscarded.Add(uint64(len(b.Messages)))
+				w.totalDiscarded.Add(uint64(droppedCount))
 			}
-			w.WorkerIsBusy(routesName[i])
+			w.WorkerIsBusy(routesName[i], droppedCount)
 		}
 	}
 }

--- a/workers/worker.go
+++ b/workers/worker.go
@@ -12,6 +12,8 @@ import (
 	"github.com/dmachard/go-logger"
 )
 
+// Ensure time import is used by Monitor() ticker; declared here to keep linter happy.
+
 type Worker interface {
 	SetMetrics(metrics *telemetry.PrometheusCollector)
 	AddDefaultRoute(wrk Worker)
@@ -22,7 +24,7 @@ type Worker interface {
 	StartCollect()
 	CountIngressTraffic()
 	CountEgressTraffic()
-	GetInputChannel() chan *dnsutils.DNSMessage
+	GetInputChannel() chan *dnsutils.DNSMessageBatch
 	ReadConfig()
 	ReloadConfig(config *pkgconfig.Config)
 	GetMetrics() *telemetry.PrometheusCollector
@@ -39,7 +41,7 @@ type GenericWorker struct {
 	droppedRoutes, defaultRoutes                                         []Worker
 	droppedWorker                                                        chan string
 	droppedWorkerCount                                                   map[string]int
-	dnsMessageIn, dnsMessageOut                                          chan *dnsutils.DNSMessage
+	dnsMessageIn, dnsMessageOut                                          chan *dnsutils.DNSMessageBatch
 
 	metrics                                                                 atomic.Pointer[telemetry.PrometheusCollector]
 	totalIngress, totalEgress, totalForwarded, totalDropped, totalDiscarded atomic.Uint64
@@ -63,8 +65,8 @@ func NewGenericWorker(config *pkgconfig.Config, logger *logger.Logger, name stri
 		stopProcess:        make(chan bool),
 		droppedWorker:      make(chan string),
 		droppedWorkerCount: map[string]int{},
-		dnsMessageIn:       make(chan *dnsutils.DNSMessage, bufferSize),
-		dnsMessageOut:      make(chan *dnsutils.DNSMessage, bufferSize),
+		dnsMessageIn:       make(chan *dnsutils.DNSMessageBatch, bufferSize),
+		dnsMessageOut:      make(chan *dnsutils.DNSMessageBatch, bufferSize),
 		TextBufferPool: &sync.Pool{
 			New: func() interface{} { return new(bytes.Buffer) },
 		},
@@ -89,6 +91,20 @@ func (w *GenericWorker) GetConfig() *pkgconfig.Config { return w.config }
 
 func (w *GenericWorker) SetConfig(config *pkgconfig.Config) { w.config = config }
 
+func (w *GenericWorker) GetBatchSize() int {
+	if w.config != nil && w.config.Global.Worker.BatchSize > 0 {
+		return w.config.Global.Worker.BatchSize
+	}
+	return pkgconfig.DefaultBatchSize
+}
+
+func (w *GenericWorker) GetFlushInterval() time.Duration {
+	if w.config != nil && w.config.Global.Worker.BatchFlushIntervalMs > 0 {
+		return time.Duration(w.config.Global.Worker.BatchFlushIntervalMs) * time.Millisecond
+	}
+	return time.Duration(pkgconfig.DefaultFlushInterval) * time.Millisecond
+}
+
 func (w *GenericWorker) ReadConfig() {}
 
 func (w *GenericWorker) NewConfig() chan *pkgconfig.Config { return w.configChan }
@@ -99,20 +115,16 @@ func (w *GenericWorker) GetDroppedRoutes() []Worker { return w.droppedRoutes }
 
 func (w *GenericWorker) GetDefaultRoutes() []Worker { return w.defaultRoutes }
 
-func (w *GenericWorker) GetInputChannel() chan *dnsutils.DNSMessage { return w.dnsMessageIn }
+func (w *GenericWorker) GetInputChannel() chan *dnsutils.DNSMessageBatch { return w.dnsMessageIn }
 
-func (w *GenericWorker) GetInputChannelAsList() []chan *dnsutils.DNSMessage {
-	listChannel := []chan *dnsutils.DNSMessage{}
-	listChannel = append(listChannel, w.GetInputChannel())
-	return listChannel
+func (w *GenericWorker) GetInputChannelAsList() []chan *dnsutils.DNSMessageBatch {
+	return []chan *dnsutils.DNSMessageBatch{w.dnsMessageIn}
 }
 
-func (w *GenericWorker) GetOutputChannel() chan *dnsutils.DNSMessage { return w.dnsMessageOut }
+func (w *GenericWorker) GetOutputChannel() chan *dnsutils.DNSMessageBatch { return w.dnsMessageOut }
 
-func (w *GenericWorker) GetOutputChannelAsList() []chan *dnsutils.DNSMessage {
-	listChannel := []chan *dnsutils.DNSMessage{}
-	listChannel = append(listChannel, w.GetOutputChannel())
-	return listChannel
+func (w *GenericWorker) GetOutputChannelAsList() []chan *dnsutils.DNSMessageBatch {
+	return []chan *dnsutils.DNSMessageBatch{w.dnsMessageOut}
 }
 
 func (w *GenericWorker) AddDroppedRoute(wrk Worker) {
@@ -133,7 +145,7 @@ func (w *GenericWorker) SetDefaultDropped(workers []Worker) {
 
 func (w *GenericWorker) SetLoggers(loggers []Worker) { w.defaultRoutes = loggers }
 
-func (w *GenericWorker) Loggers() ([]chan *dnsutils.DNSMessage, []string) {
+func (w *GenericWorker) Loggers() ([]chan *dnsutils.DNSMessageBatch, []string) {
 	return GetRoutes(w.defaultRoutes)
 }
 
@@ -282,59 +294,100 @@ func (w *GenericWorker) CountEgressDiscarded() {
 	}
 }
 
-func (w *GenericWorker) SendDroppedTo(routes []chan *dnsutils.DNSMessage, routesName []string, dm *dnsutils.DNSMessage) {
+// sendBatch is the internal helper that dispatches a *DNSMessageBatch to all routes.
+// It handles reference counting for fan-out and drops + telemetry when a route is full.
+func (w *GenericWorker) sendBatch(routes []chan *dnsutils.DNSMessageBatch, routesName []string, b *dnsutils.DNSMessageBatch, dropped bool) {
 	if len(routes) == 0 {
-		dm.Release()
+		b.Release()
 		return
 	}
 	if len(routes) > 1 {
-		dm.Retain(int32(len(routes) - 1))
+		b.Retain(int32(len(routes) - 1))
 	}
 	for i := range routes {
 		select {
-		case routes[i] <- dm:
+		case routes[i] <- b:
 			if w.config.Global.Telemetry.Enabled {
-				w.totalDropped.Add(1)
+				if dropped {
+					w.totalDropped.Add(uint64(len(b.Messages)))
+				} else {
+					w.totalForwarded.Add(uint64(len(b.Messages)))
+				}
 			}
 		default:
-			dm.Release()
+			b.Release()
 			if w.config.Global.Telemetry.Enabled {
-				w.totalDiscarded.Add(1)
+				w.totalDiscarded.Add(uint64(len(b.Messages)))
 			}
 			w.WorkerIsBusy(routesName[i])
 		}
 	}
 }
 
-func (w *GenericWorker) SendForwardedTo(routes []chan *dnsutils.DNSMessage, routesName []string, dm *dnsutils.DNSMessage) {
-	if len(routes) == 0 {
-		dm.Release()
+// SendDroppedTo wraps dm in a batch-of-1 and dispatches it to all dropped routes.
+func (w *GenericWorker) SendDroppedTo(routes []chan *dnsutils.DNSMessageBatch, routesName []string, dm *dnsutils.DNSMessage) {
+	dm.Retain(1)
+	b := dnsutils.AcquireDNSMessageBatch(1)
+	b.Messages = append(b.Messages, dm)
+	w.sendBatch(routes, routesName, b, true)
+}
+
+// SendForwardedTo wraps dm in a batch-of-1 and dispatches it to all default routes.
+func (w *GenericWorker) SendForwardedTo(routes []chan *dnsutils.DNSMessageBatch, routesName []string, dm *dnsutils.DNSMessage) {
+	dm.Retain(1)
+	b := dnsutils.AcquireDNSMessageBatch(1)
+	b.Messages = append(b.Messages, dm)
+	w.sendBatch(routes, routesName, b, false)
+}
+
+// SendForwardedBatchTo dispatches a pre-assembled *DNSMessageBatch to all default routes.
+// This is the high-throughput path — callers that can accumulate messages should use this.
+func (w *GenericWorker) SendForwardedBatchTo(routes []chan *dnsutils.DNSMessageBatch, routesName []string, batch *dnsutils.DNSMessageBatch) {
+	if batch == nil || len(batch.Messages) == 0 {
+		if batch != nil {
+			batch.Release()
+		}
 		return
 	}
-	if len(routes) > 1 {
-		dm.Retain(int32(len(routes) - 1))
-	}
-	for i := range routes {
+	w.sendBatch(routes, routesName, batch, false)
+}
+
+// RunBatchLoop reads *DNSMessageBatch values from the input channel and calls
+// process() for each one. Batching is now done by the producer (via SendForwardedBatchTo
+// or SendForwardedTo which wraps into batch-of-1). No accumulation or ticker needed here.
+func (w *GenericWorker) RunBatchLoop(process func(*dnsutils.DNSMessageBatch)) {
+	for {
 		select {
-		case routes[i] <- dm:
-			if w.config.Global.Telemetry.Enabled {
-				w.totalForwarded.Add(1)
+		case <-w.OnStop():
+			return
+
+		case batch, opened := <-w.dnsMessageIn:
+			if !opened {
+				w.LogInfo("run: input channel closed!")
+				return
 			}
-		default:
-			dm.Release()
-			if w.config.Global.Telemetry.Enabled {
-				w.totalDiscarded.Add(1)
-			}
-			w.WorkerIsBusy(routesName[i])
+			process(batch)
 		}
 	}
 }
 
-func (w *GenericWorker) SendToOutputAndForward(routes []chan *dnsutils.DNSMessage, routesName []string, dm *dnsutils.DNSMessage) {
+func (w *GenericWorker) SendToOutputAndForward(routes []chan *dnsutils.DNSMessageBatch, routesName []string, dm *dnsutils.DNSMessage) {
 	w.CountEgressTraffic()
 	dm.Retain(1)
-	w.SendForwardedTo(routes, routesName, dm)
-	w.GetOutputChannel() <- dm
+	b := dnsutils.AcquireDNSMessageBatch(1)
+	b.Messages = append(b.Messages, dm)
+
+	outChan := w.GetOutputChannel()
+	switch {
+	case outChan != nil && len(routes) > 0:
+		b.Retain(1)
+		w.sendBatch(routes, routesName, b, false)
+		outChan <- b
+	case outChan != nil:
+		outChan <- b
+	default:
+		w.sendBatch(routes, routesName, b, false)
+	}
 }
 
 func (w *GenericWorker) GetTextBuffer() *bytes.Buffer {
@@ -346,8 +399,8 @@ func (w *GenericWorker) PutTextBuffer(buf *bytes.Buffer) {
 	w.TextBufferPool.Put(buf)
 }
 
-func GetRoutes(routes []Worker) ([]chan *dnsutils.DNSMessage, []string) {
-	channels := []chan *dnsutils.DNSMessage{}
+func GetRoutes(routes []Worker) ([]chan *dnsutils.DNSMessageBatch, []string) {
+	channels := []chan *dnsutils.DNSMessageBatch{}
 	names := []string{}
 	for _, p := range routes {
 		if c := p.GetInputChannel(); c != nil {

--- a/workers/worker.go
+++ b/workers/worker.go
@@ -60,12 +60,12 @@ func NewGenericWorker(config *pkgconfig.Config, logger *logger.Logger, name stri
 		logger:        logger,
 		name:          name,
 		descr:         descr,
-		doneRun:       make(chan bool),
-		doneMonitor:   make(chan bool),
-		doneProcess:   make(chan bool),
-		stopRun:       make(chan bool),
-		stopMonitor:   make(chan bool),
-		stopProcess:   make(chan bool),
+		doneRun:       make(chan bool, 1),
+		doneMonitor:   make(chan bool, 1),
+		doneProcess:   make(chan bool, 1),
+		stopRun:       make(chan bool, 1),
+		stopMonitor:   make(chan bool, 1),
+		stopProcess:   make(chan bool, 1),
 		dnsMessageIn:  make(chan *dnsutils.DNSMessageBatch, bufferSize),
 		dnsMessageOut: make(chan *dnsutils.DNSMessageBatch, bufferSize),
 		TextBufferPool: &sync.Pool{
@@ -211,11 +211,19 @@ func (w *GenericWorker) Monitor() {
 			w.LogError("monitor - recovered panic: %v", r)
 		}
 		w.LogInfo("monitor terminated")
-		w.doneMonitor <- true
+		select {
+		case w.doneMonitor <- true:
+		default:
+		}
 	}()
 
-	w.LogInfo("starting monitoring - refresh every %ds", w.config.Global.Worker.InternalMonitor)
-	ticker := time.NewTicker(time.Duration(w.config.Global.Worker.InternalMonitor) * time.Second)
+	interval := 10
+	if w.config != nil && w.config.Global.Worker.InternalMonitor > 0 {
+		interval = w.config.Global.Worker.InternalMonitor
+	}
+
+	w.LogInfo("starting monitoring - refresh every %ds", interval)
+	ticker := time.NewTicker(time.Duration(interval) * time.Second)
 	defer ticker.Stop()
 
 	for {

--- a/workers/worker_bench_test.go
+++ b/workers/worker_bench_test.go
@@ -52,7 +52,7 @@ func Benchmark_Worker_SendForwardedTo_TelemetryOn(b *testing.B) {
 	go target.StartCollect()
 	defer target.Stop()
 
-	routes := []chan *dnsutils.DNSMessage{target.GetInputChannel()}
+	routes := []chan *dnsutils.DNSMessageBatch{target.GetInputChannel()}
 	routesName := []string{"target-devnull"}
 	dm := dnsutils.GetFakeDNSMessage()
 
@@ -62,5 +62,87 @@ func Benchmark_Worker_SendForwardedTo_TelemetryOn(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		msg := dm
 		devNull.SendForwardedTo(routes, routesName, &msg)
+	}
+}
+
+func Benchmark_Worker_SendForwardedBatchTo_TelemetryOn(b *testing.B) {
+	config := pkgconfig.GetDefaultConfig()
+	config.Global.Telemetry.Enabled = true
+
+	devNull := NewDevNull(config, logger.New(false), "bench-devnull")
+	go devNull.StartCollect()
+	defer devNull.Stop()
+
+	target := NewDevNull(config, logger.New(false), "target-devnull")
+	go target.StartCollect()
+	defer target.Stop()
+
+	routes := []chan *dnsutils.DNSMessageBatch{target.GetInputChannel()}
+	routesName := []string{"target-devnull"}
+	dm := dnsutils.GetFakeDNSMessage()
+
+	batchSize := 64
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i += batchSize {
+		batch := dnsutils.AcquireDNSMessageBatch(batchSize)
+		for j := 0; j < batchSize; j++ {
+			msg := dm
+			batch.Messages = append(batch.Messages, &msg)
+		}
+		devNull.SendForwardedBatchTo(routes, routesName, batch)
+	}
+}
+
+// Benchmark_Worker_E2E_RunBatchLoop measures end-to-end throughput when a producer
+// goroutine feeds messages in batches into the GenericWorker channel and RunBatchLoop
+// processes them in the consumer (DevNull).
+func Benchmark_Worker_E2E_RunBatchLoop(b *testing.B) {
+	config := pkgconfig.GetDefaultConfig()
+	config.Global.Telemetry.Enabled = true
+	config.Global.Worker.ChannelBufferSize = 65536
+
+	sink := NewDevNull(config, logger.New(false), "sink-devnull")
+	go sink.StartCollect()
+	defer sink.Stop()
+
+	dm := dnsutils.GetFakeDNSMessage()
+	batchSize := 64
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i += batchSize {
+		batch := dnsutils.AcquireDNSMessageBatch(batchSize)
+		for j := 0; j < batchSize; j++ {
+			msg := dm
+			batch.Messages = append(batch.Messages, &msg)
+		}
+		sink.GetInputChannel() <- batch
+	}
+}
+
+// Benchmark_Worker_E2E_SingleMessage measures single message wrapped in batch per channel send.
+func Benchmark_Worker_E2E_SingleMessage(b *testing.B) {
+	config := pkgconfig.GetDefaultConfig()
+	config.Global.Telemetry.Enabled = true
+	config.Global.Worker.ChannelBufferSize = 65536
+
+	sink := NewDevNull(config, logger.New(false), "sink-devnull")
+	go sink.StartCollect()
+	defer sink.Stop()
+
+	dm := dnsutils.GetFakeDNSMessage()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		batch := dnsutils.AcquireDNSMessageBatch(1)
+		msg := dm
+		batch.Messages = append(batch.Messages, &msg)
+		sink.GetInputChannel() <- batch
 	}
 }

--- a/workers/worker_bench_test.go
+++ b/workers/worker_bench_test.go
@@ -1,6 +1,7 @@
 package workers
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/dmachard/go-dnscollector/v2/dnsutils"
@@ -144,5 +145,35 @@ func Benchmark_Worker_E2E_SingleMessage(b *testing.B) {
 		msg := dm
 		batch.Messages = append(batch.Messages, &msg)
 		sink.GetInputChannel() <- batch
+	}
+}
+
+func Benchmark_Worker_BatchSize_Comparison(b *testing.B) {
+	sizes := []int{1, 16, 32, 64, 128, 256, 512, 1024}
+	dm := dnsutils.GetFakeDNSMessage()
+
+	for _, sz := range sizes {
+		sz := sz
+		b.Run("BatchSize_"+strconv.Itoa(sz), func(subB *testing.B) {
+			config := pkgconfig.GetDefaultConfig()
+			config.Global.Telemetry.Enabled = true
+			config.Global.Worker.ChannelBufferSize = 65536
+
+			sink := NewDevNull(config, logger.New(false), "sink-devnull")
+			go sink.StartCollect()
+			defer sink.Stop()
+
+			subB.ReportAllocs()
+			subB.ResetTimer()
+
+			for i := 0; i < subB.N; i += sz {
+				batch := dnsutils.AcquireDNSMessageBatch(sz)
+				for j := 0; j < sz; j++ {
+					msg := dm
+					batch.Messages = append(batch.Messages, &msg)
+				}
+				sink.GetInputChannel() <- batch
+			}
+		})
 	}
 }

--- a/workers/workers_test.go
+++ b/workers/workers_test.go
@@ -18,7 +18,7 @@ func TestGenericWorker(t *testing.T) {
 func Test_MultiLogger_ConcurrentRace(t *testing.T) {
 	config := pkgconfig.GetDefaultConfig()
 	config.Collectors.Dnstap.DisableDNSParser = false
-	config.Collectors.Dnstap.ChannelBufferSize = 1000
+	config.Global.Worker.ChannelBufferSize = 1000
 
 	// Create 5 consumer workers (multi-logger scenario)
 	numLoggers := 5


### PR DESCRIPTION
# Refactor: End-to-end channel message batching for high throughput and reduced memory

## 🎯 Summary

This PR migrates the internal worker pipeline from passing individual `*dnsutils.DNSMessage` on Go channels to passing pooled batches of `*dnsutils.DNSMessageBatch`.

By processing and forwarding messages in batches, this refactor significantly reduces Go channel synchronization contention, amortizes locking overhead, and cuts down garbage collection pressure across all collectors, transformers, and loggers.

---

## ⚡ Performance Benchmark Results

### 1. Comparison against `v2.5.0` (5,000,000 frames via `tests/compare_vN1_test.go`)
| Metric | v2.5.0 | Refactored (Batched) | Delta |
| :--- | :--- | :--- | :--- |
| **Throughput** | 2,040,941 msg/s | **2,524,714 msg/s** | **+23.70%** 🚀 |
| **Execution Time** | 2.45s | **1.98s** | **-19.16%** ⏱️ |
| **Total CPU Time (User+Sys)** | 4.854s | **4.410s** | **-9.14%** 💻 |
| **Peak Memory (Max RSS)** | 103.16 MB | **69.57 MB** | **-32.56%** 📉 |

### 2. Comparison against `v2.6.0-beta6` (1,000,000 frames)
| Metric | v2.6.0-beta6 | Refactored (Batched) | Delta |
| :--- | :--- | :--- | :--- |
| **Throughput** | 1,265,497 msg/s | **1,360,397 msg/s** | **+7.50%** 🚀 |
| **Total CPU Time** | 824ms | **629ms** | **-23.60%** 💻 |
| **Execution Time** | 790ms | **735ms** | **-6.98%** ⏱️ |

### 3. Channel Transit Micro-Benchmark by Batch Size (`workers/worker_bench_test.go`)
| Batch Size | Latency per message | Speedup vs no-batch |
| :--- | :--- | :--- |
| **1 (no batch)** | 323.1 ns/op | Baseline |
| **16** | 209.3 ns/op | +35% |
| **32** | 202.2 ns/op | +37% |
| **64 (Sweet spot)** | **194.9 ns/op** | **+40%** |
| **128** | 205.6 ns/op | +36% |

---

## 🛠️ Key Changes

### 1. `GenericWorker` & Pipeline Core
- Migrated internal Go channels `dnsMessageIn` and `dnsMessageOut` to `chan *dnsutils.DNSMessageBatch`.
- Added helper methods: `SendForwardedBatchTo`, `SendForwardedTo`, `SendDroppedTo`, `SendToOutputAndForward`.
- Added batch loop management via `RunBatchLoop()` with `ProcessBatch(batch *DNSMessageBatch)` interface for downstream workers.
- Encapsulated batch size configuration (`GetBatchSize()`, `GetFlushInterval()`) with dynamic fallback to defaults.

### 2. Collectors & Loggers Migration (28 workers updated)
- **Loggers** (`stdout`, `logfile`, `syslog`, `dnstapclient`, `tcp`, `elasticsearch`, `kafka`, `clickhouse`, `nsq`, `falco`, `prometheus`, etc.): Optimized to iterate directly over `batch.Messages` and release the batch cleanly via `batch.Release()`.
- **Collectors & Processors** (`dnstapserver`, `dnsprocessor`, `powerdns`, `file_tail`, `file_ingestor`, `tzsp`, `sniffer_afpacket`, `sniffer_xdp`): Updated to accumulate and forward batches directly without channel contention.

### 3. Configuration & Backward Compatibility
- Added global worker configuration options in `global.worker`:
  - `buffer-size`: `512` (provides 32,768 messages of retention with low memory footprint).
  - `batch-size`: `64` (configurable max batch size).
  - `flush-interval-ms`: `10` (max periodic flush delay).
- **Backward compatibility**: If legacy per-worker `chan-buffer-size` is present in a configuration, a clear `WARNING` is logged rather than failing startup.

---

## ✅ Quality & Validation

- [x] **0 Regressions**: 100% unit tests passing across all packages (`pkgconfig`, `dnsutils`, `pkginit`, `telemetry`, `transformers`, `workers`, `tests`).
- [x] **Linter**: `golangci-lint run --config=.golangci.yml ./...` passed with **0 issues**.
- [x] **Configuration Validation**: `go run . -config config.yml -test-config` passed successfully.
