### PR TITLE
refactor(core): eliminate panic calls and introduce structured error handling

### DIFF
--- a/docs/transformers/transform_uniqueresponsetracker.md
+++ b/docs/transformers/transform_uniqueresponsetracker.md
@@ -79,6 +79,7 @@ transforms:
 The default storage engine uses an **LRU (Least Recently Used) Cache** optimized for throughput and minimal latency.
 
 **Performance Characteristics:**
+
 - **Lookup Speed**: ~192 ns/op (measured with realistic mixed DNS workload: 80% lookups, 20% inserts)
 - **Memory Footprint**: ~30.84 MB for 100,000 tuples
 - **Allocations**: 1 per operation (minimal garbage collection pressure)
@@ -109,6 +110,7 @@ The **Cuckoo Filter** is a probabilistic data structure optimized for extreme me
 | **`32 bits`** | **~11.6 MB** | **$< 10^{-7}\%$** | Ultra-high fidelity (near-zero collision tolerance). |
 
 **Trade-offs & Anti-Saturation Mechanism:**
+
 - **Generational Anti-Churning**: Unlike single-table filters that suffer from high eviction churn when nearly full, the UDR sliding window maintains `active` and `previous` generation tables. New entries are always inserted into a fresh `active` table ($O(1)$ with no kicks), while hot entries are seamlessly promoted from `previous` upon hit.
 - **Zero Eviction Scan Cost**: Stale/cold entries naturally expire when the `previous` table is rotated at $TTL/2$, requiring zero background deletion loops or CPU sweeps.
 
@@ -130,6 +132,7 @@ du -h /var/lib/dnscollector/udr_cache.json
 ### Cuckoo Engine Cache
 
 The Cuckoo Filter operates entirely in-memory with a dual sliding window (`active` and `previous` generation tables rotated every `TTL / 2`):
+
 - **Hot Item Residency (LRU Promotion)**: Continuously queried domains ("hot items") observed in the previous generation are automatically promoted to the active window, ensuring active traffic never prematurely expires.
 - **Automatic Stale Eviction**: Inactive tuples that receive no traffic across two rotation cycles are automatically forgotten.
 - **Bounded Memory**: Memory footprint remains fixed and bounded by `cache-size` (~5.8 MB for 100k items).

--- a/pkginit/errors.go
+++ b/pkginit/errors.go
@@ -1,0 +1,113 @@
+package pkginit
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors for pkginit
+var (
+	ErrNoRoutesDefined = errors.New("no routes are defined")
+	ErrDuplicateStanza = errors.New("duplicate stanza name")
+	ErrRouteNotFound   = errors.New("route not found")
+	ErrRoutingLoop     = errors.New("routing loop detected")
+	ErrStanzaNotFound  = errors.New("stanza not found")
+	ErrStanzaConfig    = errors.New("stanza config error")
+	ErrYAMLConfig      = errors.New("yaml config error")
+)
+
+// StanzaConfigError represents an error during stanza configuration retrieval
+type StanzaConfigError struct {
+	Message string
+	Err     error
+}
+
+func (e *StanzaConfigError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("stanza config error: %s - %v", e.Message, e.Err)
+	}
+	return fmt.Sprintf("stanza config error: %s", e.Message)
+}
+
+func (e *StanzaConfigError) Unwrap() error {
+	return e.Err
+}
+
+func (e *StanzaConfigError) Is(target error) bool {
+	return target == ErrStanzaConfig
+}
+
+// YAMLConfigError represents an error during YAML unmarshaling for pipeline config
+type YAMLConfigError struct {
+	Section string
+	Err     error
+}
+
+func (e *YAMLConfigError) Error() string {
+	return fmt.Sprintf("yaml %s config error: %v", e.Section, e.Err)
+}
+
+func (e *YAMLConfigError) Unwrap() error {
+	return e.Err
+}
+
+func (e *YAMLConfigError) Is(target error) bool {
+	return target == ErrYAMLConfig
+}
+
+// StanzaNotFoundError represents a pipeline stanza that was not found
+type StanzaNotFoundError struct {
+	Name string
+}
+
+func (e *StanzaNotFoundError) Error() string {
+	return fmt.Sprintf("stanza not found: %s", e.Name)
+}
+
+func (e *StanzaNotFoundError) Is(target error) bool {
+	return target == ErrStanzaNotFound
+}
+
+// DuplicateStanzaError represents an error when a stanza name is duplicated
+type DuplicateStanzaError struct {
+	Name string
+}
+
+func (e *DuplicateStanzaError) Error() string {
+	return fmt.Sprintf("stanza with name=[%s] is duplicated", e.Name)
+}
+
+func (e *DuplicateStanzaError) Is(target error) bool {
+	return target == ErrDuplicateStanza
+}
+
+// RouteNotFoundError represents an error when a configured route target does not exist
+type RouteNotFoundError struct {
+	Name string
+	From string
+}
+
+func (e *RouteNotFoundError) Error() string {
+	if e.From != "" {
+		return fmt.Sprintf("stanza=[%s] route=[%s] does not exist", e.From, e.Name)
+	}
+	return fmt.Sprintf("route=[%s] does not exist", e.Name)
+}
+
+func (e *RouteNotFoundError) Is(target error) bool {
+	return target == ErrRouteNotFound
+}
+
+// RoutingLoopError represents an error when a stanza routes to itself
+type RoutingLoopError struct {
+	From string
+	To   string
+}
+
+func (e *RoutingLoopError) Error() string {
+	return fmt.Sprintf("routing error loop with stanza=%s to stanza=%s", e.From, e.To)
+}
+
+func (e *RoutingLoopError) Is(target error) bool {
+	return target == ErrRoutingLoop
+}

--- a/pkginit/pipelines.go
+++ b/pkginit/pipelines.go
@@ -7,7 +7,6 @@ import (
 	"github.com/dmachard/go-dnscollector/v2/telemetry"
 	"github.com/dmachard/go-dnscollector/v2/workers"
 	"github.com/dmachard/go-logger"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
 
@@ -24,8 +23,7 @@ func IsPipelinesEnabled(config *pkgconfig.Config) bool {
 	return len(config.Pipelines) > 0
 }
 
-func GetStanzaConfig(config *pkgconfig.Config, item pkgconfig.ConfigPipelines) *pkgconfig.Config {
-
+func GetStanzaConfig(config *pkgconfig.Config, item pkgconfig.ConfigPipelines) (*pkgconfig.Config, error) {
 	cfg := make(map[string]interface{})
 	section := "collectors"
 
@@ -33,7 +31,9 @@ func GetStanzaConfig(config *pkgconfig.Config, item pkgconfig.ConfigPipelines) *
 	for k, p := range item.Params {
 		// is a logger or collector ?
 		if !config.Loggers.IsExists(k) && !config.Collectors.IsExists(k) {
-			panic(fmt.Sprintln("main - get stanza config error"))
+			return nil, &StanzaConfigError{
+				Message: fmt.Sprintf("stanza '%s' references unknown collector or logger '%s'", item.Name, k),
+			}
 		}
 		if config.Loggers.IsExists(k) {
 			section = "loggers"
@@ -69,13 +69,16 @@ func GetStanzaConfig(config *pkgconfig.Config, item pkgconfig.ConfigPipelines) *
 
 	yamlcfg, _ := yaml.Marshal(cfg)
 	if err := yaml.Unmarshal(yamlcfg, subcfg); err != nil {
-		panic(fmt.Sprintf("main - yaml logger config error: %v", err))
+		return nil, &YAMLConfigError{
+			Section: section,
+			Err:     err,
+		}
 	}
 
-	return subcfg
+	return subcfg, nil
 }
 
-func StanzaNameIsUniq(name string, config *pkgconfig.Config) (ret error) {
+func StanzaNameIsUniq(name string, config *pkgconfig.Config) error {
 	stanzaCounter := 0
 	for _, stanza := range config.Pipelines {
 		if name == stanza.Name {
@@ -84,18 +87,18 @@ func StanzaNameIsUniq(name string, config *pkgconfig.Config) (ret error) {
 	}
 
 	if stanzaCounter > 1 {
-		return fmt.Errorf("stanza=%s already exists", name)
+		return &DuplicateStanzaError{Name: name}
 	}
 	return nil
 }
 
-func IsRouteExist(target string, config *pkgconfig.Config) (ret error) {
+func IsRouteExist(target string, config *pkgconfig.Config) error {
 	for _, stanza := range config.Pipelines {
 		if target == stanza.Name {
 			return nil
 		}
 	}
-	return fmt.Errorf("route=%s doest not exist", target)
+	return &RouteNotFoundError{Name: target}
 }
 
 func CreateRouting(stanza pkgconfig.ConfigPipelines, mapCollectors map[string]workers.Worker, mapLoggers map[string]workers.Worker, logger *logger.Logger) error {
@@ -103,36 +106,63 @@ func CreateRouting(stanza pkgconfig.ConfigPipelines, mapCollectors map[string]wo
 	if collector, ok := mapCollectors[stanza.Name]; ok {
 		currentStanza = collector
 	}
-	if logger, ok := mapLoggers[stanza.Name]; ok {
-		currentStanza = logger
+	if logWorker, ok := mapLoggers[stanza.Name]; ok {
+		currentStanza = logWorker
+	}
+	if currentStanza == nil {
+		return &StanzaNotFoundError{Name: stanza.Name}
 	}
 
 	// forward routing
 	for _, route := range stanza.RoutingPolicy.Forward {
 		if route == stanza.Name {
-			return fmt.Errorf("main - routing error loop with stanza=%s to stanza=%s", stanza.Name, route)
+			return &RoutingLoopError{From: stanza.Name, To: route}
 		}
-		if _, ok := mapCollectors[route]; ok {
-			currentStanza.AddDefaultRoute(mapCollectors[route])
+		if collector, ok := mapCollectors[route]; ok {
+			if collector.GetInputChannel() == nil {
+				return &workers.DefaultRoutingError{
+					StanzaName: route,
+					Reason:     "worker does not accept incoming messages",
+				}
+			}
+			currentStanza.AddDefaultRoute(collector)
 			logger.Info("main - routing (policy=forward) stanza=[%s] to stanza=[%s]", stanza.Name, route)
-		} else if _, ok := mapLoggers[route]; ok {
-			currentStanza.AddDefaultRoute(mapLoggers[route])
+		} else if logWorker, ok := mapLoggers[route]; ok {
+			if logWorker.GetInputChannel() == nil {
+				return &workers.DefaultRoutingError{
+					StanzaName: route,
+					Reason:     "worker does not accept incoming messages",
+				}
+			}
+			currentStanza.AddDefaultRoute(logWorker)
 			logger.Info("main - routing (policy=forward) stanza=[%s] to stanza=[%s]", stanza.Name, route)
 		} else {
-			return fmt.Errorf("main - forward routing error from stanza=%s to stanza=%s doest not exist", stanza.Name, route)
+			return &RouteNotFoundError{Name: route, From: stanza.Name}
 		}
 	}
 
 	// dropped routing
 	for _, route := range stanza.RoutingPolicy.Dropped {
-		if _, ok := mapCollectors[route]; ok {
-			currentStanza.AddDroppedRoute(mapCollectors[route])
+		if collector, ok := mapCollectors[route]; ok {
+			if collector.GetInputChannel() == nil {
+				return &workers.DefaultRoutingError{
+					StanzaName: route,
+					Reason:     "worker does not accept incoming messages",
+				}
+			}
+			currentStanza.AddDroppedRoute(collector)
 			logger.Info("main - routing (policy=dropped) stanza=[%s] to stanza=[%s]", stanza.Name, route)
-		} else if _, ok := mapLoggers[route]; ok {
-			currentStanza.AddDroppedRoute(mapLoggers[route])
+		} else if logWorker, ok := mapLoggers[route]; ok {
+			if logWorker.GetInputChannel() == nil {
+				return &workers.DefaultRoutingError{
+					StanzaName: route,
+					Reason:     "worker does not accept incoming messages",
+				}
+			}
+			currentStanza.AddDroppedRoute(logWorker)
 			logger.Info("main - routing (policy=dropped) stanza=[%s] to stanza=[%s]", stanza.Name, route)
 		} else {
-			return fmt.Errorf("main - routing error with dropped messages from stanza=%s to stanza=%s doest not exist", stanza.Name, route)
+			return &RouteNotFoundError{Name: route, From: stanza.Name}
 		}
 	}
 	return nil
@@ -157,7 +187,7 @@ func InitPipelines(mapLoggers map[string]workers.Worker, mapCollectors map[strin
 	routesDefined := false
 	for _, stanza := range config.Pipelines {
 		if err := StanzaNameIsUniq(stanza.Name, config); err != nil {
-			return errors.Errorf("stanza with name=[%s] is duplicated", stanza.Name)
+			return err
 		}
 		if len(stanza.RoutingPolicy.Forward) > 0 || len(stanza.RoutingPolicy.Dropped) > 0 {
 			routesDefined = true
@@ -165,38 +195,40 @@ func InitPipelines(mapLoggers map[string]workers.Worker, mapCollectors map[strin
 	}
 
 	if !routesDefined {
-		return errors.Errorf("no routes are defined")
+		return ErrNoRoutesDefined
 	}
 
 	// check if all routes exists before continue
 	for _, stanza := range config.Pipelines {
 		for _, route := range stanza.RoutingPolicy.Forward {
 			if err := IsRouteExist(route, config); err != nil {
-				return errors.Errorf("stanza=[%s] forward route=[%s] doest not exist", stanza.Name, route)
+				return &RouteNotFoundError{Name: route, From: stanza.Name}
 			}
 		}
 		for _, route := range stanza.RoutingPolicy.Dropped {
 			if err := IsRouteExist(route, config); err != nil {
-				return errors.Errorf("stanza=[%s] dropped route=[%s] doest not exist", stanza.Name, route)
+				return &RouteNotFoundError{Name: route, From: stanza.Name}
 			}
 		}
 	}
 
 	// read each stanza and init
 	for _, stanza := range config.Pipelines {
-		stanzaConfig := GetStanzaConfig(config, stanza)
+		stanzaConfig, err := GetStanzaConfig(config, stanza)
+		if err != nil {
+			return err
+		}
 		CreateStanza(stanza.Name, stanzaConfig, mapCollectors, mapLoggers, logger, telemetry)
-
 	}
 
 	// create routing
 	for _, stanza := range config.Pipelines {
 		if mapCollectors[stanza.Name] != nil || mapLoggers[stanza.Name] != nil {
 			if err := CreateRouting(stanza, mapCollectors, mapLoggers, logger); err != nil {
-				return errors.Wrap(err, "routing")
+				return err
 			}
 		} else {
-			return errors.Errorf("routing - stanza=[%v] doest not exist", stanza.Name)
+			return &StanzaNotFoundError{Name: stanza.Name}
 		}
 	}
 
@@ -205,7 +237,11 @@ func InitPipelines(mapLoggers map[string]workers.Worker, mapCollectors map[strin
 
 func ReloadPipelines(mapLoggers map[string]workers.Worker, mapCollectors map[string]workers.Worker, config *pkgconfig.Config, logger *logger.Logger) {
 	for _, stanza := range config.Pipelines {
-		newCfg := GetStanzaConfig(config, stanza)
+		newCfg, err := GetStanzaConfig(config, stanza)
+		if err != nil {
+			logger.Error("main - reload config error for stanza=%s: %v", stanza.Name, err)
+			continue
+		}
 		if _, ok := mapLoggers[stanza.Name]; ok {
 			mapLoggers[stanza.Name].ReloadConfig(newCfg)
 		} else if _, ok := mapCollectors[stanza.Name]; ok {

--- a/pkginit/pipelines.go
+++ b/pkginit/pipelines.go
@@ -1,6 +1,7 @@
 package pkginit
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/dmachard/go-dnscollector/v2/pkgconfig"
@@ -183,53 +184,77 @@ func CreateStanza(stanzaName string, config *pkgconfig.Config, mapCollectors map
 }
 
 func InitPipelines(mapLoggers map[string]workers.Worker, mapCollectors map[string]workers.Worker, config *pkgconfig.Config, logger *logger.Logger, telemetry *telemetry.PrometheusCollector) error {
-	// check if the name of each stanza is uniq
+	var errs []error
+	seenStanzas := make(map[string]bool)
+	duplicateReported := make(map[string]bool)
 	routesDefined := false
+
+	// 1. Check duplicate stanzas and route definitions
 	for _, stanza := range config.Pipelines {
-		if err := StanzaNameIsUniq(stanza.Name, config); err != nil {
-			return err
+		if seenStanzas[stanza.Name] {
+			if !duplicateReported[stanza.Name] {
+				errs = append(errs, &DuplicateStanzaError{Name: stanza.Name})
+				duplicateReported[stanza.Name] = true
+			}
 		}
+		seenStanzas[stanza.Name] = true
+
 		if len(stanza.RoutingPolicy.Forward) > 0 || len(stanza.RoutingPolicy.Dropped) > 0 {
 			routesDefined = true
 		}
+	}
+
+	// 2. Check if all target routes exist
+	for _, stanza := range config.Pipelines {
+		for _, route := range stanza.RoutingPolicy.Forward {
+			if err := IsRouteExist(route, config); err != nil {
+				errs = append(errs, &RouteNotFoundError{Name: route, From: stanza.Name})
+			}
+		}
+		for _, route := range stanza.RoutingPolicy.Dropped {
+			if err := IsRouteExist(route, config); err != nil {
+				errs = append(errs, &RouteNotFoundError{Name: route, From: stanza.Name})
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
 	}
 
 	if !routesDefined {
 		return ErrNoRoutesDefined
 	}
 
-	// check if all routes exists before continue
-	for _, stanza := range config.Pipelines {
-		for _, route := range stanza.RoutingPolicy.Forward {
-			if err := IsRouteExist(route, config); err != nil {
-				return &RouteNotFoundError{Name: route, From: stanza.Name}
-			}
-		}
-		for _, route := range stanza.RoutingPolicy.Dropped {
-			if err := IsRouteExist(route, config); err != nil {
-				return &RouteNotFoundError{Name: route, From: stanza.Name}
-			}
-		}
-	}
-
-	// read each stanza and init
+	// 3. Read and instantiate each stanza
+	var stanzaErrs []error
 	for _, stanza := range config.Pipelines {
 		stanzaConfig, err := GetStanzaConfig(config, stanza)
 		if err != nil {
-			return err
+			stanzaErrs = append(stanzaErrs, err)
+			continue
 		}
 		CreateStanza(stanza.Name, stanzaConfig, mapCollectors, mapLoggers, logger, telemetry)
 	}
 
-	// create routing
+	if len(stanzaErrs) > 0 {
+		return errors.Join(stanzaErrs...)
+	}
+
+	// 4. Create routing connections between instantiated stanzas
+	var routingErrs []error
 	for _, stanza := range config.Pipelines {
 		if mapCollectors[stanza.Name] != nil || mapLoggers[stanza.Name] != nil {
 			if err := CreateRouting(stanza, mapCollectors, mapLoggers, logger); err != nil {
-				return err
+				routingErrs = append(routingErrs, err)
 			}
 		} else {
-			return &StanzaNotFoundError{Name: stanza.Name}
+			routingErrs = append(routingErrs, &StanzaNotFoundError{Name: stanza.Name})
 		}
+	}
+
+	if len(routingErrs) > 0 {
+		return errors.Join(routingErrs...)
 	}
 
 	return nil

--- a/pkginit/pipelines_test.go
+++ b/pkginit/pipelines_test.go
@@ -203,3 +203,50 @@ func TestPipelines_CreateRouting_UnsupportedDefaultRouting(t *testing.T) {
 		t.Errorf("expected DefaultRoutingError, got: %v", err)
 	}
 }
+
+func TestPipelines_MultipleErrors_Joined(t *testing.T) {
+	config := pkgconfig.GetDefaultConfig()
+	config.Pipelines = []pkgconfig.ConfigPipelines{
+		{
+			Name: "tap",
+			Params: map[string]interface{}{
+				"dnstap": map[string]interface{}{"enable": true},
+			},
+			RoutingPolicy: pkgconfig.PipelinesRouting{
+				Forward: []string{"nonexistent1", "nonexistent2"},
+			},
+		},
+		{
+			Name: "tap", // Duplicate stanza name
+			Params: map[string]interface{}{
+				"dnstap": map[string]interface{}{"enable": true},
+			},
+			RoutingPolicy: pkgconfig.PipelinesRouting{
+				Forward: []string{"nonexistent3"},
+			},
+		},
+	}
+
+	mapLoggers := make(map[string]workers.Worker)
+	mapCollectors := make(map[string]workers.Worker)
+	metrics := telemetry.NewPrometheusCollector(config)
+
+	err := InitPipelines(mapLoggers, mapCollectors, config, logger.New(false), metrics)
+	if err == nil {
+		t.Fatalf("expected multiple errors, got nil")
+	}
+
+	// Verify that errors.Join preserved both error categories
+	if !errors.Is(err, ErrDuplicateStanza) {
+		t.Errorf("expected joined error to contain ErrDuplicateStanza, got: %v", err)
+	}
+	if !errors.Is(err, ErrRouteNotFound) {
+		t.Errorf("expected joined error to contain ErrRouteNotFound, got: %v", err)
+	}
+
+	// Verify that error message contains details from both errors
+	errStr := err.Error()
+	if !strings.Contains(errStr, "duplicated") || !strings.Contains(errStr, "nonexistent") {
+		t.Errorf("expected comprehensive multi-error message, got: %s", errStr)
+	}
+}

--- a/pkginit/pipelines_test.go
+++ b/pkginit/pipelines_test.go
@@ -1,6 +1,7 @@
 package pkginit
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -40,6 +41,13 @@ func TestPipelines_IsRouteExist(t *testing.T) {
 	if err == nil {
 		t.Errorf("For the non-existing route %s, an expected error was not returned. Received error: %v", nonExistingRoute, err)
 	}
+	if !errors.Is(err, ErrRouteNotFound) {
+		t.Errorf("Expected ErrRouteNotFound, got: %v", err)
+	}
+	var routeNotFoundErr *RouteNotFoundError
+	if !errors.As(err, &routeNotFoundErr) {
+		t.Errorf("Expected RouteNotFoundError type assertion, got: %v", err)
+	}
 }
 
 func TestPipelines_StanzaNameIsUniq(t *testing.T) {
@@ -64,6 +72,13 @@ func TestPipelines_StanzaNameIsUniq(t *testing.T) {
 	if err == nil {
 		t.Errorf("For the duplicate stanza name %s, an expected error was not returned. Received error: %v", duplicateStanzaName, err)
 	}
+	if !errors.Is(err, ErrDuplicateStanza) {
+		t.Errorf("Expected ErrDuplicateStanza, got: %v", err)
+	}
+	var dupErr *DuplicateStanzaError
+	if !errors.As(err, &dupErr) {
+		t.Errorf("Expected DuplicateStanzaError, got: %v", err)
+	}
 }
 
 func TestPipelines_NoRoutesDefined(t *testing.T) {
@@ -81,8 +96,9 @@ func TestPipelines_NoRoutesDefined(t *testing.T) {
 	err := InitPipelines(mapLoggers, mapCollectors, config, logger.New(false), metrics)
 	if err == nil {
 		t.Errorf("Want err, got nil")
-	} else if err.Error() != "no routes are defined" {
-		t.Errorf("Unexpected error: %s", err.Error())
+	}
+	if !errors.Is(err, ErrNoRoutesDefined) {
+		t.Errorf("Expected ErrNoRoutesDefined, got: %v", err)
 	}
 }
 
@@ -109,5 +125,81 @@ func TestPipelines_RoutingLoop(t *testing.T) {
 	} else if !strings.Contains(err.Error(), "routing error loop") {
 		t.Errorf("Unexpected error: %s", err.Error())
 	}
+	if !errors.Is(err, ErrRoutingLoop) {
+		t.Errorf("Expected ErrRoutingLoop, got: %v", err)
+	}
+	var loopErr *RoutingLoopError
+	if !errors.As(err, &loopErr) {
+		t.Errorf("Expected RoutingLoopError, got: %v", err)
+	}
+}
 
+func TestPipelines_GetStanzaConfig_UnknownWorker(t *testing.T) {
+	config := pkgconfig.GetDefaultConfig()
+	stanza := pkgconfig.ConfigPipelines{
+		Name: "invalid-stanza",
+		Params: map[string]interface{}{
+			"unknown-worker": map[string]interface{}{"enable": true},
+		},
+	}
+
+	_, err := GetStanzaConfig(config, stanza)
+	if err == nil {
+		t.Fatalf("expected error for unknown worker, got nil")
+	}
+	if !errors.Is(err, ErrStanzaConfig) {
+		t.Errorf("expected ErrStanzaConfig, got: %v", err)
+	}
+	var cfgErr *StanzaConfigError
+	if !errors.As(err, &cfgErr) {
+		t.Errorf("expected StanzaConfigError type, got: %v", err)
+	}
+}
+
+func TestPipelines_CreateRouting_StanzaNotFound(t *testing.T) {
+	stanza := pkgconfig.ConfigPipelines{
+		Name: "nonexistent",
+		RoutingPolicy: pkgconfig.PipelinesRouting{
+			Forward: []string{"target"},
+		},
+	}
+	mapLoggers := make(map[string]workers.Worker)
+	mapCollectors := make(map[string]workers.Worker)
+
+	err := CreateRouting(stanza, mapCollectors, mapLoggers, logger.New(false))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !errors.Is(err, ErrStanzaNotFound) {
+		t.Errorf("expected ErrStanzaNotFound, got: %v", err)
+	}
+}
+
+func TestPipelines_CreateRouting_UnsupportedDefaultRouting(t *testing.T) {
+	stanza := pkgconfig.ConfigPipelines{
+		Name: "stanzaA",
+		RoutingPolicy: pkgconfig.PipelinesRouting{
+			Forward: []string{"stanzaB"},
+		},
+	}
+	wA := workers.GetWorkerForTest(10)
+	wB := &workers.GenericWorker{} // No input channel
+
+	mapCollectors := map[string]workers.Worker{
+		"stanzaA": wA,
+		"stanzaB": wB,
+	}
+	mapLoggers := make(map[string]workers.Worker)
+
+	err := CreateRouting(stanza, mapCollectors, mapLoggers, logger.New(false))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !errors.Is(err, workers.ErrDefaultRoutingNotSupported) {
+		t.Errorf("expected ErrDefaultRoutingNotSupported, got: %v", err)
+	}
+	var routingErr *workers.DefaultRoutingError
+	if !errors.As(err, &routingErr) {
+		t.Errorf("expected DefaultRoutingError, got: %v", err)
+	}
 }

--- a/workers/errors.go
+++ b/workers/errors.go
@@ -1,0 +1,28 @@
+package workers
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors for workers
+var (
+	ErrDefaultRoutingNotSupported = errors.New("default routing not supported")
+)
+
+// DefaultRoutingError represents an error when default routing to a stanza is not supported
+type DefaultRoutingError struct {
+	StanzaName string
+	Reason     string
+}
+
+func (e *DefaultRoutingError) Error() string {
+	if e.Reason != "" {
+		return fmt.Sprintf("default routing to stanza=[%s] not supported: %s", e.StanzaName, e.Reason)
+	}
+	return fmt.Sprintf("default routing to stanza=[%s] not supported", e.StanzaName)
+}
+
+func (e *DefaultRoutingError) Is(target error) bool {
+	return target == ErrDefaultRoutingNotSupported
+}

--- a/workers/errors_test.go
+++ b/workers/errors_test.go
@@ -1,0 +1,56 @@
+package workers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dmachard/go-dnscollector/v2/dnsutils"
+)
+
+func TestWorkerErrors_IsAndAs(t *testing.T) {
+	// Test DefaultRoutingError
+	routErr := &DefaultRoutingError{StanzaName: "stanzaX", Reason: "no input channel"}
+	if !errors.Is(routErr, ErrDefaultRoutingNotSupported) {
+		t.Errorf("expected ErrDefaultRoutingNotSupported, got: %v", routErr)
+	}
+	var targetRoutErr *DefaultRoutingError
+	if !errors.As(routErr, &targetRoutErr) {
+		t.Errorf("expected *DefaultRoutingError, got: %v", routErr)
+	}
+}
+
+func TestGetRoutes_ZeroPanic(t *testing.T) {
+	wValid := GetWorkerForTest(10)
+	wWithoutInput := &GenericWorker{name: "no-input"}
+	routes := []Worker{nil, wWithoutInput, wValid}
+
+	channels, names := GetRoutes(routes)
+	if len(channels) != 1 {
+		t.Errorf("expected 1 channel, got %d", len(channels))
+	}
+	if len(names) != 1 || names[0] != wValid.GetName() {
+		t.Errorf("expected [%s], got %v", wValid.GetName(), names)
+	}
+}
+
+func TestPrometheusCatalogue_ZeroPanic(t *testing.T) {
+	// Test GetAllCounterSets with unexpected element type (should not panic)
+	container := &PromCounterCatalogueContainer{
+		stats: map[string]PrometheusCountersCatalogue{
+			"bad": nil,
+		},
+	}
+	sets := container.GetAllCounterSets()
+	if len(sets) != 0 {
+		t.Errorf("expected 0 sets, got %d", len(sets))
+	}
+
+	// Test GetCountersSet with nil selector (should return nil and not panic)
+	containerNilSelector := &PromCounterCatalogueContainer{
+		selector: nil,
+	}
+	res := containerNilSelector.GetCountersSet(&dnsutils.DNSMessage{})
+	if res != nil {
+		t.Errorf("expected nil result for nil selector, got %v", res)
+	}
+}

--- a/workers/prometheus.go
+++ b/workers/prometheus.go
@@ -858,7 +858,9 @@ func (w *PromCounterCatalogueContainer) GetAllCounterSets() []*PrometheusCounter
 		case *PromCounterCatalogueContainer:
 			ret = append(ret, elem.GetAllCounterSets()...)
 		default:
-			panic(fmt.Sprintf("Unexpected element in PromCounterCatalogueContainer of %T: %v", v, v))
+			if w.prom != nil {
+				w.prom.LogError("unexpected element in PromCounterCatalogueContainer: %T (%v)", v, v)
+			}
 		}
 	}
 	w.RUnlock()
@@ -868,7 +870,10 @@ func (w *PromCounterCatalogueContainer) GetAllCounterSets() []*PrometheusCounter
 // Searches for an existing element for a label value, creating one if not found
 func (w *PromCounterCatalogueContainer) GetCountersSet(dm *dnsutils.DNSMessage) PrometheusCountersCatalogue {
 	if w.selector == nil {
-		panic(fmt.Sprintf("%v: nil selector", w))
+		if w.prom != nil {
+			w.prom.LogError("nil selector in PromCounterCatalogueContainer: %v", w)
+		}
+		return nil
 	}
 
 	// w.selector fetches the value for the label *this* Catalogue Element considers.

--- a/workers/worker.go
+++ b/workers/worker.go
@@ -444,11 +444,12 @@ func GetRoutes(routes []Worker) ([]chan *dnsutils.DNSMessageBatch, []string) {
 	channels := []chan *dnsutils.DNSMessageBatch{}
 	names := []string{}
 	for _, p := range routes {
+		if p == nil {
+			continue
+		}
 		if c := p.GetInputChannel(); c != nil {
 			channels = append(channels, c)
 			names = append(names, p.GetName())
-		} else {
-			panic("default routing to stanza=[" + p.GetName() + "] not supported")
 		}
 	}
 	return channels, names


### PR DESCRIPTION
## Summary

This PR improves service resilience and fault tolerance by eliminating all `panic()` calls across pipeline initialization, routing, and metric scraping, replacing them with structured Go 1.13+ error types and sentinel errors (`errors.Is` / `errors.As`).

## Changes

### 1. Zero Panic & Configuration Resilience
- **`pkginit/pipelines.go`**:
  - `GetStanzaConfig` now returns `(*pkgconfig.Config, error)` instead of panicking on unknown workers or invalid YAML.
  - SIGHUP configuration reload (`ReloadPipelines`) now gracefully handles invalid configuration by logging errors without crashing the running instance.
  - `CreateRouting` validates that route targets support incoming message streams (`GetInputChannel() != nil`) and returns a typed error early during startup.
- **`workers/worker.go`**:
  - Removed `panic()` in `GetRoutes()`, safely filtering active input channels.
- **`workers/prometheus.go`**:
  - Removed `panic()` in `GetAllCounterSets()` and `GetCountersSet()`, replacing them with non-fatal error logs (`LogError`).

### 2. Structured & Sentinel Errors
- **`pkginit/errors.go`**: Added sentinel errors (`ErrNoRoutesDefined`, `ErrDuplicateStanza`, `ErrRouteNotFound`, `ErrRoutingLoop`, `ErrStanzaNotFound`, `ErrStanzaConfig`, `ErrYAMLConfig`) and corresponding typed error structs with `Unwrap()` and `Is()`.
- **`workers/errors.go`**: Added `DefaultRoutingError` and sentinel `ErrDefaultRoutingNotSupported`.

### 3. Unit Tests
- Added unit tests in `pkginit/pipelines_test.go` and `workers/errors_test.go` to validate error wrapping, `errors.Is`/`errors.As` compliance, and zero-panic runtime behavior.

## Verification
- All unit tests pass: `go test ./pkginit/... ./workers/...` (100% PASS).
- Binary builds cleanly with `go build .`.
