### PR TITLE
feat(clickhouse): add JSONEachRow batching, DNS flags support and connection pooling (#877, #921)

### DIFF
--- a/docs/loggers/logger_clickhouse.md
+++ b/docs/loggers/logger_clickhouse.md
@@ -1,33 +1,112 @@
-
 # Logger: ClickHouse client
 
-Clickhouse client to remote ClickHouse server
+ClickHouse client to stream DNS logs directly to a remote ClickHouse server using the high-performance `JSONEachRow` batch insertion format.
 
-Options:
+## Options
 
 * `url` (string)
-  > Clickhouse server url
+  > ClickHouse HTTP server URL (e.g. `http://localhost:8123`)
 
 * `user` (string)
-  > Clickhouse database user
+  > ClickHouse database user (sent via `X-ClickHouse-User` header)
 
 * `password` (string)
-  > Clickhouse database user password
-
-* `table` (string)
-  > Clickhouse table name
+  > ClickHouse database user password (sent via `X-ClickHouse-Key` header)
 
 * `database` (string)
-  > Clickhouse database name
+  > ClickHouse database name (default: `dnscollector`)
 
+* `table` (string)
+  > ClickHouse table name (default: `records`)
 
-Defaults:
+* `buffer-size` (integer)
+  > Number of DNS events to batch in memory before flushing an HTTP POST request (default: `100`)
+
+* `flush-interval` (integer)
+  > Interval in seconds to flush the buffer even if `buffer-size` is not reached (default: `10`)
+
+* `timeout` (integer)
+  > HTTP connection and request timeout in seconds (default: `5`)
+
+* `tls-support` (bool)
+  > Enable TLS/HTTPS communication with ClickHouse (default: `false`)
+
+* `tls-insecure` (bool)
+  > Disable TLS certificate verification (default: `false`)
+
+* `tls-min-version` (string)
+  > Minimum TLS version (`1.2` or `1.3`, default: `1.2`)
+
+* `ca-file` (string)
+  > Path to custom CA certificate file
+
+* `cert-file` (string)
+  > Path to client certificate file
+
+* `key-file` (string)
+  > Path to client private key file
+
+---
+
+## Configuration Example
 
 ```yaml
 clickhouse:
+  enable: true
   url: "http://localhost:8123"
   user: "default"
   password: "password"
-  table: "records"
   database: "dnscollector"
+  table: "records"
+  buffer-size: 1000
+  flush-interval: 5
+  timeout: 5
+```
+
+---
+
+## ClickHouse Table Schema Example
+
+You can create the corresponding table in ClickHouse:
+
+```sql
+CREATE DATABASE IF NOT EXISTS dnscollector;
+
+CREATE TABLE IF NOT EXISTS dnscollector.records (
+    timestamp DateTime64(3, 'UTC'),
+    timensec UInt64,
+    timestamp_rfc3339 String,
+    identity LowCardinality(String),
+    operation LowCardinality(String),
+    family LowCardinality(String),
+    protocol LowCardinality(String),
+    queryip IPv4,
+    queryport UInt16,
+    responseip IPv4,
+    responseport UInt16,
+    qname String,
+    qtype LowCardinality(String),
+    rcode LowCardinality(String),
+    length UInt16,
+    id UInt16,
+    opcode UInt8,
+    latency Float64,
+    qr Bool,
+    tc Bool,
+    aa Bool,
+    ra Bool,
+    ad Bool,
+    rd Bool,
+    cd Bool,
+    malformed_packet Bool,
+    tld LowCardinality(String),
+    etld_plus_one LowCardinality(String),
+    city LowCardinality(String),
+    country LowCardinality(String),
+    as_number UInt32,
+    as_owner LowCardinality(String),
+    suspicious_score Float64
+) ENGINE = MergeTree()
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (timestamp, qname);
 ```

--- a/pkgconfig/loggers.go
+++ b/pkgconfig/loggers.go
@@ -310,12 +310,21 @@ type ConfigLoggers struct {
 		URL    string `yaml:"url" default:"http://127.0.0.1:9200"`
 	} `yaml:"falco"`
 	ClickhouseClient struct {
-		Enable   bool   `yaml:"enable" default:"false"`
-		URL      string `yaml:"url" default:"http://localhost:8123"`
-		User     string `yaml:"user" default:"default"`
-		Password string `yaml:"password" default:"password"`
-		Database string `yaml:"database" default:"dnscollector"`
-		Table    string `yaml:"table" default:"records"`
+		Enable        bool   `yaml:"enable" default:"false"`
+		URL           string `yaml:"url" default:"http://localhost:8123"`
+		User          string `yaml:"user" default:"default"`
+		Password      string `yaml:"password" default:"password"`
+		Database      string `yaml:"database" default:"dnscollector"`
+		Table         string `yaml:"table" default:"records"`
+		BufferSize    int    `yaml:"buffer-size" default:"100"`
+		FlushInterval int    `yaml:"flush-interval" default:"10"`
+		Timeout       int    `yaml:"timeout" default:"5"`
+		TLSSupport    bool   `yaml:"tls-support" default:"false"`
+		TLSInsecure   bool   `yaml:"tls-insecure" default:"false"`
+		TLSMinVersion string `yaml:"tls-min-version" default:"1.2"`
+		CAFile        string `yaml:"ca-file" default:""`
+		CertFile      string `yaml:"cert-file" default:""`
+		KeyFile       string `yaml:"key-file" default:""`
 	} `yaml:"clickhouse"`
 	MQTT struct {
 		Enable          bool   `yaml:"enable" default:"false"`

--- a/workers/clickhouse.go
+++ b/workers/clickhouse.go
@@ -1,58 +1,138 @@
 package workers
 
 import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/dmachard/go-dnscollector/v2/dnsutils"
 	"github.com/dmachard/go-dnscollector/v2/pkgconfig"
 	"github.com/dmachard/go-dnscollector/v2/transformers"
 	"github.com/dmachard/go-logger"
+	"github.com/dmachard/go-netutils"
 )
 
-var (
-	separator = "','"
-)
-
-type ClickhouseData struct {
-	Identity  string `json:"identity"`
-	QueryIP   string `json:"query_ip"`
-	QName     string `json:"q_name"`
-	Operation string `json:"operation"`
-	Family    string `json:"family"`
-	Protocol  string `json:"protocol"`
-	QType     string `json:"q_type"`
-	RCode     string `json:"r_code"`
-	TimeNSec  string `json:"timensec"`
-	TimeStamp string `json:"timestamp"`
+type ClickhouseRecord struct {
+	Timestamp       int64   `json:"timestamp"`
+	TimeNSec        int64   `json:"timensec"`
+	TimestampRFC    string  `json:"timestamp_rfc3339,omitempty"`
+	Identity        string  `json:"identity,omitempty"`
+	QueryIP         string  `json:"queryip,omitempty"`
+	QueryPort       int     `json:"queryport,omitempty"`
+	ResponseIP      string  `json:"responseip,omitempty"`
+	ResponsePort    int     `json:"responseport,omitempty"`
+	Family          string  `json:"family,omitempty"`
+	Protocol        string  `json:"protocol,omitempty"`
+	Length          int     `json:"length,omitempty"`
+	ID              int     `json:"id,omitempty"`
+	Opcode          int     `json:"opcode,omitempty"`
+	RCode           string  `json:"rcode,omitempty"`
+	QName           string  `json:"qname,omitempty"`
+	QType           string  `json:"qtype,omitempty"`
+	Operation       string  `json:"operation,omitempty"`
+	Latency         float64 `json:"latency,omitempty"`
+	QR              bool    `json:"qr"`
+	TC              bool    `json:"tc"`
+	AA              bool    `json:"aa"`
+	RA              bool    `json:"ra"`
+	AD              bool    `json:"ad"`
+	RD              bool    `json:"rd"`
+	CD              bool    `json:"cd"`
+	TLD             string  `json:"tld,omitempty"`
+	ETLDPlusOne     string  `json:"etld_plus_one,omitempty"`
+	City            string  `json:"city,omitempty"`
+	Country         string  `json:"country,omitempty"`
+	ASNumber        int     `json:"as_number,omitempty"`
+	ASOwner         string  `json:"as_owner,omitempty"`
+	SuspiciousScore float64 `json:"suspicious_score,omitempty"`
+	Malformed       bool    `json:"malformed_packet,omitempty"`
 }
 
 type ClickhouseClient struct {
 	*GenericWorker
+	httpClient  *http.Client
+	requestURL  string
+	jsonBuffer  *bytes.Buffer
+	jsonEncoder *json.Encoder
+	bufferCount int
 }
 
 func NewClickhouseClient(config *pkgconfig.Config, console *logger.Logger, name string) *ClickhouseClient {
 	bufSize := config.Global.Worker.ChannelBufferSize
-	w := &ClickhouseClient{GenericWorker: NewGenericWorker(config, console, name, "clickhouse", bufSize, pkgconfig.DefaultMonitor)}
+	w := &ClickhouseClient{
+		GenericWorker: NewGenericWorker(config, console, name, "clickhouse", bufSize, pkgconfig.DefaultMonitor),
+		jsonBuffer:    new(bytes.Buffer),
+	}
+	w.jsonEncoder = json.NewEncoder(w.jsonBuffer)
 	w.ReadConfig()
 	return w
+}
+
+func (w *ClickhouseClient) ReadConfig() {
+	cfg := w.GetConfig().Loggers.ClickhouseClient
+
+	// Build endpoint URL with JSONEachRow format
+	targetURL := cfg.URL
+	if !strings.HasSuffix(targetURL, "/") {
+		targetURL += "/"
+	}
+	queryParam := fmt.Sprintf("INSERT INTO %s.%s FORMAT JSONEachRow", cfg.Database, cfg.Table)
+	w.requestURL = targetURL + "?query=" + url.QueryEscape(queryParam)
+
+	// TLS configuration
+	var tlsConfig *tls.Config
+	if cfg.TLSSupport {
+		var err error
+		tlsOptions := netutils.TLSOptions{
+			InsecureSkipVerify: cfg.TLSInsecure,
+			MinVersion:         cfg.TLSMinVersion,
+			CAFile:             cfg.CAFile,
+			CertFile:           cfg.CertFile,
+			KeyFile:            cfg.KeyFile,
+		}
+		tlsConfig, err = netutils.TLSClientConfig(tlsOptions)
+		if err != nil {
+			w.LogFatal(pkgconfig.PrefixLogWorker+"["+w.GetName()+"] clickhouse - tls config error: ", err.Error())
+		}
+	}
+
+	// HTTP Transport with connection pooling
+	transport := &http.Transport{
+		TLSClientConfig:     tlsConfig,
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 100,
+		IdleConnTimeout:     90 * time.Second,
+		DialContext: (&net.Dialer{
+			Timeout:   time.Duration(cfg.Timeout) * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+	}
+
+	w.httpClient = &http.Client{
+		Timeout:   time.Duration(cfg.Timeout) * time.Second,
+		Transport: transport,
+	}
 }
 
 func (w *ClickhouseClient) StartCollect() {
 	w.LogInfo("starting data collection")
 	defer w.CollectDone()
 
-	// prepare next channels
 	defaultRoutes, defaultNames := GetRoutes(w.GetDefaultRoutes())
 	droppedRoutes, droppedNames := GetRoutes(w.GetDroppedRoutes())
 
-	// prepare transforms
 	subprocessors := transformers.NewTransforms(&w.GetConfig().OutgoingTransformers, w.GetLogger(), w.GetName(), w.GetOutputChannelAsList(), 0)
 
-	// goroutine to process transformed dns messages
 	go w.StartLogging()
 
-	// loop to process incoming messages
 	for {
 		select {
 		case <-w.OnStop():
@@ -60,7 +140,6 @@ func (w *ClickhouseClient) StartCollect() {
 			subprocessors.Reset()
 			return
 
-			// new config provided?
 		case cfg := <-w.NewConfig():
 			w.SetConfig(cfg)
 			w.ReadConfig()
@@ -73,10 +152,8 @@ func (w *ClickhouseClient) StartCollect() {
 			}
 			outBatch := dnsutils.AcquireDNSMessageBatch(len(batch.Messages))
 			for _, dm := range batch.Messages {
-				// count global messages
 				w.CountIngressTraffic()
 
-				// apply transforms, init dns message with additional parts if necessary
 				transformResult, err := subprocessors.ProcessMessage(dm)
 				if err != nil {
 					w.LogError(err.Error())
@@ -91,7 +168,6 @@ func (w *ClickhouseClient) StartCollect() {
 			}
 			w.SendToOutputAndForwardBatch(defaultRoutes, defaultNames, outBatch)
 			batch.Release()
-
 		}
 	}
 }
@@ -100,48 +176,149 @@ func (w *ClickhouseClient) StartLogging() {
 	w.LogInfo("logging has started")
 	defer w.LoggingDone()
 
+	flushInterval := time.Duration(w.GetConfig().Loggers.ClickhouseClient.FlushInterval) * time.Second
+	if flushInterval <= 0 {
+		flushInterval = 10 * time.Second
+	}
+	flushTicker := time.NewTicker(flushInterval)
+	defer flushTicker.Stop()
+
 	for {
 		select {
 		case <-w.OnLoggerStopped():
+			if w.bufferCount > 0 {
+				w.flush()
+			}
 			return
 
-			// incoming dns message to process
+		case <-flushTicker.C:
+			if w.bufferCount > 0 {
+				w.flush()
+			}
+
 		case batch, opened := <-w.GetOutputChannel():
 			if !opened {
 				w.LogInfo("output channel closed!")
+				if w.bufferCount > 0 {
+					w.flush()
+				}
 				return
 			}
+
+			bufferSize := w.GetConfig().Loggers.ClickhouseClient.BufferSize
+			if bufferSize <= 0 {
+				bufferSize = 100
+			}
+
 			for _, dm := range batch.Messages {
-				timensec := strconv.FormatInt(dm.DNSTap.Timestamp, 10)
-				data := ClickhouseData{
-					Identity:  dm.DNSTap.Identity,
-					QueryIP:   dm.NetworkInfo.GetQueryIP(),
-					QName:     dm.DNS.Qname,
-					Operation: dm.DNSTap.Operation,
-					Family:    dm.NetworkInfo.Family,
-					Protocol:  dm.NetworkInfo.Protocol,
-					QType:     dm.DNS.Qtype,
-					RCode:     dm.DNS.Rcode,
-					TimeNSec:  timensec,
-					TimeStamp: strconv.Itoa(int(int64(dm.DNSTap.TimeSec))),
+				record := convertDNSMessageToRecord(dm)
+				if err := w.jsonEncoder.Encode(record); err != nil {
+					w.LogError("failed to encode record to json: %s", err)
+					continue
 				}
-				url := w.GetConfig().Loggers.ClickhouseClient.URL + "?query=INSERT%20INTO%20"
-				url += w.GetConfig().Loggers.ClickhouseClient.Database + "." + w.GetConfig().Loggers.ClickhouseClient.Table
-				url += "(identity,queryip,qname,operation,family,protocol,qtype,rcode,timensec,timestamp)%20VALUES%20('" + data.Identity + separator
-				url += data.QueryIP + separator + data.QName + separator + data.Operation + separator + data.Family + separator + data.Protocol
-				url += separator + data.QType + separator + data.RCode + separator + data.TimeNSec + separator + data.TimeStamp + "')"
-				req, _ := http.NewRequest("POST", url, nil)
-
-				req.Header.Add("Accept", "*/*")
-				req.Header.Add("X-ClickHouse-User", w.GetConfig().Loggers.ClickhouseClient.User)
-				req.Header.Add("X-ClickHouse-Key", w.GetConfig().Loggers.ClickhouseClient.Password)
-
-				_, errReq := http.DefaultClient.Do(req)
-				if errReq != nil {
-					w.LogError(errReq.Error())
+				w.bufferCount++
+				if w.bufferCount >= bufferSize {
+					w.flush()
 				}
 			}
 			batch.Release()
 		}
 	}
+}
+
+func (w *ClickhouseClient) flush() {
+	if w.bufferCount == 0 || w.jsonBuffer.Len() == 0 {
+		return
+	}
+
+	payloadBytes := w.jsonBuffer.Bytes()
+	req, err := http.NewRequest("POST", w.requestURL, bytes.NewReader(payloadBytes))
+	if err != nil {
+		w.LogError("failed to create http request: %s", err)
+		w.jsonBuffer.Reset()
+		w.bufferCount = 0
+		return
+	}
+
+	cfg := w.GetConfig().Loggers.ClickhouseClient
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "*/*")
+	if len(cfg.User) > 0 {
+		req.Header.Set("X-ClickHouse-User", cfg.User)
+	}
+	if len(cfg.Password) > 0 {
+		req.Header.Set("X-ClickHouse-Key", cfg.Password)
+	}
+
+	resp, err := w.httpClient.Do(req)
+	if err != nil {
+		w.CountEgressDiscarded()
+		w.LogError("http post failed: %s", err)
+		w.jsonBuffer.Reset()
+		w.bufferCount = 0
+		return
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		w.CountEgressDiscarded()
+		w.LogError("clickhouse returned error status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	} else {
+		w.CountEgressTraffic()
+	}
+
+	w.jsonBuffer.Reset()
+	w.bufferCount = 0
+}
+
+func convertDNSMessageToRecord(dm *dnsutils.DNSMessage) ClickhouseRecord {
+	qPort, _ := strconv.Atoi(dm.NetworkInfo.QueryPort)
+	rPort, _ := strconv.Atoi(dm.NetworkInfo.ResponsePort)
+
+	record := ClickhouseRecord{
+		Timestamp:    int64(dm.DNSTap.TimeSec),
+		TimeNSec:     dm.DNSTap.Timestamp,
+		TimestampRFC: dm.DNSTap.TimestampRFC3339,
+		Identity:     dm.DNSTap.Identity,
+		QueryIP:      dm.NetworkInfo.GetQueryIP(),
+		QueryPort:    qPort,
+		ResponseIP:   dm.NetworkInfo.GetResponseIP(),
+		ResponsePort: rPort,
+		Family:       dm.NetworkInfo.Family,
+		Protocol:     dm.NetworkInfo.Protocol,
+		Length:       dm.DNS.Length,
+		ID:           dm.DNS.ID,
+		Opcode:       dm.DNS.Opcode,
+		RCode:        dm.DNS.Rcode,
+		QName:        dm.DNS.Qname,
+		QType:        dm.DNS.Qtype,
+		Operation:    dm.DNSTap.Operation,
+		Latency:      dm.DNSTap.Latency,
+		QR:           dm.DNS.Flags.QR,
+		TC:           dm.DNS.Flags.TC,
+		AA:           dm.DNS.Flags.AA,
+		RA:           dm.DNS.Flags.RA,
+		AD:           dm.DNS.Flags.AD,
+		RD:           dm.DNS.Flags.RD,
+		CD:           dm.DNS.Flags.CD,
+		Malformed:    dm.DNS.MalformedPacket,
+	}
+
+	if dm.PublicSuffix != nil {
+		record.TLD = dm.PublicSuffix.QnamePublicSuffix
+		record.ETLDPlusOne = dm.PublicSuffix.QnameEffectiveTLDPlusOne
+	}
+	if dm.Geo != nil {
+		record.City = dm.Geo.City
+		record.Country = dm.Geo.CountryIsoCode
+		record.ASNumber, _ = strconv.Atoi(dm.Geo.AutonomousSystemNumber)
+		record.ASOwner = dm.Geo.AutonomousSystemOrg
+	}
+	if dm.Suspicious != nil {
+		record.SuspiciousScore = dm.Suspicious.Score
+	}
+
+	return record
 }

--- a/workers/clickhouse_bench_test.go
+++ b/workers/clickhouse_bench_test.go
@@ -1,0 +1,96 @@
+package workers
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmachard/go-dnscollector/v2/dnsutils"
+	"github.com/dmachard/go-dnscollector/v2/pkgconfig"
+	"github.com/dmachard/go-logger"
+)
+
+func Benchmark_Clickhouse_Record_EncodeJSON(b *testing.B) {
+	dm := dnsutils.GetFakeDNSMessage()
+	dm.DNS.Qname = "dnscollector.dev"
+	dm.DNS.Flags = dnsutils.DNSFlags{
+		QR: true,
+		AA: true,
+		RD: true,
+		RA: true,
+	}
+	dm.DNSTap.Latency = 0.00123
+
+	buf := new(bytes.Buffer)
+	enc := json.NewEncoder(buf)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		record := convertDNSMessageToRecord(&dm)
+		_ = enc.Encode(record)
+	}
+}
+
+func Benchmark_Clickhouse_Throughput_Batch100(b *testing.B) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Ok."))
+	}))
+	defer server.Close()
+
+	cfg := pkgconfig.GetDefaultConfig()
+	cfg.Loggers.ClickhouseClient.URL = server.URL
+	cfg.Loggers.ClickhouseClient.BufferSize = 100
+	cfg.Loggers.ClickhouseClient.FlushInterval = 60
+
+	client := NewClickhouseClient(cfg, logger.New(false), "bench_clickhouse")
+	go client.StartCollect()
+	defer client.Stop()
+
+	dm := dnsutils.GetFakeDNSMessage()
+	dm.DNS.Qname = "dnscollector.dev"
+	dm.DNS.Flags = dnsutils.DNSFlags{QR: true, RD: true}
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		batch := dnsutils.NewDNSMessageBatch(&dm)
+		client.GetInputChannel() <- batch
+	}
+}
+
+func Benchmark_Clickhouse_Throughput_Batch1000(b *testing.B) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Ok."))
+	}))
+	defer server.Close()
+
+	cfg := pkgconfig.GetDefaultConfig()
+	cfg.Loggers.ClickhouseClient.URL = server.URL
+	cfg.Loggers.ClickhouseClient.BufferSize = 1000
+	cfg.Loggers.ClickhouseClient.FlushInterval = 60
+
+	client := NewClickhouseClient(cfg, logger.New(false), "bench_clickhouse")
+	go client.StartCollect()
+	defer client.Stop()
+
+	dm := dnsutils.GetFakeDNSMessage()
+	dm.DNS.Qname = "dnscollector.dev"
+	dm.DNS.Flags = dnsutils.DNSFlags{QR: true, RD: true}
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		batch := dnsutils.NewDNSMessageBatch(&dm)
+		client.GetInputChannel() <- batch
+	}
+}

--- a/workers/clickhouse_test.go
+++ b/workers/clickhouse_test.go
@@ -2,66 +2,172 @@ package workers
 
 import (
 	"bufio"
-	"net"
+	"encoding/json"
 	"net/http"
-	"regexp"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/dmachard/go-dnscollector/v2/dnsutils"
 	"github.com/dmachard/go-dnscollector/v2/pkgconfig"
 	"github.com/dmachard/go-logger"
+	"github.com/stretchr/testify/assert"
 )
 
-func Test_ClickhouseClient(t *testing.T) {
+func Test_ClickhouseClient_BatchInsert(t *testing.T) {
+	var receivedCount atomic.Int32
+	var receivedBody []byte
+	var receivedQuery string
+	var receivedUser, receivedKey string
 
-	testcases := []struct {
-		mode    string
-		pattern string
-	}{
-		{
-			mode:    pkgconfig.ModeJSON,
-			pattern: pkgconfig.ProgQname,
-		},
-	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedUser = r.Header.Get("X-ClickHouse-User")
+		receivedKey = r.Header.Get("X-ClickHouse-Key")
+		receivedQuery = r.URL.Query().Get("query")
+
+		scanner := bufio.NewScanner(r.Body)
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			if len(line) > 0 {
+				receivedCount.Add(1)
+				var record ClickhouseRecord
+				if err := json.Unmarshal(line, &record); err == nil {
+					assert.Equal(t, "dnscollector.dev", record.QName)
+					assert.True(t, record.RD)
+				}
+			}
+		}
+		receivedBody = scanner.Bytes()
+		_ = receivedBody
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Ok."))
+	}))
+	defer server.Close()
+
 	cfg := pkgconfig.GetDefaultConfig()
-	cfg.Loggers.ClickhouseClient.URL = "http://127.0.0.1:8123"
-	cfg.Loggers.ClickhouseClient.User = "default"
-	cfg.Loggers.ClickhouseClient.Password = "password"
-	cfg.Loggers.ClickhouseClient.Database = "database"
-	cfg.Loggers.ClickhouseClient.Table = "table"
-	fakeRcvr, err := net.Listen("tcp", "127.0.0.1:8123")
-	if err != nil {
-		t.Fatal(err)
+	cfg.Loggers.ClickhouseClient.URL = server.URL
+	cfg.Loggers.ClickhouseClient.User = "myuser"
+	cfg.Loggers.ClickhouseClient.Password = "mypass"
+	cfg.Loggers.ClickhouseClient.Database = "dnsdb"
+	cfg.Loggers.ClickhouseClient.Table = "queries"
+	cfg.Loggers.ClickhouseClient.BufferSize = 3
+	cfg.Loggers.ClickhouseClient.FlushInterval = 10
+
+	g := NewClickhouseClient(cfg, logger.New(false), "test_clickhouse")
+	go g.StartCollect()
+
+	// Send 3 messages to trigger buffer full flush
+	for i := 0; i < 3; i++ {
+		dm := dnsutils.GetFakeDNSMessage()
+		dm.DNS.Qname = "dnscollector.dev"
+		dm.DNS.Flags = dnsutils.DNSFlags{RD: true, QR: false}
+		g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 	}
-	defer fakeRcvr.Close()
 
-	for _, tc := range testcases {
-		t.Run(tc.mode, func(t *testing.T) {
-			g := NewClickhouseClient(cfg, logger.New(false), "test")
+	time.Sleep(300 * time.Millisecond)
+	g.Stop()
 
-			go g.StartCollect()
+	assert.Equal(t, int32(3), receivedCount.Load())
+	assert.Equal(t, "myuser", receivedUser)
+	assert.Equal(t, "mypass", receivedKey)
+	assert.Contains(t, receivedQuery, "INSERT INTO dnsdb.queries FORMAT JSONEachRow")
+}
 
-			dm := dnsutils.GetFakeDNSMessage()
-			g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
-			// accept conn
-			conn, err := fakeRcvr.Accept()
-			if err != nil {
-				t.Fatal(err)
+func Test_ClickhouseClient_FlushInterval(t *testing.T) {
+	var receivedCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scanner := bufio.NewScanner(r.Body)
+		for scanner.Scan() {
+			if len(scanner.Bytes()) > 0 {
+				receivedCount.Add(1)
 			}
-			defer conn.Close()
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
 
-			// read and parse http request on server side
-			request, err := http.ReadRequest(bufio.NewReader(conn))
-			if err != nil {
-				t.Fatal(err)
-			}
-			query := request.URL.Query().Get("query")
-			conn.Write([]byte(pkgconfig.HTTPOK))
+	cfg := pkgconfig.GetDefaultConfig()
+	cfg.Loggers.ClickhouseClient.URL = server.URL
+	cfg.Loggers.ClickhouseClient.BufferSize = 100  // Buffer won't be full
+	cfg.Loggers.ClickhouseClient.FlushInterval = 1 // Flush every 1s
 
-			pattern := regexp.MustCompile(tc.pattern)
-			if !pattern.MatchString(query) {
-				t.Errorf("clickhouse test error want %s, got: %s", tc.pattern, query)
-			}
-		})
+	g := NewClickhouseClient(cfg, logger.New(false), "test_flush")
+	go g.StartCollect()
+
+	// Send 2 messages
+	for i := 0; i < 2; i++ {
+		dm := dnsutils.GetFakeDNSMessage()
+		g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
 	}
+
+	// Wait for timer flush
+	time.Sleep(1500 * time.Millisecond)
+	g.Stop()
+
+	assert.Equal(t, int32(2), receivedCount.Load())
+}
+
+func Test_ClickhouseClient_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("DB::Exception: Table does not exist"))
+	}))
+	defer server.Close()
+
+	cfg := pkgconfig.GetDefaultConfig()
+	cfg.Loggers.ClickhouseClient.URL = server.URL
+	cfg.Loggers.ClickhouseClient.BufferSize = 1
+	cfg.Loggers.ClickhouseClient.FlushInterval = 1
+
+	g := NewClickhouseClient(cfg, logger.New(false), "test_error")
+	go g.StartCollect()
+
+	dm := dnsutils.GetFakeDNSMessage()
+	g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
+
+	time.Sleep(300 * time.Millisecond)
+	g.Stop()
+}
+
+func Test_ClickhouseRecord_DNSFlags(t *testing.T) {
+	dm := dnsutils.GetFakeDNSMessage()
+	dm.DNS.Qname = "test.example.com"
+	dm.DNS.Flags = dnsutils.DNSFlags{
+		QR: true,
+		AA: true,
+		TC: false,
+		RD: true,
+		RA: true,
+		AD: true,
+		CD: false,
+	}
+	dm.DNSTap.Latency = 0.001234
+	dm.PublicSuffix = &dnsutils.TransformPublicSuffix{
+		QnamePublicSuffix:        "com",
+		QnameEffectiveTLDPlusOne: "example.com",
+	}
+
+	record := convertDNSMessageToRecord(&dm)
+
+	assert.Equal(t, "test.example.com", record.QName)
+	assert.True(t, record.QR)
+	assert.True(t, record.AA)
+	assert.False(t, record.TC)
+	assert.True(t, record.RD)
+	assert.True(t, record.RA)
+	assert.True(t, record.AD)
+	assert.False(t, record.CD)
+	assert.Equal(t, 0.001234, record.Latency)
+	assert.Equal(t, "com", record.TLD)
+	assert.Equal(t, "example.com", record.ETLDPlusOne)
+
+	// JSON Marshalling test
+	data, err := json.Marshal(record)
+	assert.NoError(t, err)
+	assert.True(t, strings.Contains(string(data), `"qr":true`))
+	assert.True(t, strings.Contains(string(data), `"aa":true`))
+	assert.True(t, strings.Contains(string(data), `"etld_plus_one":"example.com"`))
 }


### PR DESCRIPTION
## Description

Closes #877
Closes #921

This PR overhauls the ClickHouse logger to significantly improve performance, reduce memory overhead, and support modern ClickHouse ingestion best practices.

### Key Improvements

1. **`JSONEachRow` Batching Ingestion**:
   - Replaced individual URL-encoded SQL `INSERT` statements with newline-delimited `JSONEachRow` streaming batches.
   - Added configurable `buffer-size` (default: 100) and `flush-interval` (default: 10s) timers.

2. **Complete Data Model & DNS Flags**:
   - Added DNS header flags (`qr`, `tc`, `aa`, `ra`, `ad`, `rd`, `cd`).
   - Added `latency`, `length`, `id`, `opcode`, `queryport`, `responseport`, `tld`, `etld_plus_one`, `city`, `country`, `as_number`, `as_owner`, and `suspicious_score`.

3. **HTTP Connection Pooling & Memory Safety (#921)**:
   - Configured dedicated `http.Client` with Keep-Alive transport and idle connection pooling.
   - Added TLS support (`tls-support`, `tls-insecure`, `ca-file`, `cert-file`, `key-file`).
   - Ensured response bodies are always drained and closed to prevent descriptor/memory leaks.

4. **Testing & Documentation**:
   - Added unit test suite covering batch inserts, timer flushes, HTTP errors, and DNS flag serialization with `-race`.
   - Updated documentation with full configuration options and ClickHouse SQL schema.
