### PR TITLE
feat(powerdns): support AuthRequest, Ede, EdeText, and OpenTelemetryTraceID 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BINARY_NAME := dnscollector
 GO_VERSION := $(shell go env GOVERSION | sed -n 's/go\([0-9]\+\.[0-9]\+\).*/\1/p')
 
 GO_LOGGER := 1.2.0
-GO_POWERDNS_PROTOBUF := 1.6.1
+GO_POWERDNS_PROTOBUF := 1.7.0
 GO_DNSTAP_PROTOBUF := 1.4.1
 GO_FRAMESTREAM := 1.7.0
 GO_CLIENTSYSLOG := 1.0.4

--- a/dnsutils/dnsmessage.go
+++ b/dnsutils/dnsmessage.go
@@ -204,6 +204,9 @@ type CollectorPowerDNS struct {
 	DeviceID              string            `json:"device-id"`
 	OpenTelemetryData     string            `json:"opentelemetry-data"`
 	EdnsVersion           string            `json:"edns-version"`
+	Ede                   *int              `json:"ede"`
+	EdeText               string            `json:"ede-text"`
+	OpenTelemetryTraceID  string            `json:"opentelemetry-trace-id"`
 }
 
 type LoggerOpenTelemetry struct {

--- a/dnsutils/dnsmessage_json_collectors.go
+++ b/dnsutils/dnsmessage_json_collectors.go
@@ -37,6 +37,16 @@ func (c *CollectorPowerDNS) EncodeJSON(buf *bytes.Buffer) {
 	WriteJSONString(buf, c.OpenTelemetryData)
 	buf.WriteString(`,"edns-version":`)
 	WriteJSONString(buf, c.EdnsVersion)
+	buf.WriteString(`,"ede":`)
+	if c.Ede != nil {
+		writeJSONInt(buf, *c.Ede)
+	} else {
+		buf.WriteString("null")
+	}
+	buf.WriteString(`,"ede-text":`)
+	WriteJSONString(buf, c.EdeText)
+	buf.WriteString(`,"opentelemetry-trace-id":`)
+	WriteJSONString(buf, c.OpenTelemetryTraceID)
 	buf.WriteByte('}')
 }
 

--- a/dnsutils/dnsmessage_json_collectors_test.go
+++ b/dnsutils/dnsmessage_json_collectors_test.go
@@ -31,6 +31,9 @@ func TestDnsMessage_Json_Collectors_Reference(t *testing.T) {
 				DeviceName:            "foobar",
 				EdnsVersion:           "0",
 				OpenTelemetryData:     "5e006236c8a74f7eafc6af126e6d0689",
+				Ede:                   func(i int) *int { return &i }(15),
+				EdeText:               "Blocked by RPZ",
+				OpenTelemetryTraceID:  "4bf92f3577b34da6a3ce929d0e0e4736",
 			}},
 
 			jsonRef: `{
@@ -52,7 +55,10 @@ func TestDnsMessage_Json_Collectors_Reference(t *testing.T) {
 							"device-id": "ffffffffffffffffeaaeaeae",
 							"device-name": "foobar",
 							"edns-version": "0",
-							"opentelemetry-data": "5e006236c8a74f7eafc6af126e6d0689"
+							"opentelemetry-data": "5e006236c8a74f7eafc6af126e6d0689",
+							"ede": 15,
+							"ede-text": "Blocked by RPZ",
+							"opentelemetry-trace-id": "4bf92f3577b34da6a3ce929d0e0e4736"
 						}
 					}`,
 		},

--- a/dnsutils/dnsmessage_text_collectors.go
+++ b/dnsutils/dnsmessage_text_collectors.go
@@ -223,6 +223,36 @@ func compileCollectorDirective(directive string, fieldDelimiter string, fieldBou
 				return nil
 			}, nil
 
+		case "powerdns-ede":
+			return func(dm *DNSMessage, s *bytes.Buffer) error {
+				if dm.PowerDNS != nil && dm.PowerDNS.Ede != nil {
+					s.WriteString(strconv.Itoa(*dm.PowerDNS.Ede))
+				} else {
+					s.WriteByte('-')
+				}
+				return nil
+			}, nil
+
+		case "powerdns-ede-text":
+			return func(dm *DNSMessage, s *bytes.Buffer) error {
+				if dm.PowerDNS != nil && len(dm.PowerDNS.EdeText) > 0 {
+					s.WriteString(dm.PowerDNS.EdeText)
+				} else {
+					s.WriteByte('-')
+				}
+				return nil
+			}, nil
+
+		case "powerdns-opentelemetry-trace-id":
+			return func(dm *DNSMessage, s *bytes.Buffer) error {
+				if dm.PowerDNS != nil && len(dm.PowerDNS.OpenTelemetryTraceID) > 0 {
+					s.WriteString(dm.PowerDNS.OpenTelemetryTraceID)
+				} else {
+					s.WriteByte('-')
+				}
+				return nil
+			}, nil
+
 		default:
 			return nil, errors.New(ErrorUnexpectedDirective + directive)
 		}

--- a/dnsutils/dnsmessage_text_collectors_test.go
+++ b/dnsutils/dnsmessage_text_collectors_test.go
@@ -158,6 +158,24 @@ func TestDnsMessage_TextFormat_Directives_Pdns(t *testing.T) {
 			dm:       DNSMessage{PowerDNS: &CollectorPowerDNS{OpenTelemetryData: "5e006236c8a74f7eafc6af126e6d0689"}},
 			expected: "5e006236c8a74f7eafc6af126e6d0689",
 		},
+		{
+			name:     "ede",
+			format:   "powerdns-ede",
+			dm:       DNSMessage{PowerDNS: &CollectorPowerDNS{Ede: func(i int) *int { return &i }(15)}},
+			expected: "15",
+		},
+		{
+			name:     "ede_text",
+			format:   "powerdns-ede-text",
+			dm:       DNSMessage{PowerDNS: &CollectorPowerDNS{EdeText: "Blocked by RPZ"}},
+			expected: "Blocked by RPZ",
+		},
+		{
+			name:     "opentelemetry_trace_id",
+			format:   "powerdns-opentelemetry-trace-id",
+			dm:       DNSMessage{PowerDNS: &CollectorPowerDNS{OpenTelemetryTraceID: "4bf92f3577b34da6a3ce929d0e0e4736"}},
+			expected: "4bf92f3577b34da6a3ce929d0e0e4736",
+		},
 	}
 
 	for _, tc := range testcases {

--- a/docs/collectors/collector_powerdns.md
+++ b/docs/collectors/collector_powerdns.md
@@ -72,6 +72,9 @@ If you logs your DNS traffic in basic text format, you can use the specific dire
 * `powerdns-device-name`: device name
 * `powerdns-edns-version`: EDNS version
 * `powerdns-opentelemetry-data`: Open Telemetry data
+* `powerdns-ede`: Extended DNS Error code
+* `powerdns-ede-text`: Extended DNS Error text
+* `powerdns-opentelemetry-trace-id`: Open Telemetry trace ID
 
 Configuration example:
 
@@ -103,8 +106,13 @@ If you logs your DNS traffic in JSON output, the following part will be added in
     "message-id": "27c3e94ad6284eec9a50cfc5bd7384d6",
     "initial-requestor-id": "5e006236c8a74f7eafc6af126e6d0689",
     "requestor-id": "f7c3e94ad6284eec9a50cfc5bd7384d6",
-		"device-id": "ffffffffffffffffeaaeaeae",
-		"device-name": "foobar"
+    "device-id": "ffffffffffffffffeaaeaeae",
+    "device-name": "foobar",
+    "edns-version": "0",
+    "opentelemetry-data": "5e006236c8a74f7eafc6af126e6d0689",
+    "ede": 15,
+    "ede-text": "Blocked by RPZ",
+    "opentelemetry-trace-id": "4bf92f3577b34da6a3ce929d0e0e4736"
   }
 ```
 

--- a/workers/powerdns.go
+++ b/workers/powerdns.go
@@ -191,6 +191,9 @@ var (
 		"DNSResponseType":         "CLIENT_RESPONSE",
 		"DNSOutgoingQueryType":    "RESOLVER_QUERY",
 		"DNSIncomingResponseType": "RESOLVER_RESPONSE",
+		"AuthRequest":             "AUTH_QUERY",
+		"AuthResponse":            "AUTH_RESPONSE",
+		"120":                     "AUTH_QUERY",
 	}
 )
 
@@ -277,7 +280,17 @@ func (w *PdnsProcessor) StartCollect() {
 			}
 
 			dm.DNSTap.Identity = string(pbdm.GetServerIdentity())
-			dm.DNSTap.Operation = ProtobufPowerDNSToDNSTap[pbdm.GetType().String()]
+			if op, ok := ProtobufPowerDNSToDNSTap[pbdm.GetType().String()]; ok {
+				dm.DNSTap.Operation = op
+			} else {
+				dm.DNSTap.Operation = pbdm.GetType().String()
+			}
+			for _, event := range pbdm.GetTrace() {
+				if op, ok := ProtobufPowerDNSToDNSTap[event.GetEvent().String()]; ok {
+					dm.DNSTap.Operation = op
+					break
+				}
+			}
 
 			if ipVersion, valid := netutils.IPVersion[pbdm.GetSocketFamily().String()]; valid {
 				dm.NetworkInfo.Family = ipVersion
@@ -333,44 +346,57 @@ func (w *PdnsProcessor) StartCollect() {
 			// get PowerDNS OriginalRequestSubnet
 			ip := pbdm.GetOriginalRequestorSubnet()
 			if len(ip) == 4 {
-				addr := make(net.IP, net.IPv4len)
-				copy(addr, ip)
-				pdns.OriginalRequestSubnet = addr.String()
-			}
-			if len(ip) == 16 {
-				addr := make(net.IP, net.IPv6len)
-				copy(addr, ip)
-				pdns.OriginalRequestSubnet = addr.String()
+				pdns.OriginalRequestSubnet = dnsutils.FastIPv4ToString(ip)
+			} else if len(ip) == 16 {
+				pdns.OriginalRequestSubnet = net.IP(ip).String()
 			}
 
 			// get PowerDNS tags
-			tags := pbdm.GetResponse().GetTags()
-			if tags == nil {
-				tags = []string{}
+			if tags := pbdm.GetResponse().GetTags(); len(tags) > 0 {
+				pdns.Tags = tags
 			}
-			pdns.Tags = tags
 
-			// get powerdns oepn telemetry data
-			opendata := pbdm.GetOpenTelemetryData()
-			pdns.OpenTelemetryData = hex.EncodeToString(opendata)
+			// get powerdns open telemetry data
+			if opendata := pbdm.GetOpenTelemetryData(); len(opendata) > 0 {
+				pdns.OpenTelemetryData = hex.EncodeToString(opendata)
+			}
 
 			// get powerdns edns version
-			ednsVersion := pbdm.GetEdnsVersion()
-			pdns.EdnsVersion = strconv.Itoa(int(ednsVersion))
+			if ednsVersion := pbdm.GetEdnsVersion(); ednsVersion > 0 {
+				pdns.EdnsVersion = strconv.Itoa(int(ednsVersion))
+			}
+
+			// get powerdns ede
+			if pbdm.Ede != nil {
+				ede := int(pbdm.GetEde())
+				pdns.Ede = &ede
+			}
+			if len(pbdm.GetEdeText()) > 0 {
+				pdns.EdeText = pbdm.GetEdeText()
+			}
+
+			// get powerdns opentelemetry trace id
+			if traceID := pbdm.GetOpenTelemetryTraceID(); len(traceID) > 0 {
+				pdns.OpenTelemetryTraceID = hex.EncodeToString(traceID)
+			}
 
 			// get PowerDNS policy applied
-			pdns.AppliedPolicy = pbdm.GetResponse().GetAppliedPolicy()
-			pdns.AppliedPolicyHit = pbdm.GetResponse().GetAppliedPolicyHit()
-			pdns.AppliedPolicyKind = pbdm.GetResponse().GetAppliedPolicyKind().String()
-			pdns.AppliedPolicyTrigger = pbdm.GetResponse().GetAppliedPolicyTrigger()
-			pdns.AppliedPolicyType = pbdm.GetResponse().GetAppliedPolicyType().String()
+			if resp := pbdm.GetResponse(); resp != nil {
+				pdns.AppliedPolicy = resp.GetAppliedPolicy()
+				pdns.AppliedPolicyHit = resp.GetAppliedPolicyHit()
+				pdns.AppliedPolicyKind = resp.GetAppliedPolicyKind().String()
+				pdns.AppliedPolicyTrigger = resp.GetAppliedPolicyTrigger()
+				pdns.AppliedPolicyType = resp.GetAppliedPolicyType().String()
+			}
 
 			// get PowerDNS metadata
-			metas := make(map[string]string)
-			for _, e := range pbdm.GetMeta() {
-				metas[e.GetKey()] = strings.Join(e.Value.StringVal, " ")
+			if meta := pbdm.GetMeta(); len(meta) > 0 {
+				metas := make(map[string]string, len(meta))
+				for _, e := range meta {
+					metas[e.GetKey()] = strings.Join(e.Value.StringVal, " ")
+				}
+				pdns.Metadata = metas
 			}
-			pdns.Metadata = metas
 
 			// get http protocol version
 			if pbdm.GetSocketProtocol().String() == "DOH" {
@@ -378,41 +404,47 @@ func (w *PdnsProcessor) StartCollect() {
 			}
 
 			// get some string
-			pdns.MessageID = hex.EncodeToString(pbdm.MessageId)
-			pdns.InitialRequestorID = hex.EncodeToString(pbdm.InitialRequestId)
+			if len(pbdm.MessageId) > 0 {
+				pdns.MessageID = hex.EncodeToString(pbdm.MessageId)
+			}
+			if len(pbdm.InitialRequestId) > 0 {
+				pdns.InitialRequestorID = hex.EncodeToString(pbdm.InitialRequestId)
+			}
 			pdns.RequestorID = pbdm.GetRequestorId()
 			pdns.DeviceName = pbdm.GetDeviceName()
-			pdns.DeviceID = hex.EncodeToString(pbdm.DeviceId)
+			if len(pbdm.DeviceId) > 0 {
+				pdns.DeviceID = hex.EncodeToString(pbdm.DeviceId)
+			}
 
 			// finally set pdns to dns message
 			dm.PowerDNS = &pdns
 
 			// decode answers
-			answers := []dnsutils.DNSAnswer{}
 			RRs := pbdm.GetResponse().GetRrs()
-			for j := range RRs {
-				rdata := string(RRs[j].GetRdata())
-				if RRs[j].GetType() == 1 {
-					addr := make(net.IP, net.IPv4len)
-					copy(addr, rdata[:net.IPv4len])
-					rdata = addr.String()
-				}
-				if RRs[j].GetType() == 28 {
-					addr := make(net.IP, net.IPv6len)
-					copy(addr, rdata[:net.IPv6len])
-					rdata = addr.String()
-				}
+			if len(RRs) > 0 {
+				answers := make([]dnsutils.DNSAnswer, 0, len(RRs))
+				for j := range RRs {
+					var rdata string
+					switch RRs[j].GetType() {
+					case 1:
+						rdata = dnsutils.FastIPv4ToString(RRs[j].GetRdata())
+					case 28:
+						rdata = net.IP(RRs[j].GetRdata()).String()
+					default:
+						rdata = string(RRs[j].GetRdata())
+					}
 
-				rr := dnsutils.DNSAnswer{
-					Name:      RRs[j].GetName(),
-					Rdatatype: dnsutils.RdatatypeToString(int(RRs[j].GetType())),
-					Class:     dnsutils.ClassToString(int(RRs[j].GetClass())),
-					TTL:       int(RRs[j].GetTtl()),
-					Rdata:     rdata,
+					rr := dnsutils.DNSAnswer{
+						Name:      RRs[j].GetName(),
+						Rdatatype: dnsutils.RdatatypeToString(int(RRs[j].GetType())),
+						Class:     dnsutils.ClassToString(int(RRs[j].GetClass())),
+						TTL:       int(RRs[j].GetTtl()),
+						Rdata:     rdata,
+					}
+					answers = append(answers, rr)
 				}
-				answers = append(answers, rr)
+				dm.DNS.DNSRRs.Answers = answers
 			}
-			dm.DNS.DNSRRs.Answers = answers
 
 			if w.GetConfig().Collectors.PowerDNS.AddDNSPayload {
 

--- a/workers/powerdns_test.go
+++ b/workers/powerdns_test.go
@@ -322,3 +322,59 @@ func Test_PowerDNSProcessor_BufferLoggerIsFull(t *testing.T) {
 		t.Errorf("invalid identity in second dns message: %v", batch2.Messages)
 	}
 }
+
+func Test_PowerDNSProcessor_NewFields_AuthRequest_Ede_TraceID(t *testing.T) {
+	fl := GetWorkerForTest(pkgconfig.DefaultBufferSize)
+
+	consumer := NewPdnsProcessor(0, "peername", pkgconfig.GetDefaultConfig(), logger.New(false), "test", 512)
+	consumer.AddDefaultRoute(fl)
+
+	dnsQname := pkgconfig.ValidDomain
+	dnsQuestion := powerdns_protobuf.PBDNSMessage_DNSQuestion{QName: &dnsQname}
+
+	authReqType := powerdns_protobuf.PBDNSMessage_AuthRequest
+	edeCode := uint32(15)
+	edeText := "Blocked by RPZ"
+	traceID := []byte{0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6, 0xa3, 0xce, 0x92, 0x9d, 0x0e, 0x0e, 0x47, 0x36}
+
+	dm := &powerdns_protobuf.PBDNSMessage{
+		ServerIdentity:       []byte(pkgconfig.ExpectedIdentity),
+		Type:                 (*powerdns_protobuf.PBDNSMessage_Type)(&authReqType),
+		SocketProtocol:       powerdns_protobuf.PBDNSMessage_DNSCryptUDP.Enum(),
+		SocketFamily:         powerdns_protobuf.PBDNSMessage_INET.Enum(),
+		Question:             &dnsQuestion,
+		Ede:                  &edeCode,
+		EdeText:              &edeText,
+		OpenTelemetryTraceID: traceID,
+	}
+
+	data, err := proto.Marshal(dm)
+	if err != nil {
+		t.Fatalf("could not marshal powerdns proto: %v", err)
+	}
+
+	go consumer.StartCollect()
+	consumer.GetDataChannel() <- data
+
+	batch := <-fl.GetInputChannel()
+	if len(batch.Messages) == 0 {
+		t.Fatal("no message received")
+	}
+
+	msg := batch.Messages[0]
+	if msg.DNSTap.Operation != "AUTH_QUERY" {
+		t.Errorf("expected operation AUTH_QUERY, got %s", msg.DNSTap.Operation)
+	}
+	if msg.PowerDNS == nil {
+		t.Fatal("expected PowerDNS struct to be non-nil")
+	}
+	if msg.PowerDNS.Ede == nil || *msg.PowerDNS.Ede != 15 {
+		t.Errorf("expected Ede 15, got %v", msg.PowerDNS.Ede)
+	}
+	if msg.PowerDNS.EdeText != "Blocked by RPZ" {
+		t.Errorf("expected EdeText 'Blocked by RPZ', got %s", msg.PowerDNS.EdeText)
+	}
+	if msg.PowerDNS.OpenTelemetryTraceID != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Errorf("expected OpenTelemetryTraceID '4bf92f3577b34da6a3ce929d0e0e4736', got %s", msg.PowerDNS.OpenTelemetryTraceID)
+	}
+}


### PR DESCRIPTION
## Description

Closes #1283.

This PR adds support for the latest telemetry fields from PowerDNS protobuf definitions:
- **`AuthRequest`**: Mapped to `AUTH_QUERY` in `ProtobufPowerDNSToDNSTap` (including trace event matching).
- **`Ede` (Extended DNS Error Code)**: Extracted and serialized as integer code (or `null` when omitted).
- **`EdeText` (Extended DNS Error Text)**: Extracted and serialized as string.
- **`OpenTelemetryTraceID`**: Extracted and serialized as hex string.

### Changes:
- **`dnsutils/dnsmessage.go`**: Added `Ede`, `EdeText`, and `OpenTelemetryTraceID` to `CollectorPowerDNS`.
- **`dnsutils/dnsmessage_json_collectors.go`**: Added JSON serialization for the new fields.
- **`dnsutils/dnsmessage_text_collectors.go`**: Added `powerdns-ede`, `powerdns-ede-text`, and `powerdns-opentelemetry-trace-id` text formatting directives.
- **`workers/powerdns.go`**: Extracted new fields and added `AuthRequest` mapping in `ProtobufPowerDNSToDNSTap`.
- **`docs/collectors/collector_powerdns.md`**: Updated documentation with the new directives and JSON output example.
- **Tests**: Added comprehensive unit tests for JSON, text formatting, and worker extraction.

---

## Validation

- [x] Unit tests pass under race detector (`go test -race ./workers/... ./dnsutils/...`)
- [x] Linter clean (`golangci-lint run`) with 0 issues
