### PR TITLE
feat(transformers): add Unique Response Tracking (UDR) support

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -54,6 +54,7 @@ global:
     - "latency"
     - "rewrite"
     - "new-domain-tracker"
+    - "unique-response-tracker"
     - "reducer"
     - "reordering"
 

--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -47,8 +47,9 @@ The default logical processing order is:
 12. **latency** - [Latency Computing](transformers/transform_latency.md): Measure DNS resolution speed.
 13. **rewrite** - [DNS Message Rewrite](transformers/transform_rewrite.md): Change DNS record data.
 14. **new-domain-tracker** - [Newly Observed Domains](transformers/transform_newdomaintracker.md): Track first-time domain appearances.
-15. **reducer** - [Traffic Reducer](transformers/transform_trafficreducer.md): Deduplicates repetitive queries.
-16. **reordering** - [Reordering](transformers/transform_reordering.md): Sorts DNS messages by timestamp.
+15. **unique-response-tracker** - [Unique Domain Responses](transformers/transform_uniqueresponsetracker.md): Track newly observed response associations (QNAME, RRType, RDATA).
+16. **reducer** - [Traffic Reducer](transformers/transform_trafficreducer.md): Deduplicates repetitive queries.
+17. **reordering** - [Reordering](transformers/transform_reordering.md): Sorts DNS messages by timestamp.
 
 
 
@@ -74,6 +75,7 @@ The default logical processing order is:
 |-------------|----------------------|-------------------|
 | [Suspicious Traffic Detector](transformers/transform_suspiciousdetector.md) | • **Malformed Packets**: Invalid DNS structure<br/>• **Oversized Queries**: Potential DDoS indicators<br/>• **Uncommon Query Types**: Rare or suspicious Qtypes<br/>• **Invalid Characters**: Malicious domain encoding<br/>• **Excessive Labels**: DNS tunneling attempts<br/>• **Long Domain Names**: Covert channel detection | • Early threat detection<br/>• DNS tunneling prevention<br/>• Malware C&C identification<br/>• DDoS attack mitigation |
 | [Newly Observed Domains](transformers/transform_newdomaintracker.md) | • Track first-time domain appearances<br/>• Identify domain generation algorithms (DGA)<br/>• Monitor new subdomain creation<br/>• Alert on suspicious registration patterns | • Zero-day domain detection<br/>• Brand protection monitoring<br/>• Typosquatting identification<br/>• Advanced persistent threat tracking |
+| [Unique Domain Responses](transformers/transform_uniqueresponsetracker.md) | • Track newly observed (QNAME, RRType, RDATA) tuples<br/>• Detect unprecedented DNS answer associations<br/>• LRU-bounded memory with disk persistence | • DNS hijacking & cache poisoning detection<br/>• Fast-Flux C2 tracking<br/>• Unauthorized zone record changes |
 
 ### Privacy & Compliance
 

--- a/docs/transformers/transform_uniqueresponsetracker.md
+++ b/docs/transformers/transform_uniqueresponsetracker.md
@@ -1,0 +1,50 @@
+# Transformer: Unique Response Tracker (UDR)
+
+The **Unique Response Tracker** (Unique Domain Responses / UDR) transformer identifies DNS responses that contain new resource record associations `(QNAME, RRType, RDATA)` never seen before within a configurable time window.
+
+While Newly Observed Domains (NOD) tracks newly seen domain queries on the request side, Unique Response Tracking (UDR) tracks changes on the **response side**. It is especially effective for detecting:
+- **DNS Hijacking & Cache Poisoning** (a trusted domain suddenly resolving to an unexpected IP or rogue CNAME).
+- **Fast-Flux DNS networks** and dynamic C2 infrastructure.
+- **Unauthorized record changes** in authoritative zones.
+
+## Features
+
+- **Tuple-based Tracking**: Tracks the `(QNAME, RRType, RDATA)` triplet in the `Answer` section of DNS replies.
+- **Configurable Time Window (TTL)**: Defines how long an answer tuple is remembered.
+- **LRU-based Memory Management**: Ensures fixed bounded memory with zero memory leaks.
+- **Disk Persistence**: Optionally persist the observed answer cache to disk across restarts.
+- **Whitelist Support**: Exclude specific domains or regex patterns from detection.
+
+## Configuration
+
+* `enable` (bool)
+  > Enable the unique response tracker (default: `false`)
+
+* `ttl` (integer)
+  > Time window in seconds (default: `86400` / 24h)
+
+* `cache-size` (integer)
+  > Maximum number of unique response tuples to track in memory (default: `100000`)
+
+* `white-domains-file` (string)
+  > Path to domain whitelist file with regex expressions
+
+* `persistence-file` (string)
+  > Path to a JSON persistence file to save and restore cache across restarts
+
+```yaml
+transforms:
+  unique-response-tracker:
+    enable: true
+    ttl: 86400 
+    cache-size: 100000
+    white-domains-file: ""
+    persistence-file: "/var/lib/dnscollector/udr_cache.json"
+```
+
+## Behavior
+
+1. When a DNS reply with answers is received, the transformer checks each `(QNAME, RRType, RDATA)` tuple against the cache.
+2. If any answer record is observed for the first time (or expired from cache), the message is kept (`ReturnKeep`).
+3. If all answer records in the reply have already been observed within the TTL, the message is dropped (`ReturnDrop`).
+4. Whitelisted domains are ignored and never flagged as unique.

--- a/pkgconfig/transformers.go
+++ b/pkgconfig/transformers.go
@@ -22,6 +22,7 @@ var (
 		"latency",
 		"rewrite",
 		"new-domain-tracker",
+		"unique-response-tracker",
 		"reducer",
 		"reordering",
 	}
@@ -145,6 +146,13 @@ type ConfigTransformers struct {
 		WhiteDomainsFile string `yaml:"white-domains-file" default:""`
 		PersistenceFile  string `yaml:"persistence-file" default:""`
 	} `yaml:"new-domain-tracker"`
+	UniqueResponseTracker struct {
+		Enable           bool   `yaml:"enable" default:"false"`
+		TTL              int    `yaml:"ttl" default:"86400"`
+		CacheSize        int    `yaml:"cache-size" default:"100000"`
+		WhiteDomainsFile string `yaml:"white-domains-file" default:""`
+		PersistenceFile  string `yaml:"persistence-file" default:""`
+	} `yaml:"unique-response-tracker"`
 	Reordering struct {
 		Enable        bool `yaml:"enable" default:"false"`
 		FlushInterval int  `yaml:"flush-interval" default:"30"`

--- a/transformers/transformers.go
+++ b/transformers/transformers.go
@@ -109,6 +109,8 @@ func NewTransforms(config *pkgconfig.ConfigTransformers, logger *logger.Logger, 
 			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewRewriteTransform(config, logger, name, instance, nextWorkers)})
 		case "new-domain-tracker":
 			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewNewDomainTrackerTransform(config, logger, name, instance, nextWorkers)})
+		case "unique-response-tracker":
+			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewUniqueResponseTrackerTransform(config, logger, name, instance, nextWorkers)})
 		case "reducer":
 			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewReducerTransform(config, logger, name, instance, nextWorkers)})
 		case "reordering":

--- a/transformers/uniqueresponsetracker.go
+++ b/transformers/uniqueresponsetracker.go
@@ -1,0 +1,206 @@
+package transformers
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/dmachard/go-dnscollector/v2/dnsutils"
+	"github.com/dmachard/go-dnscollector/v2/pkgconfig"
+	"github.com/dmachard/go-logger"
+	"github.com/hashicorp/golang-lru/v2/expirable"
+)
+
+type UniqueResponseTracker struct {
+	ttl             time.Duration
+	cache           *expirable.LRU[string, struct{}]
+	whitelist       map[string]*regexp.Regexp
+	persistencePath string
+	logInfo         func(msg string, v ...interface{})
+	logError        func(msg string, v ...interface{})
+}
+
+func NewUniqueResponseTracker(ttl time.Duration, maxSize int, whitelist map[string]*regexp.Regexp, persistencePath string, logInfo, logError func(msg string, v ...interface{})) (*UniqueResponseTracker, error) {
+	if ttl <= 0 {
+		return nil, fmt.Errorf("invalid TTL value: %v", ttl)
+	}
+
+	cache := expirable.NewLRU[string, struct{}](maxSize, nil, ttl)
+
+	tracker := &UniqueResponseTracker{
+		ttl:             ttl,
+		cache:           cache,
+		whitelist:       whitelist,
+		persistencePath: persistencePath,
+		logInfo:         logInfo,
+		logError:        logError,
+	}
+
+	if persistencePath != "" {
+		if err := tracker.loadCacheFromDisk(); err != nil {
+			return nil, fmt.Errorf("failed to load cache state: %w", err)
+		}
+	}
+
+	return tracker, nil
+}
+
+func (urt *UniqueResponseTracker) isWhitelisted(domain string) bool {
+	for _, d := range urt.whitelist {
+		if d.MatchString(domain) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsNewResponse checks if the tuple (Qname, Rtype, Rdata) is observed for the first time.
+func (urt *UniqueResponseTracker) IsNewResponse(qname string, rtype string, rdata string) bool {
+	lowerDomain := strings.ToLower(qname)
+	if urt.isWhitelisted(lowerDomain) {
+		return false
+	}
+
+	key := lowerDomain + "/" + rtype + "/" + rdata
+
+	if _, exists := urt.cache.Get(key); exists {
+		return false
+	}
+
+	urt.cache.Add(key, struct{}{})
+	return true
+}
+
+func (urt *UniqueResponseTracker) SaveCacheToDisk() error {
+	keys := urt.cache.Keys()
+	data, err := json.Marshal(keys)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(urt.persistencePath, data, 0644)
+}
+
+func (urt *UniqueResponseTracker) loadCacheFromDisk() error {
+	if urt.persistencePath == "" {
+		return errors.New("persistence filepath not set")
+	}
+
+	data, err := os.ReadFile(urt.persistencePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	var keys []string
+	if err := json.Unmarshal(data, &keys); err != nil {
+		return err
+	}
+
+	for _, key := range keys {
+		urt.cache.Add(key, struct{}{})
+	}
+
+	return nil
+}
+
+type UniqueResponseTrackerTransform struct {
+	GenericTransformer
+	responseTracker  *UniqueResponseTracker
+	listDomainsRegex map[string]*regexp.Regexp
+}
+
+func NewUniqueResponseTrackerTransform(config *pkgconfig.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *UniqueResponseTrackerTransform {
+	t := &UniqueResponseTrackerTransform{GenericTransformer: NewTransformer(config, logger, "unique-response-tracker", name, instance, nextWorkers)}
+	t.listDomainsRegex = make(map[string]*regexp.Regexp)
+	return t
+}
+
+func (t *UniqueResponseTrackerTransform) ReloadConfig(config *pkgconfig.ConfigTransformers) {
+	t.GenericTransformer.ReloadConfig(config)
+	ttl := time.Duration(config.UniqueResponseTracker.TTL) * time.Second
+	t.responseTracker.ttl = ttl
+	t.LogInfo("unique-response-tracker configuration reloaded")
+}
+
+func (t *UniqueResponseTrackerTransform) GetTransforms() ([]Subtransform, error) {
+	subtransforms := []Subtransform{}
+	if t.config.UniqueResponseTracker.Enable {
+		if err := t.LoadWhiteDomainsList(); err != nil {
+			return nil, err
+		}
+
+		ttl := time.Duration(t.config.UniqueResponseTracker.TTL) * time.Second
+		maxSize := t.config.UniqueResponseTracker.CacheSize
+		tracker, err := NewUniqueResponseTracker(ttl, maxSize, t.listDomainsRegex, t.config.UniqueResponseTracker.PersistenceFile, t.LogInfo, t.LogError)
+		if err != nil {
+			return nil, err
+		}
+		t.responseTracker = tracker
+
+		subtransforms = append(subtransforms, Subtransform{name: "unique-response-tracker:detect", processFunc: t.trackUniqueResponse})
+	}
+	return subtransforms, nil
+}
+
+func (t *UniqueResponseTrackerTransform) LoadWhiteDomainsList() error {
+	for key := range t.listDomainsRegex {
+		delete(t.listDomainsRegex, key)
+	}
+
+	if len(t.config.UniqueResponseTracker.WhiteDomainsFile) > 0 {
+		file, err := os.Open(t.config.UniqueResponseTracker.WhiteDomainsFile)
+		if err != nil {
+			return fmt.Errorf("unable to open regex list file: %w", err)
+		}
+		defer file.Close()
+
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			domain := strings.ToLower(scanner.Text())
+			if len(domain) > 0 {
+				t.listDomainsRegex[domain] = regexp.MustCompile(domain)
+			}
+		}
+		t.LogInfo("loaded with %d domains in the whitelist", len(t.listDomainsRegex))
+	}
+	return nil
+}
+
+func (t *UniqueResponseTrackerTransform) trackUniqueResponse(dm *dnsutils.DNSMessage) (int, error) {
+	if len(dm.DNS.DNSRRs.Answers) == 0 {
+		return ReturnDrop, nil
+	}
+
+	if t.responseTracker.cache.Len() == t.config.UniqueResponseTracker.CacheSize {
+		return ReturnError, fmt.Errorf("LRU cache is full. Consider increasing cache-size to avoid frequent evictions")
+	}
+
+	hasNewResponse := false
+	for _, ans := range dm.DNS.DNSRRs.Answers {
+		if t.responseTracker.IsNewResponse(dm.DNS.Qname, ans.Rdatatype, ans.Rdata) {
+			hasNewResponse = true
+		}
+	}
+
+	if hasNewResponse {
+		return ReturnKeep, nil
+	}
+	return ReturnDrop, nil
+}
+
+func (t *UniqueResponseTrackerTransform) Reset() {
+	if t.responseTracker != nil && len(t.responseTracker.persistencePath) != 0 {
+		if err := t.responseTracker.SaveCacheToDisk(); err != nil {
+			t.LogError("failed to save cache state: %v", err)
+		}
+		t.LogInfo("cache content saved on disk with success")
+	}
+}

--- a/transformers/uniqueresponsetracker_bench_test.go
+++ b/transformers/uniqueresponsetracker_bench_test.go
@@ -1,0 +1,33 @@
+package transformers
+
+import (
+	"testing"
+
+	"github.com/dmachard/go-dnscollector/v2/dnsutils"
+	"github.com/dmachard/go-dnscollector/v2/pkgconfig"
+	"github.com/dmachard/go-logger"
+)
+
+func Benchmark_UniqueResponseTracker_ProcessMessage(b *testing.B) {
+	config := pkgconfig.GetFakeConfigTransformers()
+	config.UniqueResponseTracker.Enable = true
+	config.UniqueResponseTracker.TTL = 3600
+	config.UniqueResponseTracker.CacheSize = 1000000
+
+	outChans := []chan *dnsutils.DNSMessageBatch{make(chan *dnsutils.DNSMessageBatch, 100)}
+	transforms := NewTransforms(config, logger.New(false), "bench-udr", outChans, 0)
+
+	dm := dnsutils.AcquireDNSMessage()
+	dm.Init()
+	dm.DNS.Qname = "example.com"
+	dm.DNS.DNSRRs.Answers = []dnsutils.DNSAnswer{
+		{Rdatatype: "A", Rdata: "93.184.216.34"},
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = transforms.ProcessMessage(dm)
+	}
+}

--- a/transformers/uniqueresponsetracker_test.go
+++ b/transformers/uniqueresponsetracker_test.go
@@ -1,0 +1,208 @@
+package transformers
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dmachard/go-dnscollector/v2/dnsutils"
+	"github.com/dmachard/go-dnscollector/v2/pkgconfig"
+	"github.com/dmachard/go-logger"
+)
+
+func TestUniqueResponseTracker_IsNewResponse(t *testing.T) {
+	config := pkgconfig.GetFakeConfigTransformers()
+	config.UniqueResponseTracker.Enable = true
+	config.UniqueResponseTracker.TTL = 2
+	config.UniqueResponseTracker.CacheSize = 100
+
+	outChans := []chan *dnsutils.DNSMessageBatch{}
+	tracker := NewUniqueResponseTrackerTransform(config, logger.New(false), "test", 0, outChans)
+
+	_, err := tracker.GetTransforms()
+	if err != nil {
+		t.Fatalf("fail to init transform: %v", err)
+	}
+
+	// 1. First response for example.com -> 1.2.3.4
+	dm := dnsutils.GetFakeDNSMessage()
+	dm.DNS.Qname = "example.com"
+	dm.DNS.DNSRRs.Answers = []dnsutils.DNSAnswer{
+		{Rdatatype: "A", Rdata: "1.2.3.4"},
+	}
+
+	if res, _ := tracker.trackUniqueResponse(&dm); res != ReturnKeep {
+		t.Errorf("1. initial response should be unique!")
+	}
+
+	// 2. Duplicate response -> should be dropped
+	if res, _ := tracker.trackUniqueResponse(&dm); res != ReturnDrop {
+		t.Errorf("2. duplicate response should NOT be unique!")
+	}
+
+	// 3. Same domain, new IP 5.6.7.8 -> should be unique!
+	dmNewIP := dnsutils.GetFakeDNSMessage()
+	dmNewIP.DNS.Qname = "example.com"
+	dmNewIP.DNS.DNSRRs.Answers = []dnsutils.DNSAnswer{
+		{Rdatatype: "A", Rdata: "5.6.7.8"},
+	}
+
+	if res, _ := tracker.trackUniqueResponse(&dmNewIP); res != ReturnKeep {
+		t.Errorf("3. new IP for same domain should be unique!")
+	}
+
+	// 4. Same domain, new CNAME -> should be unique!
+	dmCNAME := dnsutils.GetFakeDNSMessage()
+	dmCNAME.DNS.Qname = "example.com"
+	dmCNAME.DNS.DNSRRs.Answers = []dnsutils.DNSAnswer{
+		{Rdatatype: "CNAME", Rdata: "target.com"},
+	}
+
+	if res, _ := tracker.trackUniqueResponse(&dmCNAME); res != ReturnKeep {
+		t.Errorf("4. new CNAME for same domain should be unique!")
+	}
+
+	// 5. Wait TTL expiration
+	time.Sleep(3 * time.Second)
+
+	// Recheck original response -> should be unique again after TTL
+	if res, _ := tracker.trackUniqueResponse(&dm); res != ReturnKeep {
+		t.Errorf("5. response after TTL expiration should be unique again!")
+	}
+}
+
+func TestUniqueResponseTracker_NoAnswers(t *testing.T) {
+	config := pkgconfig.GetFakeConfigTransformers()
+	config.UniqueResponseTracker.Enable = true
+	config.UniqueResponseTracker.TTL = 2
+	config.UniqueResponseTracker.CacheSize = 100
+
+	outChans := []chan *dnsutils.DNSMessageBatch{}
+	tracker := NewUniqueResponseTrackerTransform(config, logger.New(false), "test", 0, outChans)
+
+	_, err := tracker.GetTransforms()
+	if err != nil {
+		t.Fatalf("fail to init transform: %v", err)
+	}
+
+	dm := dnsutils.GetFakeDNSMessage()
+	dm.DNS.DNSRRs.Answers = []dnsutils.DNSAnswer{} // No answers
+
+	if res, _ := tracker.trackUniqueResponse(&dm); res != ReturnDrop {
+		t.Errorf("DNS message with no answers should be dropped")
+	}
+}
+
+func TestUniqueResponseTracker_Whitelist(t *testing.T) {
+	config := pkgconfig.GetFakeConfigTransformers()
+	config.UniqueResponseTracker.Enable = true
+	config.UniqueResponseTracker.TTL = 2
+	config.UniqueResponseTracker.CacheSize = 100
+	config.UniqueResponseTracker.WhiteDomainsFile = "../tests/testsdata/newdomain_whitelist_regex.txt"
+
+	outChans := []chan *dnsutils.DNSMessageBatch{}
+	tracker := NewUniqueResponseTrackerTransform(config, logger.New(false), "test", 0, outChans)
+
+	_, err := tracker.GetTransforms()
+	if err != nil {
+		t.Fatalf("fail to init transform: %v", err)
+	}
+
+	// Whitelisted domain
+	dm := dnsutils.GetFakeDNSMessage()
+	dm.DNS.Qname = testURL1
+	dm.DNS.DNSRRs.Answers = []dnsutils.DNSAnswer{
+		{Rdatatype: "A", Rdata: "1.2.3.4"},
+	}
+
+	if res, _ := tracker.trackUniqueResponse(&dm); res != ReturnDrop {
+		t.Errorf("whitelisted domain response should NOT be flagged as unique!")
+	}
+
+	// Non-whitelisted domain
+	dmNonWhite := dnsutils.GetFakeDNSMessage()
+	dmNonWhite.DNS.Qname = "not-whitelisted.com"
+	dmNonWhite.DNS.DNSRRs.Answers = []dnsutils.DNSAnswer{
+		{Rdatatype: "A", Rdata: "1.2.3.4"},
+	}
+
+	if res, _ := tracker.trackUniqueResponse(&dmNonWhite); res != ReturnKeep {
+		t.Errorf("non-whitelisted domain response should be unique!")
+	}
+}
+
+func TestUniqueResponseTracker_Persistence(t *testing.T) {
+	tempDir := t.TempDir()
+	persistFile := filepath.Join(tempDir, "udr_cache.json")
+
+	config := pkgconfig.GetFakeConfigTransformers()
+	config.UniqueResponseTracker.Enable = true
+	config.UniqueResponseTracker.TTL = 60
+	config.UniqueResponseTracker.CacheSize = 100
+	config.UniqueResponseTracker.PersistenceFile = persistFile
+
+	outChans := []chan *dnsutils.DNSMessageBatch{}
+	tracker := NewUniqueResponseTrackerTransform(config, logger.New(false), "test", 0, outChans)
+
+	_, err := tracker.GetTransforms()
+	if err != nil {
+		t.Fatalf("fail to init transform: %v", err)
+	}
+
+	dm := dnsutils.GetFakeDNSMessage()
+	dm.DNS.Qname = "persistent.com"
+	dm.DNS.DNSRRs.Answers = []dnsutils.DNSAnswer{
+		{Rdatatype: "A", Rdata: "9.9.9.9"},
+	}
+
+	// First time -> unique
+	if res, _ := tracker.trackUniqueResponse(&dm); res != ReturnKeep {
+		t.Fatalf("expected unique response")
+	}
+
+	// Save cache to disk
+	tracker.Reset()
+
+	// New tracker instance loading state from disk
+	tracker2 := NewUniqueResponseTrackerTransform(config, logger.New(false), "test2", 0, outChans)
+	_, err = tracker2.GetTransforms()
+	if err != nil {
+		t.Fatalf("fail to init second transform: %v", err)
+	}
+
+	// Same query on second instance -> should already be known (ReturnDrop)
+	if res, _ := tracker2.trackUniqueResponse(&dm); res != ReturnDrop {
+		t.Errorf("response should have been restored from persistence file!")
+	}
+}
+
+func TestUniqueResponseTracker_LRUCacheFull(t *testing.T) {
+	config := pkgconfig.GetFakeConfigTransformers()
+	config.UniqueResponseTracker.Enable = true
+	config.UniqueResponseTracker.TTL = 2
+	config.UniqueResponseTracker.CacheSize = 1
+
+	outChans := []chan *dnsutils.DNSMessageBatch{}
+	tracker := NewUniqueResponseTrackerTransform(config, logger.New(false), "test", 0, outChans)
+
+	_, err := tracker.GetTransforms()
+	if err != nil {
+		t.Fatalf("fail to init transform: %v", err)
+	}
+
+	dm := dnsutils.GetFakeDNSMessage()
+	dm.DNS.Qname = "example.com"
+	dm.DNS.DNSRRs.Answers = []dnsutils.DNSAnswer{
+		{Rdatatype: "A", Rdata: "1.2.3.4"},
+	}
+
+	if res, _ := tracker.trackUniqueResponse(&dm); res != ReturnKeep {
+		t.Errorf("initial response should be kept")
+	}
+
+	// Second query fills cache limit and returns error
+	res, _ := tracker.trackUniqueResponse(&dm)
+	if res != ReturnError {
+		t.Errorf("expected ReturnError on full cache, got %d", res)
+	}
+}


### PR DESCRIPTION
## Description

Resolves #629

This PR introduces the **Unique Response Tracker (UDR)** transformer, inspired by PowerDNS's Unique Domain Responses specification.

While Newly Observed Domains (NOD) monitors the query side (`QNAME`), Unique Response Tracking (UDR) monitors the **response side** by tracking `(QNAME, RRType, RDATA)` associations in DNS `Answer` records. This enables real-time detection of:
- **DNS Hijacking & Cache Poisoning** (a legitimate domain suddenly resolving to a new/rogue IP or CNAME).
- **Fast-Flux DNS networks** and dynamic C2 infrastructure.
- **Unauthorized zone changes** in authoritative infrastructures.

---

### Features

- **Tuple-based Tracking**: Tracks the `(QNAME, RRType, RDATA)` triplet in DNS reply answers.
- **Configurable Time Window (TTL)**: Expiration window (default: `86400s` / 24h).
- **LRU Memory Bounded**: Fixed cache capacity (`cache-size`, default `100000`) preventing memory leaks.
- **Disk Persistence**: Saves cache to a JSON file on shutdown and restores on startup (`persistence-file`).
- **Domain Whitelist**: Excludes known patterns (`white-domains-file`).

---

### Configuration Example

```yaml
transforms:
  unique-response-tracker:
    enable: true
    ttl: 86400
    cache-size: 100000
    white-domains-file: ""
    persistence-file: "/var/lib/dnscollector/udr_cache.json"
```