### PR TITLE
docs: fix two typos

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -14,7 +14,7 @@ Building from source
 go run .
 ```
 
-- Uses the `MakeFile` (prefered way)
+- Uses the `MakeFile` (preferred way)
 
 ```bash
 make

--- a/docs/platforms/dnstap.md
+++ b/docs/platforms/dnstap.md
@@ -3,7 +3,7 @@
 [dnstap](https://dnstap.info/) is a flexible, structured binary log format for DNS servers.
 It uses [Protocol Buffers](https://protobuf.dev/) to encode DNS packets in events.
 
-dnstap can encode any DNS messages with network informations like ip and port. It includes client queries and responses.
+dnstap can encode any DNS messages with network information like ip and port. It includes client queries and responses.
 
 ## Introduction
 


### PR DESCRIPTION
Two typo fixes:

- `docs/development.md:17` — "Uses the `MakeFile` (prefered way)" → "preferred"
- `docs/platforms/dnstap.md:6` — "with network informations like ip and port" → "information" ("information" is uncountable in English)

Docs only.
