### PR TITLE
feat(syslog): support dynamic hostname based on DNStap identity, peer-name or query-ip

### DIFF
--- a/docs/examples/config-dnstap-to-syslog.yml
+++ b/docs/examples/config-dnstap-to-syslog.yml
@@ -21,3 +21,4 @@ pipelines:
       tls-insecure: true
       formatter: "rfc5424"
       framer: "rfc5425"
+      hostname: "identity" # use dynamic DNStap resolver identity in syslog header (e.g. for Splunk/SIEM indexing)

--- a/docs/loggers/logger_syslog.md
+++ b/docs/loggers/logger_syslog.md
@@ -50,7 +50,11 @@ Options:
   > Set syslog framer: `none` or `rfc5425`
 
 * `hostname` (string)
-  > Set syslog hostname
+  > Set the syslog hostname in RFC3164/RFC5424 headers. Can be a static string (e.g. `my-collector`) or a dynamic field from the incoming DNS message:
+  >   * `identity` : use the DNStap server identity (e.g., DNS resolver name)
+  >   * `peer-name` : use the client/collector peer name
+  >   * `query-ip` : use the requester client IP address
+  > If empty (default), the local system hostname is used.
 
 * `app-name` (string)
   > Set syslog program name

--- a/workers/syslog.go
+++ b/workers/syslog.go
@@ -25,6 +25,9 @@ type Syslog struct {
 	transportReady, transportReconnect chan bool
 	textFormat                         []string
 	textFormatter                      *dnsutils.TextFormatter
+	dynamicHostname                    bool
+	hostnameField                      string
+	defaultHostname                    string
 }
 
 func NewSyslog(config *pkgconfig.Config, console *logger.Logger, name string) *Syslog {
@@ -66,6 +69,18 @@ func (w *Syslog) ReadConfig() {
 	w.textFormatter, errFormatter = dnsutils.NewTextFormatter(w.textFormat, w.GetConfig().Global.TextFormatDelimiter, w.GetConfig().Global.TextFormatBoundary)
 	if errFormatter != nil {
 		w.LogFatal(pkgconfig.PrefixLogWorker + "invalid text format: " + errFormatter.Error())
+	}
+
+	hostnameCfg := strings.TrimSpace(w.GetConfig().Loggers.Syslog.Hostname)
+	normalized := strings.ToLower(strings.Trim(hostnameCfg, "%{} "))
+	switch normalized {
+	case "identity", "peer-name", "peer_name", "query-ip", "query_ip":
+		w.dynamicHostname = true
+		w.hostnameField = normalized
+		w.defaultHostname = ""
+	default:
+		w.dynamicHostname = false
+		w.defaultHostname = hostnameCfg
 	}
 }
 
@@ -151,8 +166,8 @@ func (w *Syslog) ConnectToRemote() {
 		}
 
 		// custom hostname
-		if len(w.GetConfig().Loggers.Syslog.Hostname) > 0 {
-			w.syslogWriter.SetHostname(w.GetConfig().Loggers.Syslog.Hostname)
+		if !w.dynamicHostname && len(w.defaultHostname) > 0 {
+			w.syslogWriter.SetHostname(w.defaultHostname)
 		}
 		// custom program name
 		if len(w.GetConfig().Loggers.Syslog.AppName) > 0 {
@@ -163,6 +178,26 @@ func (w *Syslog) ConnectToRemote() {
 		// block the loop until a reconnect is needed
 		w.transportReady <- true
 		w.transportReconnect <- true
+	}
+}
+
+func (w *Syslog) updateHostname(dm *dnsutils.DNSMessage) {
+	if !w.dynamicHostname || w.syslogWriter == nil {
+		return
+	}
+	var h string
+	switch w.hostnameField {
+	case "identity":
+		h = dm.DNSTap.Identity
+	case "peer-name", "peer_name":
+		h = dm.DNSTap.PeerName
+	case "query-ip", "query_ip":
+		h = dm.NetworkInfo.GetQueryIP()
+	}
+	if len(h) > 0 && h != "-" {
+		w.syslogWriter.SetHostname(h)
+	} else if len(w.defaultHostname) > 0 {
+		w.syslogWriter.SetHostname(w.defaultHostname)
 	}
 }
 
@@ -238,6 +273,7 @@ func (w *Syslog) FlushBuffer(buf *[]*dnsutils.DNSMessage) {
 	var err error
 
 	for _, dm := range *buf {
+		w.updateHostname(dm)
 		switch w.GetConfig().Loggers.Syslog.Mode {
 		case pkgconfig.ModeText:
 			buf := w.GetTextBuffer()

--- a/workers/syslog_test.go
+++ b/workers/syslog_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"net"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -261,5 +262,93 @@ func Test_SyslogRun_RemoveNullCharacter(t *testing.T) {
 	re := regexp.MustCompile(pattern)
 	if !re.MatchString(string(buf[:n])) {
 		t.Errorf("syslog error want %s, got: %s", pattern, string(buf[:n]))
+	}
+}
+
+func Test_SyslogRun_DynamicHostname(t *testing.T) {
+	testcases := []struct {
+		name          string
+		hostnameField string
+		setupDM       func(dm *dnsutils.DNSMessage)
+		expectedHost  string
+		listenAddr    string
+	}{
+		{
+			name:          "dynamic_identity",
+			hostnameField: "identity",
+			setupDM: func(dm *dnsutils.DNSMessage) {
+				dm.DNSTap.Identity = "dns-resolver-01"
+			},
+			expectedHost: "dns-resolver-01",
+			listenAddr:   ":4010",
+		},
+		{
+			name:          "dynamic_peer_name",
+			hostnameField: "peer-name",
+			setupDM: func(dm *dnsutils.DNSMessage) {
+				dm.DNSTap.PeerName = "ns1.internal.lan"
+			},
+			expectedHost: "ns1.internal.lan",
+			listenAddr:   ":4011",
+		},
+		{
+			name:          "dynamic_query_ip",
+			hostnameField: "query-ip",
+			setupDM: func(dm *dnsutils.DNSMessage) {
+				dm.NetworkInfo.QueryIP = "192.168.1.100"
+			},
+			expectedHost: "192.168.1.100",
+			listenAddr:   ":4012",
+		},
+		{
+			name:          "static_hostname",
+			hostnameField: "custom-static-hostname",
+			setupDM: func(dm *dnsutils.DNSMessage) {
+				dm.DNSTap.Identity = "should-be-ignored"
+			},
+			expectedHost: "custom-static-hostname",
+			listenAddr:   ":4013",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := pkgconfig.GetDefaultConfig()
+			config.Loggers.Syslog.Transport = netutils.SocketUDP
+			config.Loggers.Syslog.RemoteAddress = tc.listenAddr
+			config.Loggers.Syslog.Mode = pkgconfig.ModeText
+			config.Loggers.Syslog.Formatter = "rfc5424"
+			config.Loggers.Syslog.Framer = ""
+			config.Loggers.Syslog.FlushInterval = 1
+			config.Loggers.Syslog.BufferSize = 0
+			config.Loggers.Syslog.Hostname = tc.hostnameField
+
+			g := NewSyslog(config, logger.New(false), "test_dynamic_host")
+
+			fakeRcvr, err := net.ListenPacket(config.Loggers.Syslog.Transport, tc.listenAddr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer fakeRcvr.Close()
+
+			go g.StartCollect()
+
+			time.Sleep(500 * time.Millisecond)
+			dm := dnsutils.GetFakeDNSMessage()
+			tc.setupDM(&dm)
+			g.GetInputChannel() <- dnsutils.NewDNSMessageBatch(&dm)
+
+			buf := make([]byte, 1024)
+			_ = fakeRcvr.SetReadDeadline(time.Now().Add(3 * time.Second))
+			n, _, err := fakeRcvr.ReadFrom(buf)
+			if err != nil {
+				t.Fatalf("error reading syslog data: %s", err)
+			}
+
+			received := string(buf[:n])
+			if !strings.Contains(received, tc.expectedHost) {
+				t.Errorf("syslog header expected host '%s', got: %s", tc.expectedHost, received)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description

Closes #588

This PR adds support for dynamic syslog header `HOSTNAME` resolution based on incoming DNS/DNStap message fields. This allows centralized syslog receivers (such as Splunk, SIEMs, rsyslog, or syslog-ng) to properly index and attribute logs by DNS server origin instead of attributing all logs to the single DNS-collector relay.

### Supported `hostname` options:
- `identity` : use the DNStap server identity (e.g. `dns-resolver-01`)
- `peer-name` : use the DNStap peer name
- `query-ip` : use the requester client IP
- Static string (e.g. `my-custom-host`) or empty string `""` (uses local system hostname, default behavior).

### Changes:
- Updated `workers/syslog.go` to support dynamic hostnames in RFC3164/RFC5424 framing.
- Added unit tests in `workers/syslog_test.go`.
- Updated documentation in `docs/loggers/logger_syslog.md` and examples.
