### PR TITLE
perf(extract,dnsutils): zero-allocation base64 JSON encoding and fast  hex extraction

### DIFF
--- a/dnsutils/dnsmessage_bench_test.go
+++ b/dnsutils/dnsmessage_bench_test.go
@@ -143,3 +143,18 @@ func BenchmarkDnsMessage_TextFormatter_Transformers(b *testing.B) {
 		textBufferPool.Put(buf)
 	}
 }
+
+func Benchmark_DNSMessage_ToJSON_ExtractedPayload(b *testing.B) {
+	dm := DNSMessage{}
+	dm.Init()
+	dm.Extracted = &TransformExtracted{
+		Base64Payload: []byte("example payload data for DNS message 0123456789"),
+	}
+	var buf bytes.Buffer
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		dm.EncodeJSON(&buf)
+	}
+}

--- a/dnsutils/dnsmessage_json.go
+++ b/dnsutils/dnsmessage_json.go
@@ -688,6 +688,20 @@ func encodeStringMap(buf *bytes.Buffer, m map[string]string) {
 	buf.WriteByte('}')
 }
 
+func writeBase64(buf *bytes.Buffer, src []byte) {
+	if len(src) == 0 {
+		return
+	}
+	encLen := base64.StdEncoding.EncodedLen(len(src))
+	dst := buf.AvailableBuffer()
+	if cap(dst) < encLen {
+		buf.Grow(encLen)
+		dst = buf.AvailableBuffer()
+	}
+	base64.StdEncoding.Encode(dst[:encLen], src)
+	buf.Write(dst[:encLen])
+}
+
 func encodeInterfaceMap(buf *bytes.Buffer, m map[string]interface{}) {
 	if m == nil {
 		buf.WriteString("null")
@@ -707,7 +721,7 @@ func encodeInterfaceMap(buf *bytes.Buffer, m map[string]interface{}) {
 			WriteJSONString(buf, val)
 		case []byte:
 			buf.WriteByte('"')
-			buf.WriteString(base64.StdEncoding.EncodeToString(val))
+			writeBase64(buf, val)
 			buf.WriteByte('"')
 		case []string:
 			encodeStringSlice(buf, val)
@@ -718,7 +732,7 @@ func encodeInterfaceMap(buf *bytes.Buffer, m map[string]interface{}) {
 					buf.WriteByte(',')
 				}
 				buf.WriteByte('"')
-				buf.WriteString(base64.StdEncoding.EncodeToString(b))
+				writeBase64(buf, b)
 				buf.WriteByte('"')
 			}
 			buf.WriteByte(']')

--- a/dnsutils/dnsmessage_json_transforms.go
+++ b/dnsutils/dnsmessage_json_transforms.go
@@ -2,7 +2,6 @@ package dnsutils
 
 import (
 	"bytes"
-	"encoding/base64"
 )
 
 func (t *TransformDNSGeo) EncodeJSON(buf *bytes.Buffer) {
@@ -93,7 +92,7 @@ func (t *TransformExtracted) EncodeJSON(buf *bytes.Buffer) {
 	buf.WriteString(`{"dns_payload":`)
 	if t.Base64Payload != nil {
 		buf.WriteByte('"')
-		buf.WriteString(base64.StdEncoding.EncodeToString(t.Base64Payload))
+		writeBase64(buf, t.Base64Payload)
 		buf.WriteByte('"')
 	} else {
 		buf.WriteString("null")

--- a/transformers/extract.go
+++ b/transformers/extract.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"reflect"
 	"strconv"
+	"unsafe"
 
 	"github.com/dmachard/go-dnscollector/v2/dnsutils"
 	"github.com/dmachard/go-dnscollector/v2/pkgconfig"
@@ -104,12 +105,32 @@ func (t *ExtractTransform) addBase64Payload(dm *dnsutils.DNSMessage) (int, error
 	return ReturnKeep, nil
 }
 
+func fastHexEncode(s string) string {
+	if len(s) == 0 {
+		return ""
+	}
+	return hex.EncodeToString(unsafe.Slice(unsafe.StringData(s), len(s)))
+}
+
+func fastHexEncodeInt(v int) string {
+	var buf [20]byte
+	b := strconv.AppendInt(buf[:0], int64(v), 10)
+	return hex.EncodeToString(b)
+}
+
+func fastStringToBytes(s string) []byte {
+	if len(s) == 0 {
+		return nil
+	}
+	return unsafe.Slice(unsafe.StringData(s), len(s))
+}
+
 func (t *ExtractTransform) addBase64Fields(dm *dnsutils.DNSMessage) (int, error) {
 	if dm.Extracted == nil {
 		dm.Extracted = &dnsutils.TransformExtracted{}
 	}
 	if dm.Extracted.Base64Fields == nil {
-		dm.Extracted.Base64Fields = make(map[string]interface{})
+		dm.Extracted.Base64Fields = make(map[string]interface{}, len(t.config.Extract.Base64Fields))
 	}
 
 	for i, field := range t.config.Extract.Base64Fields {
@@ -117,19 +138,21 @@ func (t *ExtractTransform) addBase64Fields(dm *dnsutils.DNSMessage) (int, error)
 		if val, found := extractor(dm); found {
 			switch v := val.(type) {
 			case string:
-				dm.Extracted.Base64Fields[field] = []byte(v)
+				dm.Extracted.Base64Fields[field] = fastStringToBytes(v)
 			case int:
-				dm.Extracted.Base64Fields[field] = []byte(strconv.Itoa(v))
+				var buf [20]byte
+				dm.Extracted.Base64Fields[field] = append([]byte(nil), strconv.AppendInt(buf[:0], int64(v), 10)...)
 			case []string:
 				encodedSlice := make([][]byte, len(v))
 				for idx, s := range v {
-					encodedSlice[idx] = []byte(s)
+					encodedSlice[idx] = fastStringToBytes(s)
 				}
 				dm.Extracted.Base64Fields[field] = encodedSlice
 			case []int:
 				encodedSlice := make([][]byte, len(v))
 				for idx, s := range v {
-					encodedSlice[idx] = []byte(strconv.Itoa(s))
+					var buf [20]byte
+					encodedSlice[idx] = append([]byte(nil), strconv.AppendInt(buf[:0], int64(s), 10)...)
 				}
 				dm.Extracted.Base64Fields[field] = encodedSlice
 			default:
@@ -137,16 +160,17 @@ func (t *ExtractTransform) addBase64Fields(dm *dnsutils.DNSMessage) (int, error)
 				switch value.Kind() {
 				case reflect.Slice, reflect.Array:
 					var encodedSlice [][]byte
-					for i := 0; i < value.Len(); i++ {
-						elem := value.Index(i)
+					for j := 0; j < value.Len(); j++ {
+						elem := value.Index(j)
 						if elem.Kind() == reflect.Interface {
 							elem = elem.Elem()
 						}
 						switch elem.Kind() {
 						case reflect.String:
-							encodedSlice = append(encodedSlice, []byte(elem.String()))
+							encodedSlice = append(encodedSlice, fastStringToBytes(elem.String()))
 						case reflect.Int:
-							encodedSlice = append(encodedSlice, []byte(strconv.Itoa(int(elem.Int()))))
+							var buf [20]byte
+							encodedSlice = append(encodedSlice, append([]byte(nil), strconv.AppendInt(buf[:0], elem.Int(), 10)...))
 						}
 					}
 					dm.Extracted.Base64Fields[field] = encodedSlice
@@ -162,7 +186,7 @@ func (t *ExtractTransform) addHexFields(dm *dnsutils.DNSMessage) (int, error) {
 		dm.Extracted = &dnsutils.TransformExtracted{}
 	}
 	if dm.Extracted.HexFields == nil {
-		dm.Extracted.HexFields = make(map[string]interface{})
+		dm.Extracted.HexFields = make(map[string]interface{}, len(t.config.Extract.HexFields))
 	}
 
 	for i, field := range t.config.Extract.HexFields {
@@ -170,19 +194,19 @@ func (t *ExtractTransform) addHexFields(dm *dnsutils.DNSMessage) (int, error) {
 		if val, found := extractor(dm); found {
 			switch v := val.(type) {
 			case string:
-				dm.Extracted.HexFields[field] = hex.EncodeToString([]byte(v))
+				dm.Extracted.HexFields[field] = fastHexEncode(v)
 			case int:
-				dm.Extracted.HexFields[field] = hex.EncodeToString([]byte(strconv.Itoa(v)))
+				dm.Extracted.HexFields[field] = fastHexEncodeInt(v)
 			case []string:
 				encodedSlice := make([]string, len(v))
 				for idx, s := range v {
-					encodedSlice[idx] = hex.EncodeToString([]byte(s))
+					encodedSlice[idx] = fastHexEncode(s)
 				}
 				dm.Extracted.HexFields[field] = encodedSlice
 			case []int:
 				encodedSlice := make([]string, len(v))
 				for idx, s := range v {
-					encodedSlice[idx] = hex.EncodeToString([]byte(strconv.Itoa(s)))
+					encodedSlice[idx] = fastHexEncodeInt(s)
 				}
 				dm.Extracted.HexFields[field] = encodedSlice
 			default:
@@ -190,16 +214,16 @@ func (t *ExtractTransform) addHexFields(dm *dnsutils.DNSMessage) (int, error) {
 				switch value.Kind() {
 				case reflect.Slice, reflect.Array:
 					var encodedSlice []string
-					for i := 0; i < value.Len(); i++ {
-						elem := value.Index(i)
+					for j := 0; j < value.Len(); j++ {
+						elem := value.Index(j)
 						if elem.Kind() == reflect.Interface {
 							elem = elem.Elem()
 						}
 						switch elem.Kind() {
 						case reflect.String:
-							encodedSlice = append(encodedSlice, hex.EncodeToString([]byte(elem.String())))
+							encodedSlice = append(encodedSlice, fastHexEncode(elem.String()))
 						case reflect.Int:
-							encodedSlice = append(encodedSlice, hex.EncodeToString([]byte(strconv.Itoa(int(elem.Int())))))
+							encodedSlice = append(encodedSlice, fastHexEncodeInt(int(elem.Int())))
 						}
 					}
 					dm.Extracted.HexFields[field] = encodedSlice

--- a/transformers/extract_bench_test.go
+++ b/transformers/extract_bench_test.go
@@ -29,3 +29,21 @@ func BenchmarkExtract_AddBase64AndHexFields(b *testing.B) {
 		_, _ = extract.addHexFields(&dm)
 	}
 }
+
+func BenchmarkExtract_AddBase64Payload(b *testing.B) {
+	config := pkgconfig.GetFakeConfigTransformers()
+	config.Extract.Enable = true
+	config.Extract.AddPayload = true
+
+	outChans := []chan *dnsutils.DNSMessageBatch{}
+	extract := NewExtractTransform(config, logger.New(false), "test", 0, outChans)
+	extract.GetTransforms()
+
+	dm := dnsutils.GetFakeDNSMessageWithPayload()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = extract.addBase64Payload(&dm)
+	}
+}


### PR DESCRIPTION
## Description

This PR optimizes base64 payload serialization and field extraction:

### Key Improvements:
- **Zero-Allocation Base64 JSON Encoding**: Replaced `base64.StdEncoding.EncodeToString` in `TransformExtracted.EncodeJSON` and `encodeInterfaceMap` with direct stream encoding using `buf.AvailableBuffer()` and `base64.StdEncoding.Encode()`. Eliminates 128 B and 2 heap allocations per message during JSON output.
- **Fast Hex & String Extraction**: Avoided intermediate string-to-byte slice allocations in `addHexFields` and `addBase64Fields` using non-copying slice views and in-place integer formatting (`strconv.AppendInt`).
- **Map Pre-allocation**: Pre-sized `Base64Fields` and `HexFields` maps to the exact number of configured fields.

---

## Benchmarks

```text
cpu: AMD Ryzen 9 9900X 12-Core Processor

# JSON Encoding with extracted payload
Benchmark_DNSMessage_ToJSON_ExtractedPayload (Before) :  417.4 ns/op    128 B/op    2 allocs/op
Benchmark_DNSMessage_ToJSON_ExtractedPayload (After)  :  383.1 ns/op      0 B/op    0 allocs/op (Zero-Alloc)

# Field extraction
BenchmarkExtract_AddBase64AndHexFields (Before)       :  204.7 ns/op    304 B/op   13 allocs/op
BenchmarkExtract_AddBase64AndHexFields (After)        :  180.4 ns/op    264 B/op   11 allocs/op
