### PR TITLE
fix(filtering): prevent nil IPSet panic when both drop-queryip and keep-queryip files are configured

### DIFF
--- a/transformers/filtering.go
+++ b/transformers/filtering.go
@@ -104,6 +104,9 @@ func (t *FilteringTransform) LoadRcodes() error {
 }
 
 func (t *FilteringTransform) LoadQueryIPList() error {
+	t.ipsetDrop = nil
+	t.ipsetKeep = nil
+
 	if len(t.config.Filtering.DropQueryIPFile) > 0 {
 		read, err := t.loadQueryIPList(t.config.Filtering.DropQueryIPFile, true)
 		if err != nil {
@@ -123,6 +126,8 @@ func (t *FilteringTransform) LoadQueryIPList() error {
 }
 
 func (t *FilteringTransform) LoadrDataIPList() error {
+	t.rDataIpsetKeep = nil
+
 	if len(t.config.Filtering.KeepRdataFile) > 0 {
 		read, err := t.loadKeepRdataIPList(t.config.Filtering.KeepRdataFile)
 		if err != nil {
@@ -237,10 +242,6 @@ func (t *FilteringTransform) LoadDomainsList() error {
 }
 
 func (t *FilteringTransform) loadQueryIPList(fname string, drop bool) (uint64, error) {
-	var emptyIPSet *netaddr.IPSet
-	t.ipsetDrop = emptyIPSet
-	t.ipsetKeep = emptyIPSet
-
 	file, err := os.Open(fname)
 	if err != nil {
 		return 0, err
@@ -277,9 +278,6 @@ func (t *FilteringTransform) loadQueryIPList(fname string, drop bool) (uint64, e
 }
 
 func (t *FilteringTransform) loadKeepRdataIPList(fname string) (uint64, error) {
-	var emptyIPSet *netaddr.IPSet
-	t.rDataIpsetKeep = emptyIPSet
-
 	file, err := os.Open(fname)
 	if err != nil {
 		return 0, err
@@ -334,6 +332,9 @@ func (t *FilteringTransform) dropRCodeFilter(dm *dnsutils.DNSMessage) (int, erro
 }
 
 func (t *FilteringTransform) keepQueryIPFilter(dm *dnsutils.DNSMessage) (int, error) {
+	if t.ipsetKeep == nil {
+		return ReturnDrop, nil
+	}
 	ip, _ := netaddr.ParseIP(dm.NetworkInfo.GetQueryIP())
 	if t.ipsetKeep.Contains(ip) {
 		return ReturnKeep, nil
@@ -342,6 +343,9 @@ func (t *FilteringTransform) keepQueryIPFilter(dm *dnsutils.DNSMessage) (int, er
 }
 
 func (t *FilteringTransform) dropQueryIPFilter(dm *dnsutils.DNSMessage) (int, error) {
+	if t.ipsetDrop == nil {
+		return ReturnKeep, nil
+	}
 	ip, _ := netaddr.ParseIP(dm.NetworkInfo.GetQueryIP())
 	if t.ipsetDrop.Contains(ip) {
 		return ReturnDrop, nil
@@ -350,6 +354,9 @@ func (t *FilteringTransform) dropQueryIPFilter(dm *dnsutils.DNSMessage) (int, er
 }
 
 func (t *FilteringTransform) keepRdataFilter(dm *dnsutils.DNSMessage) (int, error) {
+	if t.rDataIpsetKeep == nil {
+		return ReturnDrop, nil
+	}
 	if len(dm.DNS.DNSRRs.Answers) > 0 {
 		// If even one exists in filter list then pass through filter
 		for _, answer := range dm.DNS.DNSRRs.Answers {

--- a/transformers/filtering_test.go
+++ b/transformers/filtering_test.go
@@ -129,6 +129,49 @@ func TestFilteringByKeepQueryIp(t *testing.T) {
 	}
 }
 
+func TestFilteringByBothDropAndKeepQueryIp(t *testing.T) {
+	// config
+	config := pkgconfig.GetFakeConfigTransformers()
+	config.Filtering.Enable = true
+	config.Filtering.DropQueryIPFile = "../tests/testsdata/filtering_queryip.txt"
+	config.Filtering.KeepQueryIPFile = "../tests/testsdata/filtering_queryip_keep.txt"
+
+	outChans := []chan *dnsutils.DNSMessageBatch{}
+
+	// init subprocessor
+	filtering := NewFilteringTransform(config, logger.New(false), "test", 0, outChans)
+
+	// get transforms
+	subtransforms, err := filtering.GetTransforms()
+	if err != nil {
+		t.Fatalf("failed to get transforms: %v", err)
+	}
+	if len(subtransforms) != 2 {
+		t.Fatalf("expected 2 subtransforms, got %d", len(subtransforms))
+	}
+
+	// 1. IP in drop list -> dropQueryIPFilter must drop
+	dmDrop := dnsutils.GetFakeDNSMessage()
+	dmDrop.NetworkInfo.QueryIP = "192.168.1.15"
+	if result, _ := filtering.dropQueryIPFilter(&dmDrop); result != ReturnDrop {
+		t.Errorf("expected dropQueryIPFilter to drop 192.168.1.15, got %d", result)
+	}
+
+	// 2. IP in keep list -> keepQueryIPFilter must keep
+	dmKeep := dnsutils.GetFakeDNSMessage()
+	dmKeep.NetworkInfo.QueryIP = "192.0.2.1"
+	if result, _ := filtering.keepQueryIPFilter(&dmKeep); result != ReturnKeep {
+		t.Errorf("expected keepQueryIPFilter to keep 192.0.2.1, got %d", result)
+	}
+
+	// 3. IP not in keep list -> keepQueryIPFilter must drop
+	dmNotKeep := dnsutils.GetFakeDNSMessage()
+	dmNotKeep.NetworkInfo.QueryIP = "10.0.0.1"
+	if result, _ := filtering.keepQueryIPFilter(&dmNotKeep); result != ReturnDrop {
+		t.Errorf("expected keepQueryIPFilter to drop 10.0.0.1, got %d", result)
+	}
+}
+
 func TestFilteringByDropQueryIp(t *testing.T) {
 	// config
 	config := pkgconfig.GetFakeConfigTransformers()


### PR DESCRIPTION
## Description

Fixes #1324

### Root Cause
`loadQueryIPList()` unconditionally reset both `ipsetDrop` and `ipsetKeep` to `nil` upon entry. When both `drop-queryip-file` and `keep-queryip-file` were configured, the second sequential call to load the keep list wiped the newly populated `ipsetDrop` back to `nil`. At runtime, `dropQueryIPFilter` invoked `.Contains()` on a nil receiver, causing a panic with nil pointer dereference.

### Fix
- Moved `ipsetDrop = nil` and `ipsetKeep = nil` initialization to `LoadQueryIPList()` prior to reading the files (same for `LoadrDataIPList()`).
- Removed the unconditional dual reset from `loadQueryIPList()`.
- Added defensive nil checks in `dropQueryIPFilter`, `keepQueryIPFilter`, and `keepRdataFilter`.
- Added regression test `TestFilteringByBothDropAndKeepQueryIp` verifying simultaneous drop + keep query IP filtering.

---

### Verification

```bash
$ go test -v -race ./transformers/ -run "TestFilteringByBothDropAndKeepQueryIp"
=== RUN   TestFilteringByBothDropAndKeepQueryIp
--- PASS: TestFilteringByBothDropAndKeepQueryIp (0.00s)
PASS
```