### PR TITLE
perf(transformers): optimize reordering with zero-alloc and batched flush

### DIFF
--- a/transformers/reordering.go
+++ b/transformers/reordering.go
@@ -1,7 +1,8 @@
 package transformers
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 	"sync"
 	"time"
 
@@ -112,27 +113,25 @@ func (t *ReorderingTransform) flushBuffer() {
 	t.buffer = t.buffer[:0]
 	t.mutex.Unlock()
 
-	// Sort the buffer by timestamp.
-	sort.SliceStable(t.backBuffer, func(i, j int) bool {
-		return t.backBuffer[i].DNSTap.Timestamp < t.backBuffer[j].DNSTap.Timestamp
+	// Sort the buffer by timestamp using pdqsort without reflection or allocation.
+	slices.SortFunc(t.backBuffer, func(a, b *dnsutils.DNSMessage) int {
+		return cmp.Compare(a.DNSTap.Timestamp, b.DNSTap.Timestamp)
 	})
 
-	// Send sorted logs to the next workers (one batch per message).
-	for _, sortedMsg := range t.backBuffer {
-		b := dnsutils.AcquireDNSMessageBatch(1)
-		b.Messages = append(b.Messages, sortedMsg)
-		if len(t.nextWorkers) > 1 {
-			b.Retain(int32(len(t.nextWorkers) - 1))
-		}
-		for _, worker := range t.nextWorkers {
-			// Non-blocking send to avoid worker congestion.
-			select {
-			case worker <- b:
-			default:
-				b.Release()
-				// Log or handle if the worker channel is full.
-				t.logger.Info("Worker channel is full, dropping message")
-			}
+	// Send sorted logs to the next workers in a single batch.
+	b := dnsutils.AcquireDNSMessageBatch(len(t.backBuffer))
+	b.Messages = append(b.Messages, t.backBuffer...)
+	if len(t.nextWorkers) > 1 {
+		b.Retain(int32(len(t.nextWorkers) - 1))
+	}
+	for _, worker := range t.nextWorkers {
+		// Non-blocking send to avoid worker congestion.
+		select {
+		case worker <- b:
+		default:
+			b.Release()
+			// Log or handle if the worker channel is full.
+			t.logger.Info("Worker channel is full, dropping message")
 		}
 	}
 }

--- a/transformers/reordering_bench_test.go
+++ b/transformers/reordering_bench_test.go
@@ -1,6 +1,10 @@
 package transformers
 
 import (
+	"cmp"
+	"math/rand"
+	"slices"
+	"sort"
 	"testing"
 	"time"
 
@@ -9,41 +13,115 @@ import (
 	"github.com/dmachard/go-logger"
 )
 
-func BenchmarkReordering_ReorderAndFlush(b *testing.B) {
-	config := pkgconfig.GetFakeConfigTransformers()
-	config.Reordering.Enable = true
-	config.Reordering.MaxBufferSize = 1000
-
-	log := logger.New(false)
-	outChans := []chan *dnsutils.DNSMessageBatch{
-		make(chan *dnsutils.DNSMessageBatch, 2000),
+func generateMessages(n int, jitter int64) []*dnsutils.DNSMessage {
+	baseTime := time.Now().UnixNano()
+	msgs := make([]*dnsutils.DNSMessage, n)
+	r := rand.New(rand.NewSource(42))
+	for i := 0; i < n; i++ {
+		dm := dnsutils.GetFakeDNSMessage()
+		var offset int64
+		if jitter > 0 {
+			offset = int64(i)*1_000_000 + r.Int63n(jitter) - jitter/2
+		} else {
+			offset = r.Int63n(1_000_000_000)
+		}
+		dm.DNSTap.Timestamp = baseTime + offset
+		msgs[i] = &dm
 	}
+	return msgs
+}
 
-	reorder := NewReorderingTransform(config, log, "test", 0, outChans)
+// -------------------------------------------------------------
+// Pure Algorithm Microbenchmarks (sort.SliceStable vs slices.SortFunc)
+// -------------------------------------------------------------
 
-	// Create 1000 fake messages with different timestamps
-	messages := make([]*dnsutils.DNSMessage, 1000)
-	for i := 0; i < 1000; i++ {
-		msg := dnsutils.GetFakeDNSMessage()
-		ts := time.Now().Add(time.Duration(i%2-i%3+i%5) * time.Millisecond)
-		msg.DNSTap.Timestamp = ts.UnixNano()
-		msg.DNSTap.TimestampRFC3339 = ts.Format(time.RFC3339Nano)
-		messages[i] = &msg
-	}
+func Benchmark_Sort_SliceStable_NearlySorted_1000(b *testing.B) {
+	template := generateMessages(1000, 50_000_000)
+	buf := make([]*dnsutils.DNSMessage, 1000)
 
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		// Fill buffer
-		for j := 0; j < 1000; j++ {
-			reorder.buffer = append(reorder.buffer, messages[j])
-		}
-		// Flush buffer
-		reorder.flushBuffer()
 
-		// Drain output channel
+	for i := 0; i < b.N; i++ {
+		copy(buf, template)
+		sort.SliceStable(buf, func(x, y int) bool {
+			return buf[x].DNSTap.Timestamp < buf[y].DNSTap.Timestamp
+		})
+	}
+}
+
+func Benchmark_Sort_SlicesSortFunc_NearlySorted_1000(b *testing.B) {
+	template := generateMessages(1000, 50_000_000)
+	buf := make([]*dnsutils.DNSMessage, 1000)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		copy(buf, template)
+		slices.SortFunc(buf, func(a, b *dnsutils.DNSMessage) int {
+			return cmp.Compare(a.DNSTap.Timestamp, b.DNSTap.Timestamp)
+		})
+	}
+}
+
+func Benchmark_Sort_SliceStable_Random_1000(b *testing.B) {
+	template := generateMessages(1000, 0)
+	buf := make([]*dnsutils.DNSMessage, 1000)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		copy(buf, template)
+		sort.SliceStable(buf, func(x, y int) bool {
+			return buf[x].DNSTap.Timestamp < buf[y].DNSTap.Timestamp
+		})
+	}
+}
+
+func Benchmark_Sort_SlicesSortFunc_Random_1000(b *testing.B) {
+	template := generateMessages(1000, 0)
+	buf := make([]*dnsutils.DNSMessage, 1000)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		copy(buf, template)
+		slices.SortFunc(buf, func(a, b *dnsutils.DNSMessage) int {
+			return cmp.Compare(a.DNSTap.Timestamp, b.DNSTap.Timestamp)
+		})
+	}
+}
+
+// -------------------------------------------------------------
+// Transformer FlushBuffer End-to-End Benchmarks
+// -------------------------------------------------------------
+
+func Benchmark_Reordering_FlushBuffer_1000(b *testing.B) {
+	config := pkgconfig.GetFakeConfigTransformers()
+	config.Reordering.Enable = true
+	config.Reordering.MaxBufferSize = 1000
+	log := logger.New(false)
+	outChans := []chan *dnsutils.DNSMessageBatch{make(chan *dnsutils.DNSMessageBatch, 2000)}
+	reorder := NewReorderingTransform(config, log, "bench", 0, outChans)
+
+	template := generateMessages(1000, 50_000_000) // nearly sorted
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		reorder.mutex.Lock()
+		reorder.buffer = append(reorder.buffer[:0], template...)
+		reorder.mutex.Unlock()
+
+		reorder.flushBuffer()
+		// drain channel
 		for len(outChans[0]) > 0 {
-			<-outChans[0]
+			batch := <-outChans[0]
+			batch.Release()
 		}
 	}
 }


### PR DESCRIPTION
## Description

This PR optimizes the `reordering` transformer by replacing `sort.SliceStable` with generic `slices.SortFunc` and dispatching flushed messages in a single grouped batch instead of per-message allocations.

### Key Improvements:

1. **Zero-Allocation Generic Sorting (`slices.SortFunc`)**:
   - Replaced `sort.SliceStable` with standard library `slices.SortFunc` and `cmp.Compare`.
   - Eliminates reflection and closure allocations.
   - Uses `pdqsort` (Pattern-defeating quicksort), providing up to **3.7x faster** sorting on random data and **0 heap allocations**.

2. **Grouped Batch Dispatch in `flushBuffer()`**:
   - Instead of allocating individual batches of 1 message (`AcquireDNSMessageBatch(1)` x N) and sending each one over downstream channels, `flushBuffer()` now acquires a single batch for the sorted buffer and emits it in one channel operation.
   - Divides downstream channel writes by N and eliminates N temporary batch allocations per flush.

3. **Benchmark Suite**:
   - Added dedicated microbenchmarks in `transformers/reordering_bench_test.go` covering pure sorting and end-to-end `flushBuffer()` execution.

---

## Benchmark Results

### 1. Pure Sorting Microbenchmark (1 000 messages)

```text
cpu: AMD Ryzen 9 9900X 12-Core Processor
Benchmark_Sort_SliceStable_Random_1000-24             42424     55886 ns/op      56 B/op      2 allocs/op
Benchmark_Sort_SlicesSortFunc_Random_1000-24         158253     15000 ns/op       0 B/op      0 allocs/op

Benchmark_Sort_SliceStable_NearlySorted_1000-24      117363     20531 ns/op      56 B/op      2 allocs/op
Benchmark_Sort_SlicesSortFunc_NearlySorted_1000-24   157203     15045 ns/op       0 B/op      0 allocs/op
