### PR TITLE
refactor(pipeline): replace YAML re-marshaling with direct mapstructure decode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/farsightsec/golang-framestream v0.3.0
 	github.com/flosch/pongo2 v0.0.0-20200913210552-0d938eb266f3
 	github.com/fsnotify/fsnotify v1.10.1
+	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/snappy v1.0.0
 	github.com/google/gopacket v1.1.19
@@ -75,7 +76,6 @@ require (
 	github.com/go-logfmt/logfmt v0.6.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/gogo/status v1.1.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
@@ -218,7 +218,7 @@ require (
 	golang.org/x/tools v0.47.0 // indirect
 	google.golang.org/grpc v1.82.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6
 )
 

--- a/pkg/config/collectors.go
+++ b/pkg/config/collectors.go
@@ -6,95 +6,117 @@ import (
 	"github.com/creasty/defaults"
 )
 
+type CollectorDNSMessageMatching struct {
+	Include map[string]interface{} `yaml:"include"`
+	Exclude map[string]interface{} `yaml:"exclude"`
+}
+
+type CollectorDNSMessage struct {
+	Enable   bool                        `yaml:"enable" default:"false"`
+	Matching CollectorDNSMessageMatching `yaml:"matching"`
+}
+
+type CollectorTail struct {
+	Enable       bool   `yaml:"enable" default:"false"`
+	TimeLayout   string `yaml:"time-layout" default:""`
+	PatternQuery string `yaml:"pattern-query" default:""`
+	PatternReply string `yaml:"pattern-reply" default:""`
+	FilePath     string `yaml:"file-path" default:""`
+}
+
+type CollectorDnstap struct {
+	Enable           bool   `yaml:"enable" default:"false"`
+	ListenIP         string `yaml:"listen-ip" default:"0.0.0.0"`
+	ListenPort       int    `yaml:"listen-port" default:"6000"`
+	SockPath         string `yaml:"sock-path" default:""`
+	TLSSupport       bool   `yaml:"tls-support" default:"false"`
+	TLSMinVersion    string `yaml:"tls-min-version" default:"1.2"`
+	CertFile         string `yaml:"cert-file" default:""`
+	KeyFile          string `yaml:"key-file" default:""`
+	RcvBufSize       int    `yaml:"sock-rcvbuf" default:"0"`
+	ReadBufferSize   int    `yaml:"sock-read-buffer-size" default:"65536"`
+	ResetConn        bool   `yaml:"reset-conn" default:"true"`
+	NumWorkers       int    `yaml:"num-workers" default:"0"`
+	DisableDNSParser bool   `yaml:"disable-dnsparser" default:"false"`
+	ExtendedSupport  bool   `yaml:"extended-support" default:"false"`
+	FastDecoder      bool   `yaml:"fast-decoder" default:"true"`
+	Compression      string `yaml:"compression" default:"none"`
+}
+
+type CollectorDnstapProxifier struct {
+	Enable        bool   `yaml:"enable" default:"false"`
+	ListenIP      string `yaml:"listen-ip" default:"0.0.0.0"`
+	ListenPort    int    `yaml:"listen-port" default:"6000"`
+	SockPath      string `yaml:"sock-path" default:""`
+	TLSSupport    bool   `yaml:"tls-support" default:"false"`
+	TLSMinVersion string `yaml:"tls-min-version" default:"1.2"`
+	CertFile      string `yaml:"cert-file" default:""`
+	KeyFile       string `yaml:"key-file" default:""`
+}
+
+type CollectorAfpacketLiveCapture struct {
+	Enable          bool   `yaml:"enable" default:"false"`
+	Port            int    `yaml:"port" default:"53"`
+	Device          string `yaml:"device" default:""`
+	FragmentSupport bool   `yaml:"enable-defrag-ip" default:"true"`
+	GreSupport      bool   `yaml:"enable-gre" default:"false"`
+	RawIPSupport    bool   `yaml:"enable-rawip" default:"false"`
+}
+
+type CollectorXdpLiveCapture struct {
+	Enable bool   `yaml:"enable" default:"false"`
+	Port   int    `yaml:"port" default:"53"`
+	Device string `yaml:"device" default:""`
+}
+
+type CollectorPowerDNS struct {
+	Enable        bool   `yaml:"enable" default:"false"`
+	ListenIP      string `yaml:"listen-ip" default:"0.0.0.0"`
+	ListenPort    int    `yaml:"listen-port" default:"6001"`
+	TLSSupport    bool   `yaml:"tls-support" default:"false"`
+	TLSMinVersion string `yaml:"tls-min-version" default:"1.2"`
+	CertFile      string `yaml:"cert-file" default:""`
+	KeyFile       string `yaml:"key-file" default:""`
+	AddDNSPayload bool   `yaml:"add-dns-payload" default:"false"`
+	RcvBufSize    int    `yaml:"sock-rcvbuf" default:"0"`
+	ResetConn     bool   `yaml:"reset-conn" default:"true"`
+}
+
+type CollectorFileIngestor struct {
+	Enable      bool   `yaml:"enable" default:"false"`
+	WatchDir    string `yaml:"watch-dir" default:""`
+	WatchMode   string `yaml:"watch-mode" default:"pcap"`
+	PcapDNSPort int    `yaml:"pcap-dns-port" default:"53"`
+	DeleteAfter bool   `yaml:"delete-after" default:"false"`
+}
+
+type CollectorTzsp struct {
+	Enable     bool   `yaml:"enable" default:"false"`
+	ListenIP   string `yaml:"listen-ip" default:"0.0.0.0"`
+	ListenPort int    `yaml:"listen-port" default:"10000"`
+}
+
+type CollectorWebhook struct {
+	Enable           bool   `yaml:"enable" default:"false"`
+	URL              string `yaml:"url" default:"http://127.0.0.1:8088"`
+	Timeout          int    `yaml:"timeout" default:"1"`
+	BasicAuthEnabled bool   `yaml:"basic-auth-enable" default:"false"`
+	BasicAuthLogin   string `yaml:"basic-auth-login" default:""`
+	BasicAuthPwd     string `yaml:"basic-auth-pwd" default:""`
+	NumThreads       int    `yaml:"num-threads" default:"1"`
+}
+
 type ConfigCollectors struct {
-	DNSMessage struct {
-		Enable   bool `yaml:"enable" default:"false"`
-		Matching struct {
-			Include map[string]interface{} `yaml:"include"`
-			Exclude map[string]interface{} `yaml:"exclude"`
-		} `yaml:"matching"`
-	} `yaml:"dnsmessage"`
-	Tail struct {
-		Enable       bool   `yaml:"enable" default:"false"`
-		TimeLayout   string `yaml:"time-layout" default:""`
-		PatternQuery string `yaml:"pattern-query" default:""`
-		PatternReply string `yaml:"pattern-reply" default:""`
-		FilePath     string `yaml:"file-path" default:""`
-	} `yaml:"tail"`
-	Dnstap struct {
-		Enable           bool   `yaml:"enable" default:"false"`
-		ListenIP         string `yaml:"listen-ip" default:"0.0.0.0"`
-		ListenPort       int    `yaml:"listen-port" default:"6000"`
-		SockPath         string `yaml:"sock-path" default:""`
-		TLSSupport       bool   `yaml:"tls-support" default:"false"`
-		TLSMinVersion    string `yaml:"tls-min-version" default:"1.2"`
-		CertFile         string `yaml:"cert-file" default:""`
-		KeyFile          string `yaml:"key-file" default:""`
-		RcvBufSize       int    `yaml:"sock-rcvbuf" default:"0"`
-		ReadBufferSize   int    `yaml:"sock-read-buffer-size" default:"65536"`
-		ResetConn        bool   `yaml:"reset-conn" default:"true"`
-		NumWorkers       int    `yaml:"num-workers" default:"0"`
-		DisableDNSParser bool   `yaml:"disable-dnsparser" default:"false"`
-		ExtendedSupport  bool   `yaml:"extended-support" default:"false"`
-		FastDecoder      bool   `yaml:"fast-decoder" default:"true"`
-		Compression      string `yaml:"compression" default:"none"`
-	} `yaml:"dnstap"`
-	DnstapProxifier struct {
-		Enable        bool   `yaml:"enable" default:"false"`
-		ListenIP      string `yaml:"listen-ip" default:"0.0.0.0"`
-		ListenPort    int    `yaml:"listen-port" default:"6000"`
-		SockPath      string `yaml:"sock-path" default:""`
-		TLSSupport    bool   `yaml:"tls-support" default:"false"`
-		TLSMinVersion string `yaml:"tls-min-version" default:"1.2"`
-		CertFile      string `yaml:"cert-file" default:""`
-		KeyFile       string `yaml:"key-file" default:""`
-	} `yaml:"dnstap-relay"`
-	AfpacketLiveCapture struct {
-		Enable          bool   `yaml:"enable" default:"false"`
-		Port            int    `yaml:"port" default:"53"`
-		Device          string `yaml:"device" default:""`
-		FragmentSupport bool   `yaml:"enable-defrag-ip" default:"true"`
-		GreSupport      bool   `yaml:"enable-gre" default:"false"`
-		RawIPSupport    bool   `yaml:"enable-rawip" default:"false"`
-	} `yaml:"afpacket-sniffer"`
-	XdpLiveCapture struct {
-		Enable bool   `yaml:"enable" default:"false"`
-		Port   int    `yaml:"port" default:"53"`
-		Device string `yaml:"device" default:""`
-	} `yaml:"xdp-sniffer"`
-	PowerDNS struct {
-		Enable        bool   `yaml:"enable" default:"false"`
-		ListenIP      string `yaml:"listen-ip" default:"0.0.0.0"`
-		ListenPort    int    `yaml:"listen-port" default:"6001"`
-		TLSSupport    bool   `yaml:"tls-support" default:"false"`
-		TLSMinVersion string `yaml:"tls-min-version" default:"1.2"`
-		CertFile      string `yaml:"cert-file" default:""`
-		KeyFile       string `yaml:"key-file" default:""`
-		AddDNSPayload bool   `yaml:"add-dns-payload" default:"false"`
-		RcvBufSize    int    `yaml:"sock-rcvbuf" default:"0"`
-		ResetConn     bool   `yaml:"reset-conn" default:"true"`
-	} `yaml:"powerdns"`
-	FileIngestor struct {
-		Enable      bool   `yaml:"enable" default:"false"`
-		WatchDir    string `yaml:"watch-dir" default:""`
-		WatchMode   string `yaml:"watch-mode" default:"pcap"`
-		PcapDNSPort int    `yaml:"pcap-dns-port" default:"53"`
-		DeleteAfter bool   `yaml:"delete-after" default:"false"`
-	} `yaml:"file-ingestor"`
-	Tzsp struct {
-		Enable     bool   `yaml:"enable" default:"false"`
-		ListenIP   string `yaml:"listen-ip" default:"0.0.0.0"`
-		ListenPort int    `yaml:"listen-port" default:"10000"`
-	} `yaml:"tzsp"`
-	Webhook struct {
-		Enable           bool   `yaml:"enable" default:"false"`
-		URL              string `yaml:"url" default:"http://127.0.0.1:8088"`
-		Timeout          int    `yaml:"timeout" default:"1"`
-		BasicAuthEnabled bool   `yaml:"basic-auth-enable" default:"false"`
-		BasicAuthLogin   string `yaml:"basic-auth-login" default:""`
-		BasicAuthPwd     string `yaml:"basic-auth-pwd" default:""`
-		NumThreads       int    `yaml:"num-threads" default:"1"`
-	} `yaml:"webhook"`
+	DNSMessage          CollectorDNSMessage          `yaml:"dnsmessage"`
+	Tail                CollectorTail                `yaml:"tail"`
+	Dnstap              CollectorDnstap              `yaml:"dnstap"`
+	DnstapProxifier     CollectorDnstapProxifier     `yaml:"dnstap-relay"`
+	AfpacketLiveCapture CollectorAfpacketLiveCapture `yaml:"afpacket-sniffer"`
+	XdpLiveCapture      CollectorXdpLiveCapture      `yaml:"xdp-sniffer"`
+	PowerDNS            CollectorPowerDNS            `yaml:"powerdns"`
+	FileIngestor        CollectorFileIngestor        `yaml:"file-ingestor"`
+	Tzsp                CollectorTzsp                `yaml:"tzsp"`
+	Webhook             CollectorWebhook             `yaml:"webhook"`
 }
 
 func (c *ConfigCollectors) SetDefault() {

--- a/pkg/config/global.go
+++ b/pkg/config/global.go
@@ -8,48 +8,56 @@ import (
 	"github.com/pkg/errors"
 )
 
+type GlobalTrace struct {
+	Verbose      bool   `yaml:"verbose" default:"false"`
+	LogMalformed bool   `yaml:"log-malformed" default:"false"`
+	Filename     string `yaml:"filename" default:""`
+	MaxSize      int    `yaml:"max-size" default:"10"`
+	MaxBackups   int    `yaml:"max-backups" default:"10"`
+}
+
+type GlobalWorker struct {
+	InternalMonitor      int `yaml:"interval-monitor" default:"10"`
+	ChannelBufferSize    int `yaml:"buffer-size" default:"512"`
+	BatchSize            int `yaml:"batch-size" default:"64"`
+	BatchFlushIntervalMs int `yaml:"flush-interval-ms" default:"10"`
+}
+
+type GlobalTelemetry struct {
+	Enabled         bool   `yaml:"enabled" default:"false"`
+	WebPath         string `yaml:"web-path" default:"/metrics"`
+	WebListen       string `yaml:"web-listen" default:":9165"`
+	SockPath        string `yaml:"sock-path" default:""`
+	SockMode        string `yaml:"sock-mode" default:"0660"`
+	PromPrefix      string `yaml:"prometheus-prefix" default:"dnscollector_exporter"`
+	TLSSupport      bool   `yaml:"tls-support" default:"false"`
+	TLSCertFile     string `yaml:"tls-cert-file" default:""`
+	TLSKeyFile      string `yaml:"tls-key-file" default:""`
+	ClientCAFile    string `yaml:"client-ca-file" default:""`
+	BasicAuthEnable bool   `yaml:"basic-auth-enable" default:"false"`
+	BasicAuthLogin  string `yaml:"basic-auth-login" default:"admin"`
+	BasicAuthPwd    string `yaml:"basic-auth-pwd" default:"changeme"`
+}
+
+type GlobalFramestream struct {
+	ControlFrameMaxLength uint32 `yaml:"control-frame-max-length" default:"4064"`
+	DataFrameMaxLength    uint32 `yaml:"data-frame-max-length" default:"65536"`
+	HandshakeTimeout      int    `yaml:"handshake-timeout" default:"5"`
+	ContentType           string `yaml:"content-type" default:"protobuf:dnstap.Dnstap"`
+}
+
 type ConfigGlobal struct {
-	TextFormat          string `yaml:"text-format" default:"timestamp identity operation rcode queryip queryport family protocol length-unit qname qtype latency"`
-	TextFormatDelimiter string `yaml:"text-format-delimiter" default:" "`
-	TextFormatBoundary  string `yaml:"text-format-boundary" default:"\""`
-	TextJinja           string `yaml:"text-jinja" default:""`
-	Trace               struct {
-		Verbose      bool   `yaml:"verbose" default:"false"`
-		LogMalformed bool   `yaml:"log-malformed" default:"false"`
-		Filename     string `yaml:"filename" default:""`
-		MaxSize      int    `yaml:"max-size" default:"10"`
-		MaxBackups   int    `yaml:"max-backups" default:"10"`
-	} `yaml:"trace"`
-	ServerIdentity string `yaml:"server-identity" default:""`
-	PidFile        string `yaml:"pid-file" default:""`
-	Worker         struct {
-		InternalMonitor      int `yaml:"interval-monitor" default:"10"`
-		ChannelBufferSize    int `yaml:"buffer-size" default:"512"`
-		BatchSize            int `yaml:"batch-size" default:"64"`
-		BatchFlushIntervalMs int `yaml:"flush-interval-ms" default:"10"`
-	} `yaml:"worker"`
-	Telemetry struct {
-		Enabled         bool   `yaml:"enabled" default:"false"`
-		WebPath         string `yaml:"web-path" default:"/metrics"`
-		WebListen       string `yaml:"web-listen" default:":9165"`
-		SockPath        string `yaml:"sock-path" default:""`
-		SockMode        string `yaml:"sock-mode" default:"0660"`
-		PromPrefix      string `yaml:"prometheus-prefix" default:"dnscollector_exporter"`
-		TLSSupport      bool   `yaml:"tls-support" default:"false"`
-		TLSCertFile     string `yaml:"tls-cert-file" default:""`
-		TLSKeyFile      string `yaml:"tls-key-file" default:""`
-		ClientCAFile    string `yaml:"client-ca-file" default:""`
-		BasicAuthEnable bool   `yaml:"basic-auth-enable" default:"false"`
-		BasicAuthLogin  string `yaml:"basic-auth-login" default:"admin"`
-		BasicAuthPwd    string `yaml:"basic-auth-pwd" default:"changeme"`
-	} `yaml:"telemetry"`
-	Framestream struct {
-		ControlFrameMaxLength uint32 `yaml:"control-frame-max-length" default:"4064"`
-		DataFrameMaxLength    uint32 `yaml:"data-frame-max-length" default:"65536"`
-		HandshakeTimeout      int    `yaml:"handshake-timeout" default:"5"`
-		ContentType           string `yaml:"content-type" default:"protobuf:dnstap.Dnstap"`
-	} `yaml:"framestream"`
-	TransformersOrder []string `yaml:"transformers-order" default:"[]"`
+	TextFormat          string            `yaml:"text-format" default:"timestamp identity operation rcode queryip queryport family protocol length-unit qname qtype latency"`
+	TextFormatDelimiter string            `yaml:"text-format-delimiter" default:" "`
+	TextFormatBoundary  string            `yaml:"text-format-boundary" default:"\""`
+	TextJinja           string            `yaml:"text-jinja" default:""`
+	Trace               GlobalTrace       `yaml:"trace"`
+	ServerIdentity      string            `yaml:"server-identity" default:""`
+	PidFile             string            `yaml:"pid-file" default:""`
+	Worker              GlobalWorker      `yaml:"worker"`
+	Telemetry           GlobalTelemetry   `yaml:"telemetry"`
+	Framestream         GlobalFramestream `yaml:"framestream"`
+	TransformersOrder   []string          `yaml:"transformers-order" default:"[]"`
 }
 
 func (c *ConfigGlobal) SetDefault() {

--- a/pkg/config/loggers.go
+++ b/pkg/config/loggers.go
@@ -7,362 +7,404 @@ import (
 	"github.com/prometheus/prometheus/model/relabel"
 )
 
+type LoggerDevNull struct {
+	Enable bool `yaml:"enable" default:"false"`
+}
+
+type LoggerStdout struct {
+	Enable               bool    `yaml:"enable" default:"false"`
+	Mode                 string  `yaml:"mode" default:"text"`
+	TextFormat           string  `yaml:"text-format" default:""`
+	JinjaFormat          string  `yaml:"jinja-format" default:""`
+	OverwriteDNSPortPcap bool    `yaml:"overwrite-dns-port-pcap" default:"false"`
+	WriterBufferSize     int     `yaml:"writer-buffer-size" default:"65536"`
+	FlushInterval        float64 `yaml:"flush-interval" default:"1.0"`
+}
+
+type LoggerPrometheus struct {
+	Enable                     bool     `yaml:"enable" default:"false"`
+	ListenIP                   string   `yaml:"listen-ip" default:"127.0.0.1"`
+	ListenPort                 int      `yaml:"listen-port" default:"8081"`
+	TLSSupport                 bool     `yaml:"tls-support" default:"false"`
+	TLSMutual                  bool     `yaml:"tls-mutual" default:"false"`
+	TLSMinVersion              string   `yaml:"tls-min-version" default:"1.2"`
+	CertFile                   string   `yaml:"cert-file" default:""`
+	KeyFile                    string   `yaml:"key-file" default:""`
+	PromPrefix                 string   `yaml:"prometheus-prefix" default:"dnscollector"`
+	LabelsList                 []string `yaml:"prometheus-labels" default:"[]"`
+	TopN                       int      `yaml:"top-n" default:"10"`
+	BasicAuthLogin             string   `yaml:"basic-auth-login" default:"admin"`
+	BasicAuthPwd               string   `yaml:"basic-auth-pwd" default:"changeme"`
+	BasicAuthEnabled           bool     `yaml:"basic-auth-enable" default:"true"`
+	RequestersMetricsEnabled   bool     `yaml:"requesters-metrics-enabled" default:"true"`
+	DomainsMetricsEnabled      bool     `yaml:"domains-metrics-enabled" default:"true"`
+	NoErrorMetricsEnabled      bool     `yaml:"noerror-metrics-enabled" default:"true"`
+	ServfailMetricsEnabled     bool     `yaml:"servfail-metrics-enabled" default:"true"`
+	NonExistentMetricsEnabled  bool     `yaml:"nonexistent-metrics-enabled" default:"true"`
+	TLDsMetricsEnabled         bool     `yaml:"tlds-metrics-enabled" default:"false"`
+	SuspiciousMetricsEnabled   bool     `yaml:"suspicious-metrics-enabled" default:"false"`
+	TimeoutMetricsEnabled      bool     `yaml:"timeout-metrics-enabled" default:"false"`
+	HistogramMetricsEnabled    bool     `yaml:"histogram-metrics-enabled" default:"false"`
+	TopCountriesMetricsEnabled bool     `yaml:"top-countries-metrics-enabled" default:"false"`
+	TopASNsMetricsEnabled      bool     `yaml:"top-asns-metrics-enabled" default:"false"`
+	RequestersCacheTTL         int      `yaml:"requesters-cache-ttl" default:"3600"`
+	RequestersCacheSize        int      `yaml:"requesters-cache-size" default:"250000"`
+	DomainsCacheTTL            int      `yaml:"domains-cache-ttl" default:"3600"`
+	DomainsCacheSize           int      `yaml:"domains-cache-size" default:"500000"`
+	NoErrorDomainsCacheTTL     int      `yaml:"noerror-domains-cache-ttl" default:"3600"`
+	NoErrorDomainsCacheSize    int      `yaml:"noerror-domains-cache-size" default:"100000"`
+	ServfailDomainsCacheTTL    int      `yaml:"servfail-domains-cache-ttl" default:"3600"`
+	ServfailDomainsCacheSize   int      `yaml:"servfail-domains-cache-size" default:"10000"`
+	NXDomainsCacheTTL          int      `yaml:"nonexistent-domains-cache-ttl" default:"3600"`
+	NXDomainsCacheSize         int      `yaml:"nonexistent-domains-cache-size" default:"10000"`
+	DefaultDomainsCacheTTL     int      `yaml:"default-domains-cache-ttl" default:"3600"`
+	DefaultDomainsCacheSize    int      `yaml:"default-domains-cache-size" default:"1000"`
+}
+
+type LoggerRestAPI struct {
+	Enable                   bool   `yaml:"enable" default:"false"`
+	ListenIP                 string `yaml:"listen-ip" default:"127.0.0.1"`
+	ListenPort               int    `yaml:"listen-port" default:"8080"`
+	BasicAuthLogin           string `yaml:"basic-auth-login" default:"admin"`
+	BasicAuthPwd             string `yaml:"basic-auth-pwd" default:"changeme"`
+	TLSSupport               bool   `yaml:"tls-support" default:"false"`
+	TLSMinVersion            string `yaml:"tls-min-version" default:"1.2"`
+	CertFile                 string `yaml:"cert-file" default:""`
+	KeyFile                  string `yaml:"key-file" default:""`
+	TopN                     int    `yaml:"top-n" default:"100"`
+	RequestersCacheTTL       int    `yaml:"requesters-cache-ttl" default:"3600"`
+	RequestersCacheSize      int    `yaml:"requesters-cache-size" default:"250000"`
+	DomainsCacheTTL          int    `yaml:"domains-cache-ttl" default:"3600"`
+	DomainsCacheSize         int    `yaml:"domains-cache-size" default:"500000"`
+	NXDomainsCacheTTL        int    `yaml:"nonexistent-domains-cache-ttl" default:"3600"`
+	NXDomainsCacheSize       int    `yaml:"nonexistent-domains-cache-size" default:"10000"`
+	ServfailDomainsCacheTTL  int    `yaml:"servfail-domains-cache-ttl" default:"3600"`
+	ServfailDomainsCacheSize int    `yaml:"servfail-domains-cache-size" default:"10000"`
+	TLDsCacheTTL             int    `yaml:"tlds-cache-ttl" default:"3600"`
+	TLDsCacheSize            int    `yaml:"tlds-cache-size" default:"10000"`
+	SuspiciousCacheTTL       int    `yaml:"suspicious-cache-ttl" default:"3600"`
+	SuspiciousCacheSize      int    `yaml:"suspicious-cache-size" default:"10000"`
+}
+
+type LoggerLogFile struct {
+	Enable               bool   `yaml:"enable" default:"false"`
+	FilePath             string `yaml:"file-path" default:""`
+	MaxSize              int    `yaml:"max-size" default:"100"`
+	MaxFiles             int    `yaml:"max-files" default:"10"`
+	MaxBatchSize         int    `yaml:"max-batch-size" default:"65536"`
+	RotationInterval     int    `yaml:"rotation-interval" default:"0"`
+	FlushInterval        int    `yaml:"flush-interval" default:"1"`
+	Compress             bool   `yaml:"compress" default:"false"`
+	Mode                 string `yaml:"mode" default:"text"`
+	PostRotateCommand    string `yaml:"postrotate-command" default:""`
+	PostRotateDelete     bool   `yaml:"postrotate-delete-success" default:"false"`
+	TextFormat           string `yaml:"text-format" default:""`
+	JinjaFormat          string `yaml:"jinja-format" default:""`
+	ExtendedSupport      bool   `yaml:"extended-support" default:"false"`
+	OverwriteDNSPortPcap bool   `yaml:"overwrite-dns-port-pcap" default:"false"`
+}
+
+type LoggerDNSTap struct {
+	Enable            bool   `yaml:"enable" default:"false"`
+	RemoteAddress     string `yaml:"remote-address" default:"127.0.0.1"`
+	RemotePort        int    `yaml:"remote-port" default:"6000"`
+	Transport         string `yaml:"transport" default:"tcp"`
+	SockPath          string `yaml:"sock-path" default:""`
+	ConnectTimeout    int    `yaml:"connect-timeout" default:"5"`
+	RetryInterval     int    `yaml:"retry-interval" default:"10"`
+	FlushInterval     int    `yaml:"flush-interval" default:"30"`
+	TLSSupport        bool   `yaml:"tls-support" default:"false"`
+	TLSInsecure       bool   `yaml:"tls-insecure" default:"false"`
+	TLSMinVersion     string `yaml:"tls-min-version" default:"1.2"`
+	CAFile            string `yaml:"ca-file" default:""`
+	CertFile          string `yaml:"cert-file" default:""`
+	KeyFile           string `yaml:"key-file" default:""`
+	ServerID          string `yaml:"server-id" default:""`
+	OverwriteIdentity bool   `yaml:"overwrite-identity" default:"false"`
+	BufferSize        int    `yaml:"buffer-size" default:"100"`
+	ExtendedSupport   bool   `yaml:"extended-support" default:"false"`
+	Compression       string `yaml:"compression" default:"none"`
+}
+
+type LoggerTCPClient struct {
+	Enable           bool   `yaml:"enable" default:"false"`
+	RemoteAddress    string `yaml:"remote-address" default:"127.0.0.1"`
+	RemotePort       int    `yaml:"remote-port" default:"9999"`
+	RetryInterval    int    `yaml:"retry-interval" default:"10"`
+	Transport        string `yaml:"transport" default:"tcp"`
+	TLSInsecure      bool   `yaml:"tls-insecure" default:"false"`
+	TLSMinVersion    string `yaml:"tls-min-version" default:"1.2"`
+	CAFile           string `yaml:"ca-file" default:""`
+	CertFile         string `yaml:"cert-file" default:""`
+	KeyFile          string `yaml:"key-file" default:""`
+	Mode             string `yaml:"mode" default:"flat-json"`
+	TextFormat       string `yaml:"text-format" default:""`
+	PayloadDelimiter string `yaml:"delimiter" default:"\n"`
+	BufferSize       int    `yaml:"buffer-size" default:"100"`
+	FlushInterval    int    `yaml:"flush-interval" default:"30"`
+	ConnectTimeout   int    `yaml:"connect-timeout" default:"5"`
+}
+
+type LoggerSyslog struct {
+	Enable          bool   `yaml:"enable" default:"false"`
+	Severity        string `yaml:"severity" default:"INFO"`
+	Facility        string `yaml:"facility" default:"DAEMON"`
+	Transport       string `yaml:"transport" default:"local"`
+	RemoteAddress   string `yaml:"remote-address" default:"127.0.0.1:514"`
+	RetryInterval   int    `yaml:"retry-interval" default:"10"`
+	TextFormat      string `yaml:"text-format" default:""`
+	Mode            string `yaml:"mode" default:"text"`
+	TLSInsecure     bool   `yaml:"tls-insecure" default:"false"`
+	TLSMinVersion   string `yaml:"tls-min-version" default:"1.2"`
+	CAFile          string `yaml:"ca-file" default:""`
+	CertFile        string `yaml:"cert-file" default:""`
+	KeyFile         string `yaml:"key-file" default:""`
+	Formatter       string `yaml:"formatter" default:"rfc5424"`
+	Framer          string `yaml:"framer" default:""`
+	Hostname        string `yaml:"hostname" default:""`
+	AppName         string `yaml:"app-name" default:"DNScollector"`
+	Tag             string `yaml:"tag" default:""`
+	ReplaceNullChar string `yaml:"replace-null-char" default:"\ufffd"`
+	FlushInterval   int    `yaml:"flush-interval" default:"30"`
+	BufferSize      int    `yaml:"buffer-size" default:"100"`
+}
+
+type LoggerFluentd struct {
+	Enable         bool   `yaml:"enable" default:"false"`
+	RemoteAddress  string `yaml:"remote-address" default:"127.0.0.1"`
+	RemotePort     int    `yaml:"remote-port" default:"24224"`
+	ConnectTimeout int    `yaml:"connect-timeout" default:"5"`
+	RetryInterval  int    `yaml:"retry-interval" default:"10"`
+	FlushInterval  int    `yaml:"flush-interval" default:"30"`
+	Transport      string `yaml:"transport" default:"tcp"`
+	TLSInsecure    bool   `yaml:"tls-insecure" default:"false"`
+	TLSMinVersion  string `yaml:"tls-min-version" default:"1.2"`
+	CAFile         string `yaml:"ca-file" default:""`
+	CertFile       string `yaml:"cert-file" default:""`
+	KeyFile        string `yaml:"key-file" default:""`
+	Tag            string `yaml:"tag" default:"dns.collector"`
+	BufferSize     int    `yaml:"buffer-size" default:"100"`
+}
+
+type LoggerInfluxDB struct {
+	Enable        bool   `yaml:"enable" default:"false"`
+	ServerURL     string `yaml:"server-url" default:"http://localhost:8086"`
+	AuthToken     string `yaml:"auth-token" default:""`
+	TLSSupport    bool   `yaml:"tls-support" default:"false"`
+	TLSInsecure   bool   `yaml:"tls-insecure" default:"false"`
+	TLSMinVersion string `yaml:"tls-min-version" default:"1.2"`
+	CAFile        string `yaml:"ca-file" default:""`
+	CertFile      string `yaml:"cert-file" default:""`
+	KeyFile       string `yaml:"key-file" default:""`
+	Bucket        string `yaml:"bucket" default:""`
+	Organization  string `yaml:"organization" default:""`
+}
+
+type LoggerLokiClient struct {
+	Enable           bool              `yaml:"enable" default:"false"`
+	ServerURL        string            `yaml:"server-url" default:"http://localhost:3100/loki/api/v1/push"`
+	JobName          string            `yaml:"job-name" default:"dnscollector"`
+	Mode             string            `yaml:"mode" default:"text"`
+	FlushInterval    int               `yaml:"flush-interval" default:"5"`
+	BatchSize        int               `yaml:"batch-size" default:"1048576"`
+	RetryInterval    int               `yaml:"retry-interval" default:"10"`
+	TextFormat       string            `yaml:"text-format" default:""`
+	ProxyURL         string            `yaml:"proxy-url" default:""`
+	TLSInsecure      bool              `yaml:"tls-insecure" default:"false"`
+	TLSMinVersion    string            `yaml:"tls-min-version" default:"1.2"`
+	CAFile           string            `yaml:"ca-file" default:""`
+	CertFile         string            `yaml:"cert-file" default:""`
+	KeyFile          string            `yaml:"key-file" default:""`
+	BasicAuthLogin   string            `yaml:"basic-auth-login" default:""`
+	BasicAuthPwd     string            `yaml:"basic-auth-pwd" default:""`
+	BasicAuthPwdFile string            `yaml:"basic-auth-pwd-file" default:""`
+	TenantID         string            `yaml:"tenant-id" default:""`
+	RelabelConfigs   []*relabel.Config `yaml:"relabel-configs" default:"[]"`
+}
+
+type LoggerStatsd struct {
+	Enable         bool   `yaml:"enable" default:"false"`
+	Prefix         string `yaml:"prefix" default:"dnscollector"`
+	RemoteAddress  string `yaml:"remote-address" default:"127.0.0.1"`
+	RemotePort     int    `yaml:"remote-port" default:"8125"`
+	ConnectTimeout int    `yaml:"connect-timeout" default:"5"`
+	Transport      string `yaml:"transport" default:"udp"`
+	FlushInterval  int    `yaml:"flush-interval" default:"10"`
+	CertFile       string `yaml:"cert-file" default:""`
+	TLSInsecure    bool   `yaml:"tls-insecure" default:"false"`
+	TLSMinVersion  string `yaml:"tls-min-version" default:"1.2"`
+	CAFile         string `yaml:"ca-file" default:""`
+	KeyFile        string `yaml:"key-file" default:""`
+}
+
+type LoggerNsq struct {
+	Enable bool   `yaml:"enable" default:"false"`
+	Host   string `yaml:"host" default:"127.0.0.1"`
+	Port   int    `yaml:"port" default:"4150"`
+	Topic  string `yaml:"topic" default:"dnscollector"`
+}
+
+type LoggerElasticSearchClient struct {
+	Enable            bool   `yaml:"enable" default:"false"`
+	Index             string `yaml:"index" default:"dnscollector"`
+	Server            string `yaml:"server" default:"http://127.0.0.1:9200/"`
+	BulkSize          int    `yaml:"bulk-size" default:"5242880"`
+	BulkChannelSize   int    `yaml:"bulk-channel-size" default:"10"`
+	FlushInterval     int    `yaml:"flush-interval" default:"10"`
+	Compression       string `yaml:"compression" default:"none"`
+	BasicAuthEnabled  bool   `yaml:"basic-auth-enable" default:"false"`
+	BasicAuthLogin    string `yaml:"basic-auth-login" default:""`
+	BasicAuthPwd      string `yaml:"basic-auth-pwd" default:""`
+	RetryEnabled      bool   `yaml:"retry-enable" default:"true"`
+	RetryMaxAttempts  int    `yaml:"retry-max-attempts" default:"5"`
+	RetryInitialDelay int    `yaml:"retry-initial-delay" default:"1"`
+	RetryMaxDelay     int    `yaml:"retry-max-delay" default:"30"`
+	TLSInsecure       bool   `yaml:"tls-insecure" default:"false"`
+	TLSMinVersion     string `yaml:"tls-min-version" default:"1.2"`
+	CAFile            string `yaml:"ca-file" default:""`
+	CertFile          string `yaml:"cert-file" default:""`
+	KeyFile           string `yaml:"key-file" default:""`
+}
+
+type LoggerOpenTelemetryClient struct {
+	Enable               bool   `yaml:"enable" default:"false"`
+	CleanupSpansInterval int    `yaml:"cleanup-spans-interval" default:"30"`
+	MaxSpanTime          int    `yaml:"max-span-time" default:"120"`
+	OtelEndpoint         string `yaml:"otel-endpoint" default:""`
+}
+
+type LoggerScalyrClient struct {
+	Enable        bool                   `yaml:"enable" default:"false"`
+	Mode          string                 `yaml:"mode" default:"text"`
+	TextFormat    string                 `yaml:"text-format" default:""`
+	SessionInfo   map[string]string      `yaml:"sessioninfo" default:"{}"`
+	Attrs         map[string]interface{} `yaml:"attrs" default:"{}"`
+	ServerURL     string                 `yaml:"server-url" default:"app.scalyr.com"`
+	APIKey        string                 `yaml:"apikey" default:""`
+	Parser        string                 `yaml:"parser" default:""`
+	FlushInterval int                    `yaml:"flush-interval" default:"10"`
+	ProxyURL      string                 `yaml:"proxy-url" default:""`
+	TLSInsecure   bool                   `yaml:"tls-insecure" default:"false"`
+	TLSMinVersion string                 `yaml:"tls-min-version" default:"1.2"`
+	CAFile        string                 `yaml:"ca-file" default:""`
+	CertFile      string                 `yaml:"cert-file" default:""`
+	KeyFile       string                 `yaml:"key-file" default:""`
+}
+
+type LoggerRedisPub struct {
+	Enable           bool   `yaml:"enable" default:"false"`
+	RemoteAddress    string `yaml:"remote-address" default:"127.0.0.1"`
+	RemotePort       int    `yaml:"remote-port" default:"6379"`
+	RetryInterval    int    `yaml:"retry-interval" default:"10"`
+	Transport        string `yaml:"transport" default:"tcp"`
+	TLSInsecure      bool   `yaml:"tls-insecure" default:"false"`
+	TLSMinVersion    string `yaml:"tls-min-version" default:"1.2"`
+	CAFile           string `yaml:"ca-file" default:""`
+	CertFile         string `yaml:"cert-file" default:""`
+	KeyFile          string `yaml:"key-file" default:""`
+	Mode             string `yaml:"mode" default:"flat-json"`
+	TextFormat       string `yaml:"text-format" default:""`
+	PayloadDelimiter string `yaml:"delimiter" default:"\n"`
+	BufferSize       int    `yaml:"buffer-size" default:"100"`
+	FlushInterval    int    `yaml:"flush-interval" default:"30"`
+	ConnectTimeout   int    `yaml:"connect-timeout" default:"5"`
+	RedisChannel     string `yaml:"redis-channel" default:"dns_collector"`
+}
+
+type LoggerKafkaProducer struct {
+	Enable         bool   `yaml:"enable" default:"false"`
+	ClientID       string `yaml:"client-id" default:""`
+	RemoteAddress  string `yaml:"remote-address" default:"127.0.0.1"`
+	RemotePort     int    `yaml:"remote-port" default:"9092"`
+	TLSSupport     bool   `yaml:"tls-support" default:"false"`
+	TLSInsecure    bool   `yaml:"tls-insecure" default:"false"`
+	TLSMinVersion  string `yaml:"tls-min-version" default:"1.2"`
+	CAFile         string `yaml:"ca-file" default:""`
+	CertFile       string `yaml:"cert-file" default:""`
+	KeyFile        string `yaml:"key-file" default:""`
+	SaslSupport    bool   `yaml:"sasl-support" default:"false"`
+	SaslUsername   string `yaml:"sasl-username" default:""`
+	SaslPassword   string `yaml:"sasl-password" default:""`
+	SaslMechanism  string `yaml:"sasl-mechanism" default:"PLAIN"`
+	Mode           string `yaml:"mode" default:"flat-json"`
+	TextFormat     string `yaml:"text-format" default:""`
+	BatchSize      int    `yaml:"batch-size" default:"100"`
+	FlushInterval  int    `yaml:"flush-interval" default:"10"`
+	ConnectTimeout int    `yaml:"connect-timeout" default:"5"`
+	Topic          string `yaml:"topic" default:"dnscollector"`
+	Partition      *int   `yaml:"partition" default:"nil"`
+	Balancer       string `yaml:"balancer" default:"round-robin"`
+	Compression    string `yaml:"compression" default:"none"`
+}
+
+type LoggerFalcoClient struct {
+	Enable bool   `yaml:"enable" default:"false"`
+	URL    string `yaml:"url" default:"http://127.0.0.1:9200"`
+}
+
+type LoggerClickhouseClient struct {
+	Enable        bool   `yaml:"enable" default:"false"`
+	URL           string `yaml:"url" default:"http://localhost:8123"`
+	User          string `yaml:"user" default:"default"`
+	Password      string `yaml:"password" default:"password"`
+	Database      string `yaml:"database" default:"dnscollector"`
+	Table         string `yaml:"table" default:"records"`
+	BufferSize    int    `yaml:"buffer-size" default:"100"`
+	FlushInterval int    `yaml:"flush-interval" default:"10"`
+	Timeout       int    `yaml:"timeout" default:"5"`
+	TLSSupport    bool   `yaml:"tls-support" default:"false"`
+	TLSInsecure   bool   `yaml:"tls-insecure" default:"false"`
+	TLSMinVersion string `yaml:"tls-min-version" default:"1.2"`
+	CAFile        string `yaml:"ca-file" default:""`
+	CertFile      string `yaml:"cert-file" default:""`
+	KeyFile       string `yaml:"key-file" default:""`
+}
+
+type LoggerMQTT struct {
+	Enable          bool   `yaml:"enable" default:"false"`
+	RemoteAddress   string `yaml:"remote-address" default:"127.0.0.1"`
+	RemotePort      int    `yaml:"remote-port" default:"1883"`
+	ConnectTimeout  int    `yaml:"connect-timeout" default:"5"`
+	RetryInterval   int    `yaml:"retry-interval" default:"10"`
+	Topic           string `yaml:"topic" default:"dnscollector/dns"`
+	QOS             byte   `yaml:"qos" default:"0"`
+	Mode            string `yaml:"mode" default:"flat-json"`
+	TextFormat      string `yaml:"text-format" default:""`
+	BufferSize      int    `yaml:"buffer-size" default:"100"`
+	FlushInterval   int    `yaml:"flush-interval" default:"30"`
+	ProtocolVersion string `yaml:"protocol-version" default:"auto"`
+	Username        string `yaml:"username" default:""`
+	Password        string `yaml:"password" default:""`
+	TLSSupport      bool   `yaml:"tls-support" default:"false"`
+	TLSInsecure     bool   `yaml:"tls-insecure" default:"false"`
+	TLSMinVersion   string `yaml:"tls-min-version" default:"1.2"`
+	CAFile          string `yaml:"ca-file" default:""`
+	CertFile        string `yaml:"cert-file" default:""`
+	KeyFile         string `yaml:"key-file" default:""`
+}
+
 type ConfigLoggers struct {
-	DevNull struct {
-		Enable bool `yaml:"enable" default:"false"`
-	} `yaml:"devnull"`
-	Stdout struct {
-		Enable               bool    `yaml:"enable" default:"false"`
-		Mode                 string  `yaml:"mode" default:"text"`
-		TextFormat           string  `yaml:"text-format" default:""`
-		JinjaFormat          string  `yaml:"jinja-format" default:""`
-		OverwriteDNSPortPcap bool    `yaml:"overwrite-dns-port-pcap" default:"false"`
-		WriterBufferSize     int     `yaml:"writer-buffer-size" default:"65536"`
-		FlushInterval        float64 `yaml:"flush-interval" default:"1.0"`
-	} `yaml:"stdout"`
-	Prometheus struct {
-		Enable                     bool     `yaml:"enable" default:"false"`
-		ListenIP                   string   `yaml:"listen-ip" default:"127.0.0.1"`
-		ListenPort                 int      `yaml:"listen-port" default:"8081"`
-		TLSSupport                 bool     `yaml:"tls-support" default:"false"`
-		TLSMutual                  bool     `yaml:"tls-mutual" default:"false"`
-		TLSMinVersion              string   `yaml:"tls-min-version" default:"1.2"`
-		CertFile                   string   `yaml:"cert-file" default:""`
-		KeyFile                    string   `yaml:"key-file" default:""`
-		PromPrefix                 string   `yaml:"prometheus-prefix" default:"dnscollector"`
-		LabelsList                 []string `yaml:"prometheus-labels" default:"[]"`
-		TopN                       int      `yaml:"top-n" default:"10"`
-		BasicAuthLogin             string   `yaml:"basic-auth-login" default:"admin"`
-		BasicAuthPwd               string   `yaml:"basic-auth-pwd" default:"changeme"`
-		BasicAuthEnabled           bool     `yaml:"basic-auth-enable" default:"true"`
-		RequestersMetricsEnabled   bool     `yaml:"requesters-metrics-enabled" default:"true"`
-		DomainsMetricsEnabled      bool     `yaml:"domains-metrics-enabled" default:"true"`
-		NoErrorMetricsEnabled      bool     `yaml:"noerror-metrics-enabled" default:"true"`
-		ServfailMetricsEnabled     bool     `yaml:"servfail-metrics-enabled" default:"true"`
-		NonExistentMetricsEnabled  bool     `yaml:"nonexistent-metrics-enabled" default:"true"`
-		TLDsMetricsEnabled         bool     `yaml:"tlds-metrics-enabled" default:"false"`
-		SuspiciousMetricsEnabled   bool     `yaml:"suspicious-metrics-enabled" default:"false"`
-		TimeoutMetricsEnabled      bool     `yaml:"timeout-metrics-enabled" default:"false"`
-		HistogramMetricsEnabled    bool     `yaml:"histogram-metrics-enabled" default:"false"`
-		TopCountriesMetricsEnabled bool     `yaml:"top-countries-metrics-enabled" default:"false"`
-		TopASNsMetricsEnabled      bool     `yaml:"top-asns-metrics-enabled" default:"false"`
-		RequestersCacheTTL         int      `yaml:"requesters-cache-ttl" default:"3600"`
-		RequestersCacheSize        int      `yaml:"requesters-cache-size" default:"250000"`
-		DomainsCacheTTL            int      `yaml:"domains-cache-ttl" default:"3600"`
-		DomainsCacheSize           int      `yaml:"domains-cache-size" default:"500000"`
-		NoErrorDomainsCacheTTL     int      `yaml:"noerror-domains-cache-ttl" default:"3600"`
-		NoErrorDomainsCacheSize    int      `yaml:"noerror-domains-cache-size" default:"100000"`
-		ServfailDomainsCacheTTL    int      `yaml:"servfail-domains-cache-ttl" default:"3600"`
-		ServfailDomainsCacheSize   int      `yaml:"servfail-domains-cache-size" default:"10000"`
-		NXDomainsCacheTTL          int      `yaml:"nonexistent-domains-cache-ttl" default:"3600"`
-		NXDomainsCacheSize         int      `yaml:"nonexistent-domains-cache-size" default:"10000"`
-		DefaultDomainsCacheTTL     int      `yaml:"default-domains-cache-ttl" default:"3600"`
-		DefaultDomainsCacheSize    int      `yaml:"default-domains-cache-size" default:"1000"`
-	} `yaml:"prometheus"`
-	RestAPI struct {
-		Enable                   bool   `yaml:"enable" default:"false"`
-		ListenIP                 string `yaml:"listen-ip" default:"127.0.0.1"`
-		ListenPort               int    `yaml:"listen-port" default:"8080"`
-		BasicAuthLogin           string `yaml:"basic-auth-login" default:"admin"`
-		BasicAuthPwd             string `yaml:"basic-auth-pwd" default:"changeme"`
-		TLSSupport               bool   `yaml:"tls-support" default:"false"`
-		TLSMinVersion            string `yaml:"tls-min-version" default:"1.2"`
-		CertFile                 string `yaml:"cert-file" default:""`
-		KeyFile                  string `yaml:"key-file" default:""`
-		TopN                     int    `yaml:"top-n" default:"100"`
-		RequestersCacheTTL       int    `yaml:"requesters-cache-ttl" default:"3600"`
-		RequestersCacheSize      int    `yaml:"requesters-cache-size" default:"250000"`
-		DomainsCacheTTL          int    `yaml:"domains-cache-ttl" default:"3600"`
-		DomainsCacheSize         int    `yaml:"domains-cache-size" default:"500000"`
-		NXDomainsCacheTTL        int    `yaml:"nonexistent-domains-cache-ttl" default:"3600"`
-		NXDomainsCacheSize       int    `yaml:"nonexistent-domains-cache-size" default:"10000"`
-		ServfailDomainsCacheTTL  int    `yaml:"servfail-domains-cache-ttl" default:"3600"`
-		ServfailDomainsCacheSize int    `yaml:"servfail-domains-cache-size" default:"10000"`
-		TLDsCacheTTL             int    `yaml:"tlds-cache-ttl" default:"3600"`
-		TLDsCacheSize            int    `yaml:"tlds-cache-size" default:"10000"`
-		SuspiciousCacheTTL       int    `yaml:"suspicious-cache-ttl" default:"3600"`
-		SuspiciousCacheSize      int    `yaml:"suspicious-cache-size" default:"10000"`
-	} `yaml:"restapi"`
-	LogFile struct {
-		Enable               bool   `yaml:"enable" default:"false"`
-		FilePath             string `yaml:"file-path" default:""`
-		MaxSize              int    `yaml:"max-size" default:"100"`
-		MaxFiles             int    `yaml:"max-files" default:"10"`
-		MaxBatchSize         int    `yaml:"max-batch-size" default:"65536"`
-		RotationInterval     int    `yaml:"rotation-interval" default:"0"`
-		FlushInterval        int    `yaml:"flush-interval" default:"1"`
-		Compress             bool   `yaml:"compress" default:"false"`
-		Mode                 string `yaml:"mode" default:"text"`
-		PostRotateCommand    string `yaml:"postrotate-command" default:""`
-		PostRotateDelete     bool   `yaml:"postrotate-delete-success" default:"false"`
-		TextFormat           string `yaml:"text-format" default:""`
-		JinjaFormat          string `yaml:"jinja-format" default:""`
-		ExtendedSupport      bool   `yaml:"extended-support" default:"false"`
-		OverwriteDNSPortPcap bool   `yaml:"overwrite-dns-port-pcap" default:"false"`
-	} `yaml:"logfile"`
-	DNSTap struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		RemoteAddress     string `yaml:"remote-address" default:"127.0.0.1"`
-		RemotePort        int    `yaml:"remote-port" default:"6000"`
-		Transport         string `yaml:"transport" default:"tcp"`
-		SockPath          string `yaml:"sock-path" default:""`
-		ConnectTimeout    int    `yaml:"connect-timeout" default:"5"`
-		RetryInterval     int    `yaml:"retry-interval" default:"10"`
-		FlushInterval     int    `yaml:"flush-interval" default:"30"`
-		TLSSupport        bool   `yaml:"tls-support" default:"false"`
-		TLSInsecure       bool   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion     string `yaml:"tls-min-version" default:"1.2"`
-		CAFile            string `yaml:"ca-file" default:""`
-		CertFile          string `yaml:"cert-file" default:""`
-		KeyFile           string `yaml:"key-file" default:""`
-		ServerID          string `yaml:"server-id" default:""`
-		OverwriteIdentity bool   `yaml:"overwrite-identity" default:"false"`
-		BufferSize        int    `yaml:"buffer-size" default:"100"`
-		ExtendedSupport   bool   `yaml:"extended-support" default:"false"`
-		Compression       string `yaml:"compression" default:"none"`
-	} `yaml:"dnstapclient"`
-	TCPClient struct {
-		Enable           bool   `yaml:"enable" default:"false"`
-		RemoteAddress    string `yaml:"remote-address" default:"127.0.0.1"`
-		RemotePort       int    `yaml:"remote-port" default:"9999"`
-		RetryInterval    int    `yaml:"retry-interval" default:"10"`
-		Transport        string `yaml:"transport" default:"tcp"`
-		TLSInsecure      bool   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion    string `yaml:"tls-min-version" default:"1.2"`
-		CAFile           string `yaml:"ca-file" default:""`
-		CertFile         string `yaml:"cert-file" default:""`
-		KeyFile          string `yaml:"key-file" default:""`
-		Mode             string `yaml:"mode" default:"flat-json"`
-		TextFormat       string `yaml:"text-format" default:""`
-		PayloadDelimiter string `yaml:"delimiter" default:"\n"`
-		BufferSize       int    `yaml:"buffer-size" default:"100"`
-		FlushInterval    int    `yaml:"flush-interval" default:"30"`
-		ConnectTimeout   int    `yaml:"connect-timeout" default:"5"`
-	} `yaml:"tcpclient"`
-	Syslog struct {
-		Enable          bool   `yaml:"enable" default:"false"`
-		Severity        string `yaml:"severity" default:"INFO"`
-		Facility        string `yaml:"facility" default:"DAEMON"`
-		Transport       string `yaml:"transport" default:"local"`
-		RemoteAddress   string `yaml:"remote-address" default:"127.0.0.1:514"`
-		RetryInterval   int    `yaml:"retry-interval" default:"10"`
-		TextFormat      string `yaml:"text-format" default:""`
-		Mode            string `yaml:"mode" default:"text"`
-		TLSInsecure     bool   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion   string `yaml:"tls-min-version" default:"1.2"`
-		CAFile          string `yaml:"ca-file" default:""`
-		CertFile        string `yaml:"cert-file" default:""`
-		KeyFile         string `yaml:"key-file" default:""`
-		Formatter       string `yaml:"formatter" default:"rfc5424"`
-		Framer          string `yaml:"framer" default:""`
-		Hostname        string `yaml:"hostname" default:""`
-		AppName         string `yaml:"app-name" default:"DNScollector"`
-		Tag             string `yaml:"tag" default:""`
-		ReplaceNullChar string `yaml:"replace-null-char" default:"�"`
-		FlushInterval   int    `yaml:"flush-interval" default:"30"`
-		BufferSize      int    `yaml:"buffer-size" default:"100"`
-	} `yaml:"syslog"`
-	Fluentd struct {
-		Enable         bool   `yaml:"enable" default:"false"`
-		RemoteAddress  string `yaml:"remote-address" default:"127.0.0.1"`
-		RemotePort     int    `yaml:"remote-port" default:"24224"`
-		ConnectTimeout int    `yaml:"connect-timeout" default:"5"`
-		RetryInterval  int    `yaml:"retry-interval" default:"10"`
-		FlushInterval  int    `yaml:"flush-interval" default:"30"`
-		Transport      string `yaml:"transport" default:"tcp"`
-		TLSInsecure    bool   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion  string `yaml:"tls-min-version" default:"1.2"`
-		CAFile         string `yaml:"ca-file" default:""`
-		CertFile       string `yaml:"cert-file" default:""`
-		KeyFile        string `yaml:"key-file" default:""`
-		Tag            string `yaml:"tag" default:"dns.collector"`
-		BufferSize     int    `yaml:"buffer-size" default:"100"`
-	} `yaml:"fluentd"`
-	InfluxDB struct {
-		Enable        bool   `yaml:"enable" default:"false"`
-		ServerURL     string `yaml:"server-url" default:"http://localhost:8086"`
-		AuthToken     string `yaml:"auth-token" default:""`
-		TLSSupport    bool   `yaml:"tls-support" default:"false"`
-		TLSInsecure   bool   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion string `yaml:"tls-min-version" default:"1.2"`
-		CAFile        string `yaml:"ca-file" default:""`
-		CertFile      string `yaml:"cert-file" default:""`
-		KeyFile       string `yaml:"key-file" default:""`
-		Bucket        string `yaml:"bucket" default:""`
-		Organization  string `yaml:"organization" default:""`
-	} `yaml:"influxdb"`
-	LokiClient struct {
-		Enable           bool              `yaml:"enable" default:"false"`
-		ServerURL        string            `yaml:"server-url" default:"http://localhost:3100/loki/api/v1/push"`
-		JobName          string            `yaml:"job-name" default:"dnscollector"`
-		Mode             string            `yaml:"mode" default:"text"`
-		FlushInterval    int               `yaml:"flush-interval" default:"5"`
-		BatchSize        int               `yaml:"batch-size" default:"1048576"`
-		RetryInterval    int               `yaml:"retry-interval" default:"10"`
-		TextFormat       string            `yaml:"text-format" default:""`
-		ProxyURL         string            `yaml:"proxy-url" default:""`
-		TLSInsecure      bool              `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion    string            `yaml:"tls-min-version" default:"1.2"`
-		CAFile           string            `yaml:"ca-file" default:""`
-		CertFile         string            `yaml:"cert-file" default:""`
-		KeyFile          string            `yaml:"key-file" default:""`
-		BasicAuthLogin   string            `yaml:"basic-auth-login" default:""`
-		BasicAuthPwd     string            `yaml:"basic-auth-pwd" default:""`
-		BasicAuthPwdFile string            `yaml:"basic-auth-pwd-file" default:""`
-		TenantID         string            `yaml:"tenant-id" default:""`
-		RelabelConfigs   []*relabel.Config `yaml:"relabel-configs" default:"[]"`
-	} `yaml:"lokiclient"`
-	Statsd struct {
-		Enable         bool   `yaml:"enable" default:"false"`
-		Prefix         string `yaml:"prefix" default:"dnscollector"`
-		RemoteAddress  string `yaml:"remote-address" default:"127.0.0.1"`
-		RemotePort     int    `yaml:"remote-port" default:"8125"`
-		ConnectTimeout int    `yaml:"connect-timeout" default:"5"`
-		Transport      string `yaml:"transport" default:"udp"`
-		FlushInterval  int    `yaml:"flush-interval" default:"10"`
-		CertFile       string `yaml:"cert-file" default:""`
-		TLSInsecure    bool   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion  string `yaml:"tls-min-version" default:"1.2"`
-		CAFile         string `yaml:"ca-file" default:""`
-		KeyFile        string `yaml:"key-file" default:""`
-	} `yaml:"statsd"`
-	Nsq struct {
-		Enable bool   `yaml:"enable" default:"false"`
-		Host   string `yaml:"host" default:"127.0.0.1"`
-		Port   int    `yaml:"port" default:"4150"`
-		Topic  string `yaml:"topic" default:"dnscollector"`
-	} `yaml:"nsq"`
-	ElasticSearchClient struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		Index             string `yaml:"index" default:"dnscollector"`
-		Server            string `yaml:"server" default:"http://127.0.0.1:9200/"`
-		BulkSize          int    `yaml:"bulk-size" default:"5242880"`
-		BulkChannelSize   int    `yaml:"bulk-channel-size" default:"10"`
-		FlushInterval     int    `yaml:"flush-interval" default:"10"`
-		Compression       string `yaml:"compression" default:"none"`
-		BasicAuthEnabled  bool   `yaml:"basic-auth-enable" default:"false"`
-		BasicAuthLogin    string `yaml:"basic-auth-login" default:""`
-		BasicAuthPwd      string `yaml:"basic-auth-pwd" default:""`
-		RetryEnabled      bool   `yaml:"retry-enable" default:"true"`
-		RetryMaxAttempts  int    `yaml:"retry-max-attempts" default:"5"`
-		RetryInitialDelay int    `yaml:"retry-initial-delay" default:"1"`
-		RetryMaxDelay     int    `yaml:"retry-max-delay" default:"30"`
-		TLSInsecure       bool   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion     string `yaml:"tls-min-version" default:"1.2"`
-		CAFile            string `yaml:"ca-file" default:""`
-		CertFile          string `yaml:"cert-file" default:""`
-		KeyFile           string `yaml:"key-file" default:""`
-	} `yaml:"elasticsearch"`
-	OpenTelemetryClient struct {
-		Enable               bool   `yaml:"enable" default:"false"`
-		CleanupSpansInterval int    `yaml:"cleanup-spans-interval" default:"30"`
-		MaxSpanTime          int    `yaml:"max-span-time" default:"120"`
-		OtelEndpoint         string `yaml:"otel-endpoint" default:""`
-	} `yaml:"opentelemetry"`
-	ScalyrClient struct {
-		Enable        bool                   `yaml:"enable" default:"false"`
-		Mode          string                 `yaml:"mode" default:"text"`
-		TextFormat    string                 `yaml:"text-format" default:""`
-		SessionInfo   map[string]string      `yaml:"sessioninfo" default:"{}"`
-		Attrs         map[string]interface{} `yaml:"attrs" default:"{}"`
-		ServerURL     string                 `yaml:"server-url" default:"app.scalyr.com"`
-		APIKey        string                 `yaml:"apikey" default:""`
-		Parser        string                 `yaml:"parser" default:""`
-		FlushInterval int                    `yaml:"flush-interval" default:"10"`
-		ProxyURL      string                 `yaml:"proxy-url" default:""`
-		TLSInsecure   bool                   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion string                 `yaml:"tls-min-version" default:"1.2"`
-		CAFile        string                 `yaml:"ca-file" default:""`
-		CertFile      string                 `yaml:"cert-file" default:""`
-		KeyFile       string                 `yaml:"key-file" default:""`
-	} `yaml:"scalyrclient"`
-	RedisPub struct {
-		Enable           bool   `yaml:"enable" default:"false"`
-		RemoteAddress    string `yaml:"remote-address" default:"127.0.0.1"`
-		RemotePort       int    `yaml:"remote-port" default:"6379"`
-		RetryInterval    int    `yaml:"retry-interval" default:"10"`
-		Transport        string `yaml:"transport" default:"tcp"`
-		TLSInsecure      bool   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion    string `yaml:"tls-min-version" default:"1.2"`
-		CAFile           string `yaml:"ca-file" default:""`
-		CertFile         string `yaml:"cert-file" default:""`
-		KeyFile          string `yaml:"key-file" default:""`
-		Mode             string `yaml:"mode" default:"flat-json"`
-		TextFormat       string `yaml:"text-format" default:""`
-		PayloadDelimiter string `yaml:"delimiter" default:"\n"`
-		BufferSize       int    `yaml:"buffer-size" default:"100"`
-		FlushInterval    int    `yaml:"flush-interval" default:"30"`
-		ConnectTimeout   int    `yaml:"connect-timeout" default:"5"`
-		RedisChannel     string `yaml:"redis-channel" default:"dns_collector"`
-	} `yaml:"redispub"`
-	KafkaProducer struct {
-		Enable         bool   `yaml:"enable" default:"false"`
-		ClientID       string `yaml:"client-id" default:""`
-		RemoteAddress  string `yaml:"remote-address" default:"127.0.0.1"`
-		RemotePort     int    `yaml:"remote-port" default:"9092"`
-		TLSSupport     bool   `yaml:"tls-support" default:"false"`
-		TLSInsecure    bool   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion  string `yaml:"tls-min-version" default:"1.2"`
-		CAFile         string `yaml:"ca-file" default:""`
-		CertFile       string `yaml:"cert-file" default:""`
-		KeyFile        string `yaml:"key-file" default:""`
-		SaslSupport    bool   `yaml:"sasl-support" default:"false"`
-		SaslUsername   string `yaml:"sasl-username" default:""`
-		SaslPassword   string `yaml:"sasl-password" default:""`
-		SaslMechanism  string `yaml:"sasl-mechanism" default:"PLAIN"`
-		Mode           string `yaml:"mode" default:"flat-json"`
-		TextFormat     string `yaml:"text-format" default:""`
-		BatchSize      int    `yaml:"batch-size" default:"100"`
-		FlushInterval  int    `yaml:"flush-interval" default:"10"`
-		ConnectTimeout int    `yaml:"connect-timeout" default:"5"`
-		Topic          string `yaml:"topic" default:"dnscollector"`
-		Partition      *int   `yaml:"partition" default:"nil"`
-		Balancer       string `yaml:"balancer" default:"round-robin"`
-		Compression    string `yaml:"compression" default:"none"`
-	} `yaml:"kafkaproducer"`
-	FalcoClient struct {
-		Enable bool   `yaml:"enable" default:"false"`
-		URL    string `yaml:"url" default:"http://127.0.0.1:9200"`
-	} `yaml:"falco"`
-	ClickhouseClient struct {
-		Enable        bool   `yaml:"enable" default:"false"`
-		URL           string `yaml:"url" default:"http://localhost:8123"`
-		User          string `yaml:"user" default:"default"`
-		Password      string `yaml:"password" default:"password"`
-		Database      string `yaml:"database" default:"dnscollector"`
-		Table         string `yaml:"table" default:"records"`
-		BufferSize    int    `yaml:"buffer-size" default:"100"`
-		FlushInterval int    `yaml:"flush-interval" default:"10"`
-		Timeout       int    `yaml:"timeout" default:"5"`
-		TLSSupport    bool   `yaml:"tls-support" default:"false"`
-		TLSInsecure   bool   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion string `yaml:"tls-min-version" default:"1.2"`
-		CAFile        string `yaml:"ca-file" default:""`
-		CertFile      string `yaml:"cert-file" default:""`
-		KeyFile       string `yaml:"key-file" default:""`
-	} `yaml:"clickhouse"`
-	MQTT struct {
-		Enable          bool   `yaml:"enable" default:"false"`
-		RemoteAddress   string `yaml:"remote-address" default:"127.0.0.1"`
-		RemotePort      int    `yaml:"remote-port" default:"1883"`
-		ConnectTimeout  int    `yaml:"connect-timeout" default:"5"`
-		RetryInterval   int    `yaml:"retry-interval" default:"10"`
-		Topic           string `yaml:"topic" default:"dnscollector/dns"`
-		QOS             byte   `yaml:"qos" default:"0"`
-		Mode            string `yaml:"mode" default:"flat-json"`
-		TextFormat      string `yaml:"text-format" default:""`
-		BufferSize      int    `yaml:"buffer-size" default:"100"`
-		FlushInterval   int    `yaml:"flush-interval" default:"30"`
-		ProtocolVersion string `yaml:"protocol-version" default:"auto"`
-		Username        string `yaml:"username" default:""`
-		Password        string `yaml:"password" default:""`
-		TLSSupport      bool   `yaml:"tls-support" default:"false"`
-		TLSInsecure     bool   `yaml:"tls-insecure" default:"false"`
-		TLSMinVersion   string `yaml:"tls-min-version" default:"1.2"`
-		CAFile          string `yaml:"ca-file" default:""`
-		CertFile        string `yaml:"cert-file" default:""`
-		KeyFile         string `yaml:"key-file" default:""`
-	} `yaml:"mqtt"`
+	DevNull             LoggerDevNull             `yaml:"devnull"`
+	Stdout              LoggerStdout              `yaml:"stdout"`
+	Prometheus          LoggerPrometheus          `yaml:"prometheus"`
+	RestAPI             LoggerRestAPI             `yaml:"restapi"`
+	LogFile             LoggerLogFile             `yaml:"logfile"`
+	DNSTap              LoggerDNSTap              `yaml:"dnstapclient"`
+	TCPClient           LoggerTCPClient           `yaml:"tcpclient"`
+	Syslog              LoggerSyslog              `yaml:"syslog"`
+	Fluentd             LoggerFluentd             `yaml:"fluentd"`
+	InfluxDB            LoggerInfluxDB            `yaml:"influxdb"`
+	LokiClient          LoggerLokiClient          `yaml:"lokiclient"`
+	Statsd              LoggerStatsd              `yaml:"statsd"`
+	Nsq                 LoggerNsq                 `yaml:"nsq"`
+	ElasticSearchClient LoggerElasticSearchClient `yaml:"elasticsearch"`
+	OpenTelemetryClient LoggerOpenTelemetryClient `yaml:"opentelemetry"`
+	ScalyrClient        LoggerScalyrClient        `yaml:"scalyrclient"`
+	RedisPub            LoggerRedisPub            `yaml:"redispub"`
+	KafkaProducer       LoggerKafkaProducer       `yaml:"kafkaproducer"`
+	FalcoClient         LoggerFalcoClient         `yaml:"falco"`
+	ClickhouseClient    LoggerClickhouseClient    `yaml:"clickhouse"`
+	MQTT                LoggerMQTT                `yaml:"mqtt"`
 }
 
 func (c *ConfigLoggers) SetDefault() {

--- a/pkg/config/transformers.go
+++ b/pkg/config/transformers.go
@@ -33,133 +33,167 @@ type RelabelingConfig struct {
 	Replacement string `yaml:"replacement"`
 }
 
+type TransformUserPrivacy struct {
+	Enable            bool   `yaml:"enable" default:"false"`
+	AnonymizeIP       bool   `yaml:"anonymize-ip" default:"false"`
+	AnonymizeIPV4Bits string `yaml:"anonymize-v4bits" default:"0.0.0.0/16"`
+	AnonymizeIPV6Bits string `yaml:"anonymize-v6bits" default:"::/64"`
+	MinimizeQname     bool   `yaml:"minimize-qname" default:"false"`
+	HashQueryIP       bool   `yaml:"hash-query-ip" default:"false"`
+	HashReplyIP       bool   `yaml:"hash-reply-ip" default:"false"`
+	HashIPAlgo        string `yaml:"hash-ip-algo" default:"sha1"`
+}
+
+type TransformNormalize struct {
+	Enable              bool `yaml:"enable" default:"false"`
+	QnameLowerCase      bool `yaml:"qname-lowercase" default:"false"`
+	RRLowerCase         bool `yaml:"rr-lowercase" default:"false"`
+	QuietText           bool `yaml:"quiet-text" default:"false"`
+	AddTld              bool `yaml:"add-tld" default:"false"`
+	AddTldPlusOne       bool `yaml:"add-tld-plus-one" default:"false"`
+	ReplaceNonPrintable bool `yaml:"qname-replace-nonprintable" default:"false"`
+}
+
+type TransformLatency struct {
+	Enable            bool `yaml:"enable" default:"false"`
+	MeasureLatency    bool `yaml:"measure-latency" default:"false"`
+	UnansweredQueries bool `yaml:"unanswered-queries" default:"false"`
+	QueriesTimeout    int  `yaml:"queries-timeout" default:"2"`
+}
+
+type TransformReducer struct {
+	Enable                    bool     `yaml:"enable" default:"false"`
+	RepetitiveTrafficDetector bool     `yaml:"repetitive-traffic-detector" default:"false"`
+	QnamePlusOne              bool     `yaml:"qname-plus-one" default:"false"`
+	WatchInterval             int      `yaml:"watch-interval" default:"2"`
+	UniqueFields              []string `yaml:"unique-fields" default:"[\"dnstap.identity\", \"dnstap.operation\", \"network.query-ip\", \"network.response-ip\",  \"dns.qname\", \"dns.qtype\"]"`
+}
+
+type TransformFiltering struct {
+	Enable          bool     `yaml:"enable" default:"false"`
+	DropFqdnFile    string   `yaml:"drop-fqdn-file" default:""`
+	DropDomainFile  string   `yaml:"drop-domain-file" default:""`
+	KeepFqdnFile    string   `yaml:"keep-fqdn-file" default:""`
+	KeepDomainFile  string   `yaml:"keep-domain-file" default:""`
+	DropQueryIPFile string   `yaml:"drop-queryip-file" default:""`
+	KeepQueryIPFile string   `yaml:"keep-queryip-file" default:""`
+	KeepRdataFile   string   `yaml:"keep-rdata-file" default:""`
+	DropRcodes      []string `yaml:"drop-rcodes,flow" default:"[]"`
+	LogQueries      bool     `yaml:"log-queries" default:"true"`
+	LogReplies      bool     `yaml:"log-replies" default:"true"`
+	Downsample      int      `yaml:"downsample" default:"0"`
+}
+
+type TransformGeoIP struct {
+	Enable           bool   `yaml:"enable" default:"false"`
+	LookupECS        bool   `yaml:"lookup-ecs" default:"false"`
+	DBCountryFile    string `yaml:"mmdb-country-file" default:""`
+	DBCityFile       string `yaml:"mmdb-city-file" default:""`
+	DBASNFile        string `yaml:"mmdb-asn-file" default:""`
+	DBCoordinateFile string `yaml:"mmdb-coordinate-file" default:""`
+}
+
+type TransformBGP struct {
+	Enable                 bool   `yaml:"enable" default:"false"`
+	LookupECS              bool   `yaml:"lookup-ecs" default:"false"`
+	MrtFile                string `yaml:"mrt-file" default:""`
+	MrtCheckUpdateInterval int    `yaml:"mrt-checkupdate-interval" default:"300"`
+	OriginASN              bool   `yaml:"origin-asn" default:"true"`
+	ASPath                 bool   `yaml:"as-path" default:"true"`
+	Prefix                 bool   `yaml:"prefix" default:"true"`
+}
+
+type TransformSuspicious struct {
+	Enable             bool     `yaml:"enable" default:"false"`
+	ThresholdQnameLen  int      `yaml:"threshold-qname-len" default:"100"`
+	ThresholdPacketLen int      `yaml:"threshold-packet-len" default:"1000"`
+	ThresholdSlow      float64  `yaml:"threshold-slow" default:"1.0"`
+	CommonQtypes       []string `yaml:"common-qtypes,flow" default:"[\"A\", \"AAAA\", \"TXT\", \"CNAME\", \"PTR\", \"NAPTR\", \"DNSKEY\", \"SRV\", \"SOA\", \"NS\", \"MX\", \"DS\", \"HTTPS\"]"`
+	UnallowedChars     []string `yaml:"unallowed-chars,flow" default:"[\"\\\"\", \"==\", \"/\", \":\"]"`
+	ThresholdMaxLabels int      `yaml:"threshold-max-labels" default:"10"`
+	WhitelistDomains   []string `yaml:"whitelist-domains,flow" default:"[\"\\\\.ip6\\\\.arpa\"]"`
+}
+
+type TransformExtract struct {
+	Enable       bool     `yaml:"enable" default:"false"`
+	AddPayload   bool     `yaml:"add-payload" default:"false"`
+	Base64Fields []string `yaml:"base64-fields,flow" default:"[]"`
+	HexFields    []string `yaml:"hex-fields,flow" default:"[]"`
+}
+
+type TransformMachineLearning struct {
+	Enable      bool `yaml:"enable" default:"false"`
+	AddFeatures bool `yaml:"add-features" default:"false"`
+}
+
+type TransformATags struct {
+	Enable  bool     `yaml:"enable" default:"false"`
+	AddTags []string `yaml:"add-tags,flow" default:"[]"`
+}
+
+type TransformRest struct {
+	Enable           bool   `yaml:"enable" default:"false"`
+	URL              string `yaml:"url" default:"http://127.0.0.1:8088"`
+	Timeout          int    `yaml:"timeout" default:"1"`
+	BasicAuthEnabled bool   `yaml:"basic-auth-enable" default:"false"`
+	BasicAuthLogin   string `yaml:"basic-auth-login" default:""`
+	BasicAuthPwd     string `yaml:"basic-auth-pwd" default:""`
+}
+
+type TransformRelabeling struct {
+	Enable bool               `yaml:"enable" default:"false"`
+	Rename []RelabelingConfig `yaml:"rename,flow"`
+	Remove []RelabelingConfig `yaml:"remove,flow"`
+}
+
+type TransformRewrite struct {
+	Enable      bool                   `yaml:"enable" default:"false"`
+	Identifiers map[string]interface{} `yaml:"identifiers,flow"`
+}
+
+type TransformNewDomainTracker struct {
+	Enable           bool   `yaml:"enable" default:"false"`
+	TTL              int    `yaml:"ttl" default:"3600"`
+	CacheSize        int    `yaml:"cache-size" default:"100000"`
+	WhiteDomainsFile string `yaml:"white-domains-file" default:""`
+	PersistenceFile  string `yaml:"persistence-file" default:""`
+}
+
+type TransformUniqueResponseTracker struct {
+	Enable                bool   `yaml:"enable" default:"false"`
+	TTL                   int    `yaml:"ttl" default:"86400"`
+	CacheSize             int    `yaml:"cache-size" default:"100000"`
+	StorageEngine         string `yaml:"storage-engine" default:"lru"`
+	CuckooFingerprintBits int    `yaml:"cuckoo-fingerprint-bits" default:"16"`
+	WhiteDomainsFile      string `yaml:"white-domains-file" default:""`
+	PersistenceFile       string `yaml:"persistence-file" default:""`
+}
+
+type TransformReordering struct {
+	Enable        bool `yaml:"enable" default:"false"`
+	FlushInterval int  `yaml:"flush-interval" default:"30"`
+	MaxBufferSize int  `yaml:"max-buffer-size" default:"100"`
+}
+
 type ConfigTransformers struct {
-	Order       []string `yaml:"order" default:"[]"`
-	UserPrivacy struct {
-		Enable            bool   `yaml:"enable" default:"false"`
-		AnonymizeIP       bool   `yaml:"anonymize-ip" default:"false"`
-		AnonymizeIPV4Bits string `yaml:"anonymize-v4bits" default:"0.0.0.0/16"`
-		AnonymizeIPV6Bits string `yaml:"anonymize-v6bits" default:"::/64"`
-		MinimizeQname     bool   `yaml:"minimize-qname" default:"false"`
-		HashQueryIP       bool   `yaml:"hash-query-ip" default:"false"`
-		HashReplyIP       bool   `yaml:"hash-reply-ip" default:"false"`
-		HashIPAlgo        string `yaml:"hash-ip-algo" default:"sha1"`
-	} `yaml:"user-privacy"`
-	Normalize struct {
-		Enable              bool `yaml:"enable" default:"false"`
-		QnameLowerCase      bool `yaml:"qname-lowercase" default:"false"`
-		RRLowerCase         bool `yaml:"rr-lowercase" default:"false"`
-		QuietText           bool `yaml:"quiet-text" default:"false"`
-		AddTld              bool `yaml:"add-tld" default:"false"`
-		AddTldPlusOne       bool `yaml:"add-tld-plus-one" default:"false"`
-		ReplaceNonPrintable bool `yaml:"qname-replace-nonprintable" default:"false"`
-	} `yaml:"normalize"`
-	Latency struct {
-		Enable            bool `yaml:"enable" default:"false"`
-		MeasureLatency    bool `yaml:"measure-latency" default:"false"`
-		UnansweredQueries bool `yaml:"unanswered-queries" default:"false"`
-		QueriesTimeout    int  `yaml:"queries-timeout" default:"2"`
-	} `yaml:"latency"`
-	Reducer struct {
-		Enable                    bool     `yaml:"enable" default:"false"`
-		RepetitiveTrafficDetector bool     `yaml:"repetitive-traffic-detector" default:"false"`
-		QnamePlusOne              bool     `yaml:"qname-plus-one" default:"false"`
-		WatchInterval             int      `yaml:"watch-interval" default:"2"`
-		UniqueFields              []string `yaml:"unique-fields" default:"[\"dnstap.identity\", \"dnstap.operation\", \"network.query-ip\", \"network.response-ip\",  \"dns.qname\", \"dns.qtype\"]"`
-	} `yaml:"reducer"`
-	Filtering struct {
-		Enable          bool     `yaml:"enable" default:"false"`
-		DropFqdnFile    string   `yaml:"drop-fqdn-file" default:""`
-		DropDomainFile  string   `yaml:"drop-domain-file" default:""`
-		KeepFqdnFile    string   `yaml:"keep-fqdn-file" default:""`
-		KeepDomainFile  string   `yaml:"keep-domain-file" default:""`
-		DropQueryIPFile string   `yaml:"drop-queryip-file" default:""`
-		KeepQueryIPFile string   `yaml:"keep-queryip-file" default:""`
-		KeepRdataFile   string   `yaml:"keep-rdata-file" default:""`
-		DropRcodes      []string `yaml:"drop-rcodes,flow" default:"[]"`
-		LogQueries      bool     `yaml:"log-queries" default:"true"`
-		LogReplies      bool     `yaml:"log-replies" default:"true"`
-		Downsample      int      `yaml:"downsample" default:"0"`
-	} `yaml:"filtering"`
-	GeoIP struct {
-		Enable           bool   `yaml:"enable" default:"false"`
-		LookupECS        bool   `yaml:"lookup-ecs" default:"false"`
-		DBCountryFile    string `yaml:"mmdb-country-file" default:""`
-		DBCityFile       string `yaml:"mmdb-city-file" default:""`
-		DBASNFile        string `yaml:"mmdb-asn-file" default:""`
-		DBCoordinateFile string `yaml:"mmdb-coordinate-file" default:""`
-	} `yaml:"geoip"`
-	BGP struct {
-		Enable                 bool   `yaml:"enable" default:"false"`
-		LookupECS              bool   `yaml:"lookup-ecs" default:"false"`
-		MrtFile                string `yaml:"mrt-file" default:""`
-		MrtCheckUpdateInterval int    `yaml:"mrt-checkupdate-interval" default:"300"`
-		OriginASN              bool   `yaml:"origin-asn" default:"true"`
-		ASPath                 bool   `yaml:"as-path" default:"true"`
-		Prefix                 bool   `yaml:"prefix" default:"true"`
-	} `yaml:"bgp"`
-	Suspicious struct {
-		Enable             bool     `yaml:"enable" default:"false"`
-		ThresholdQnameLen  int      `yaml:"threshold-qname-len" default:"100"`
-		ThresholdPacketLen int      `yaml:"threshold-packet-len" default:"1000"`
-		ThresholdSlow      float64  `yaml:"threshold-slow" default:"1.0"`
-		CommonQtypes       []string `yaml:"common-qtypes,flow" default:"[\"A\", \"AAAA\", \"TXT\", \"CNAME\", \"PTR\", \"NAPTR\", \"DNSKEY\", \"SRV\", \"SOA\", \"NS\", \"MX\", \"DS\", \"HTTPS\"]"`
-		UnallowedChars     []string `yaml:"unallowed-chars,flow" default:"[\"\\\"\", \"==\", \"/\", \":\"]"`
-		ThresholdMaxLabels int      `yaml:"threshold-max-labels" default:"10"`
-		WhitelistDomains   []string `yaml:"whitelist-domains,flow" default:"[\"\\\\.ip6\\\\.arpa\"]"`
-	} `yaml:"suspicious"`
-	Extract struct {
-		Enable       bool     `yaml:"enable" default:"false"`
-		AddPayload   bool     `yaml:"add-payload" default:"false"`
-		Base64Fields []string `yaml:"base64-fields,flow" default:"[]"`
-		HexFields    []string `yaml:"hex-fields,flow" default:"[]"`
-	} `yaml:"extract"`
-	MachineLearning struct {
-		Enable      bool `yaml:"enable" default:"false"`
-		AddFeatures bool `yaml:"add-features" default:"false"`
-	} `yaml:"machine-learning"`
-	ATags struct {
-		Enable  bool     `yaml:"enable" default:"false"`
-		AddTags []string `yaml:"add-tags,flow" default:"[]"`
-	} `yaml:"atags"`
-	Rest struct {
-		Enable           bool   `yaml:"enable" default:"false"`
-		URL              string `yaml:"url" default:"http://127.0.0.1:8088"`
-		Timeout          int    `yaml:"timeout" default:"1"`
-		BasicAuthEnabled bool   `yaml:"basic-auth-enable" default:"false"`
-		BasicAuthLogin   string `yaml:"basic-auth-login" default:""`
-		BasicAuthPwd     string `yaml:"basic-auth-pwd" default:""`
-	} `yaml:"rest"`
-	Relabeling struct {
-		Enable bool               `yaml:"enable" default:"false"`
-		Rename []RelabelingConfig `yaml:"rename,flow"`
-		Remove []RelabelingConfig `yaml:"remove,flow"`
-	} `yaml:"relabeling"`
-	Rewrite struct {
-		Enable      bool                   `yaml:"enable" default:"false"`
-		Identifiers map[string]interface{} `yaml:"identifiers,flow"`
-	} `yaml:"rewrite"`
-	NewDomainTracker struct {
-		Enable           bool   `yaml:"enable" default:"false"`
-		TTL              int    `yaml:"ttl" default:"3600"`
-		CacheSize        int    `yaml:"cache-size" default:"100000"`
-		WhiteDomainsFile string `yaml:"white-domains-file" default:""`
-		PersistenceFile  string `yaml:"persistence-file" default:""`
-	} `yaml:"new-domain-tracker"`
-	UniqueResponseTracker struct {
-		Enable                bool   `yaml:"enable" default:"false"`
-		TTL                   int    `yaml:"ttl" default:"86400"`
-		CacheSize             int    `yaml:"cache-size" default:"100000"`
-		StorageEngine         string `yaml:"storage-engine" default:"lru"`
-		CuckooFingerprintBits int    `yaml:"cuckoo-fingerprint-bits" default:"16"`
-		WhiteDomainsFile      string `yaml:"white-domains-file" default:""`
-		PersistenceFile       string `yaml:"persistence-file" default:""`
-	} `yaml:"unique-response-tracker"`
-	Reordering struct {
-		Enable        bool `yaml:"enable" default:"false"`
-		FlushInterval int  `yaml:"flush-interval" default:"30"`
-		MaxBufferSize int  `yaml:"max-buffer-size" default:"100"`
-	} `yaml:"reordering"`
+	Order                 []string                       `yaml:"order" default:"[]"`
+	UserPrivacy           TransformUserPrivacy           `yaml:"user-privacy"`
+	Normalize             TransformNormalize             `yaml:"normalize"`
+	Latency               TransformLatency               `yaml:"latency"`
+	Reducer               TransformReducer               `yaml:"reducer"`
+	Filtering             TransformFiltering             `yaml:"filtering"`
+	GeoIP                 TransformGeoIP                 `yaml:"geoip"`
+	BGP                   TransformBGP                   `yaml:"bgp"`
+	Suspicious            TransformSuspicious            `yaml:"suspicious"`
+	Extract               TransformExtract               `yaml:"extract"`
+	MachineLearning       TransformMachineLearning       `yaml:"machine-learning"`
+	ATags                 TransformATags                 `yaml:"atags"`
+	Rest                  TransformRest                  `yaml:"rest"`
+	Relabeling            TransformRelabeling            `yaml:"relabeling"`
+	Rewrite               TransformRewrite               `yaml:"rewrite"`
+	NewDomainTracker      TransformNewDomainTracker      `yaml:"new-domain-tracker"`
+	UniqueResponseTracker TransformUniqueResponseTracker `yaml:"unique-response-tracker"`
+	Reordering            TransformReordering            `yaml:"reordering"`
 }
 
 func (c *ConfigTransformers) SetDefault() {

--- a/pkg/pipeline/pipelines.go
+++ b/pkg/pipeline/pipelines.go
@@ -9,7 +9,7 @@ import (
 	"github.com/dmachard/go-dnscollector/v3/pkg/telemetry"
 	"github.com/dmachard/go-dnscollector/v3/workers"
 	"github.com/dmachard/go-logger"
-	"gopkg.in/yaml.v2"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 func registerWorker(m map[string]workers.Worker, name string, enabled bool, factory func() workers.Worker, metrics *telemetry.PrometheusCollector) {
@@ -69,8 +69,20 @@ func GetStanzaConfig(mainConfig *config.Config, item config.ConfigPipelines) (*c
 	// copy global config
 	subcfg.Global = mainConfig.Global
 
-	yamlcfg, _ := yaml.Marshal(cfgMap)
-	if err := yaml.Unmarshal(yamlcfg, subcfg); err != nil {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName:          "yaml",
+		WeaklyTypedInput: true,
+		Result:           subcfg,
+		ZeroFields:       false,
+	})
+	if err != nil {
+		return nil, &YAMLConfigError{
+			Section: section,
+			Err:     err,
+		}
+	}
+
+	if err := decoder.Decode(cfgMap); err != nil {
 		return nil, &YAMLConfigError{
 			Section: section,
 			Err:     err,

--- a/pkg/pipeline/pipelines_test.go
+++ b/pkg/pipeline/pipelines_test.go
@@ -160,6 +160,73 @@ func TestPipelines_StopPipelines(t *testing.T) {
 	}
 }
 
+func TestPipelines_GetStanzaConfig_CollectorAndTransformer(t *testing.T) {
+	cfg := config.GetDefaultConfig()
+	stanza := config.ConfigPipelines{
+		Name: "tap",
+		Params: map[string]interface{}{
+			"dnstap": map[string]interface{}{
+				"listen-ip":   "127.0.0.1",
+				"listen-port": 6000,
+			},
+		},
+		Transforms: map[string]interface{}{
+			"normalize": map[string]interface{}{
+				"qname-lowercase": true,
+			},
+		},
+	}
+
+	subcfg, err := GetStanzaConfig(cfg, stanza)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !subcfg.Collectors.Dnstap.Enable {
+		t.Errorf("expected Dnstap.Enable to be true")
+	}
+	if subcfg.Collectors.Dnstap.ListenIP != "127.0.0.1" {
+		t.Errorf("expected ListenIP '127.0.0.1', got %s", subcfg.Collectors.Dnstap.ListenIP)
+	}
+	if subcfg.Collectors.Dnstap.ListenPort != 6000 {
+		t.Errorf("expected ListenPort 6000, got %d", subcfg.Collectors.Dnstap.ListenPort)
+	}
+	if !subcfg.IngoingTransformers.Normalize.Enable {
+		t.Errorf("expected Normalize.Enable to be true")
+	}
+	if !subcfg.IngoingTransformers.Normalize.QnameLowerCase {
+		t.Errorf("expected QnameLowerCase to be true")
+	}
+}
+
+func TestPipelines_GetStanzaConfig_Logger(t *testing.T) {
+	cfg := config.GetDefaultConfig()
+	stanza := config.ConfigPipelines{
+		Name: "prom",
+		Params: map[string]interface{}{
+			"prometheus": map[string]interface{}{
+				"listen-ip":   "0.0.0.0",
+				"listen-port": 8080,
+			},
+		},
+	}
+
+	subcfg, err := GetStanzaConfig(cfg, stanza)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !subcfg.Loggers.Prometheus.Enable {
+		t.Errorf("expected Prometheus.Enable to be true")
+	}
+	if subcfg.Loggers.Prometheus.ListenIP != "0.0.0.0" {
+		t.Errorf("expected ListenIP '0.0.0.0', got %s", subcfg.Loggers.Prometheus.ListenIP)
+	}
+	if subcfg.Loggers.Prometheus.ListenPort != 8080 {
+		t.Errorf("expected ListenPort 8080, got %d", subcfg.Loggers.Prometheus.ListenPort)
+	}
+}
+
 func TestPipelines_GetStanzaConfig_UnknownWorker(t *testing.T) {
 	cfg := config.GetDefaultConfig()
 	stanza := config.ConfigPipelines{

--- a/transformers/atags.go
+++ b/transformers/atags.go
@@ -8,16 +8,20 @@ import (
 
 type ATagsTransform struct {
 	GenericTransformer
+	config *config.TransformATags
 }
 
-func NewATagsTransform(cfg *config.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *ATagsTransform {
-	t := &ATagsTransform{GenericTransformer: NewTransformer(cfg, logger, "atags", name, instance, nextWorkers)}
+func NewATagsTransform(cfg *config.TransformATags, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *ATagsTransform {
+	t := &ATagsTransform{
+		GenericTransformer: NewTransformer(logger, "atags", name, instance, nextWorkers),
+		config:             cfg,
+	}
 	return t
 }
 
 func (t *ATagsTransform) GetTransforms() ([]Subtransform, error) {
 	subtransforms := []Subtransform{}
-	if len(t.config.ATags.AddTags) > 0 {
+	if len(t.config.AddTags) > 0 {
 		subtransforms = append(subtransforms, Subtransform{name: "atags:add", processFunc: t.addTags})
 	}
 	return subtransforms, nil
@@ -28,6 +32,6 @@ func (t *ATagsTransform) addTags(dm *dnsutils.DNSMessage) (int, error) {
 		dm.ATags = &dnsutils.TransformATags{Tags: []string{}}
 	}
 
-	dm.ATags.Tags = append(dm.ATags.Tags, t.config.ATags.AddTags...)
+	dm.ATags.Tags = append(dm.ATags.Tags, t.config.AddTags...)
 	return ReturnKeep, nil
 }

--- a/transformers/atags_test.go
+++ b/transformers/atags_test.go
@@ -10,10 +10,10 @@ import (
 
 func TestATags_AddTag(t *testing.T) {
 	// enable feature
-	cfg := config.GetFakeConfigTransformers()
-	cfg.ATags.Enable = true
-	cfg.ATags.AddTags = append(cfg.ATags.AddTags, "tag1")
-	cfg.ATags.AddTags = append(cfg.ATags.AddTags, "tag2")
+	cfg := &config.TransformATags{
+		Enable:  true,
+		AddTags: []string{"tag1", "tag2"},
+	}
 
 	// init the processor
 	outChans := []chan *dnsutils.DNSMessageBatch{}

--- a/transformers/bgp.go
+++ b/transformers/bgp.go
@@ -16,20 +16,24 @@ import (
 
 type BGPTransform struct {
 	GenericTransformer
+	config       *config.TransformBGP
 	tree         atomic.Pointer[bgpmrt.BGPRadixTree]
 	cancelReload context.CancelFunc
 	lastModTime  time.Time
 	lastFileSize int64
 }
 
-func NewDNSBGPTransform(cfg *config.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *BGPTransform {
-	t := &BGPTransform{GenericTransformer: NewTransformer(cfg, logger, "bgp", name, instance, nextWorkers)}
+func NewDNSBGPTransform(cfg *config.TransformBGP, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *BGPTransform {
+	t := &BGPTransform{
+		GenericTransformer: NewTransformer(logger, "bgp", name, instance, nextWorkers),
+		config:             cfg,
+	}
 	return t
 }
 
 func (t *BGPTransform) GetTransforms() ([]Subtransform, error) {
 	subtransforms := []Subtransform{}
-	if t.config.BGP.Enable {
+	if t.config.Enable {
 		if err := t.Open(); err != nil {
 			return nil, fmt.Errorf("open error %w", err)
 		}
@@ -39,7 +43,7 @@ func (t *BGPTransform) GetTransforms() ([]Subtransform, error) {
 }
 
 func (t *BGPTransform) Reset() {
-	if t.config.BGP.Enable {
+	if t.config.Enable {
 		t.Close()
 	}
 }
@@ -47,7 +51,7 @@ func (t *BGPTransform) Reset() {
 func (t *BGPTransform) Open() error {
 	t.Close()
 
-	if len(t.config.BGP.MrtFile) == 0 {
+	if len(t.config.MrtFile) == 0 {
 		return fmt.Errorf("bgp mrt-file path is required")
 	}
 
@@ -56,7 +60,7 @@ func (t *BGPTransform) Open() error {
 	}
 
 	// Start background housekeeping loop for auto-reloading if configured
-	if t.config.BGP.MrtCheckUpdateInterval > 0 {
+	if t.config.MrtCheckUpdateInterval > 0 {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.cancelReload = cancel
 		go t.watchMRTFile(ctx)
@@ -73,13 +77,13 @@ func (t *BGPTransform) Close() {
 }
 
 func (t *BGPTransform) loadMRTFile() error {
-	fileInfo, err := os.Stat(t.config.BGP.MrtFile)
+	fileInfo, err := os.Stat(t.config.MrtFile)
 	if err != nil {
 		return fmt.Errorf("failed to stat MRT file: %w", err)
 	}
 
 	parser := bgpmrt.NewMRTParser()
-	tree, err := parser.ParseFile(t.config.BGP.MrtFile)
+	tree, err := parser.ParseFile(t.config.MrtFile)
 	if err != nil {
 		return fmt.Errorf("failed to parse MRT file: %w", err)
 	}
@@ -88,12 +92,12 @@ func (t *BGPTransform) loadMRTFile() error {
 	t.lastModTime = fileInfo.ModTime()
 	t.lastFileSize = fileInfo.Size()
 
-	t.LogInfo("MRT file loaded (%d prefixes from %s)", tree.TotalPrefixes(), t.config.BGP.MrtFile)
+	t.LogInfo("MRT file loaded (%d prefixes from %s)", tree.TotalPrefixes(), t.config.MrtFile)
 	return nil
 }
 
 func (t *BGPTransform) watchMRTFile(ctx context.Context) {
-	interval := time.Duration(t.config.BGP.MrtCheckUpdateInterval) * time.Second
+	interval := time.Duration(t.config.MrtCheckUpdateInterval) * time.Second
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
@@ -102,7 +106,7 @@ func (t *BGPTransform) watchMRTFile(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			fileInfo, err := os.Stat(t.config.BGP.MrtFile)
+			fileInfo, err := os.Stat(t.config.MrtFile)
 			if err != nil {
 				t.LogError("failed to check MRT file update: %v", err)
 				continue
@@ -138,7 +142,7 @@ func (t *BGPTransform) bgpTransform(dm *dnsutils.DNSMessage) (int, error) {
 	var parsedIP net.IP
 
 	// Lookup ECS IP if enabled and present
-	if t.config.BGP.LookupECS && len(dm.EDNS.Options) > 0 {
+	if t.config.LookupECS && len(dm.EDNS.Options) > 0 {
 		parsedIP = lookupECSIP(dm)
 	}
 
@@ -148,23 +152,23 @@ func (t *BGPTransform) bgpTransform(dm *dnsutils.DNSMessage) (int, error) {
 
 	rec := t.Lookup(parsedIP)
 	if rec != nil {
-		if t.config.BGP.OriginASN {
+		if t.config.OriginASN {
 			dm.BGP.OriginASN = rec.OriginASN
 		}
-		if t.config.BGP.ASPath {
+		if t.config.ASPath {
 			dm.BGP.ASPath = rec.ASPath
 		}
-		if t.config.BGP.Prefix {
+		if t.config.Prefix {
 			dm.BGP.Prefix = rec.Prefix
 		}
 	} else {
-		if t.config.BGP.OriginASN {
+		if t.config.OriginASN {
 			dm.BGP.OriginASN = "-"
 		}
-		if t.config.BGP.ASPath {
+		if t.config.ASPath {
 			dm.BGP.ASPath = "-"
 		}
-		if t.config.BGP.Prefix {
+		if t.config.Prefix {
 			dm.BGP.Prefix = "-"
 		}
 	}

--- a/transformers/bgp_test.go
+++ b/transformers/bgp_test.go
@@ -161,10 +161,11 @@ func Test_BGP_AutoReload(t *testing.T) {
 	_ = bgpmrt.WriteSampleMRT(f, initialRoutes)
 	f.Close()
 
-	cfg := config.GetFakeConfigTransformers()
-	cfg.BGP.Enable = true
-	cfg.BGP.MrtFile = mrtPath
-	cfg.BGP.MrtCheckUpdateInterval = 1 // Check every 1 second
+	cfg := &config.TransformBGP{
+		Enable:                 true,
+		MrtFile:                mrtPath,
+		MrtCheckUpdateInterval: 1, // Check every 1 second
+	}
 
 	bgpTrans := NewDNSBGPTransform(cfg, logger.New(false), "test-reload", 0, nil)
 	if err := bgpTrans.Open(); err != nil {

--- a/transformers/extract.go
+++ b/transformers/extract.go
@@ -15,29 +15,28 @@ type ExtractorFunc func(dm *dnsutils.DNSMessage) (interface{}, bool)
 
 type ExtractTransform struct {
 	GenericTransformer
+	config           *config.TransformExtract
 	base64Extractors []ExtractorFunc
 	hexExtractors    []ExtractorFunc
 }
 
-func NewExtractTransform(cfg *config.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *ExtractTransform {
-	t := &ExtractTransform{GenericTransformer: NewTransformer(cfg, logger, "extract", name, instance, nextWorkers)}
+func NewExtractTransform(cfg *config.TransformExtract, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *ExtractTransform {
+	t := &ExtractTransform{
+		GenericTransformer: NewTransformer(logger, "extract", name, instance, nextWorkers),
+		config:             cfg,
+	}
 	t.initExtractors()
 	return t
 }
 
-func (t *ExtractTransform) ReloadConfig(cfg *config.ConfigTransformers) {
-	t.GenericTransformer.ReloadConfig(cfg)
-	t.initExtractors()
-}
-
 func (t *ExtractTransform) initExtractors() {
-	t.base64Extractors = make([]ExtractorFunc, len(t.config.Extract.Base64Fields))
-	for i, field := range t.config.Extract.Base64Fields {
+	t.base64Extractors = make([]ExtractorFunc, len(t.config.Base64Fields))
+	for i, field := range t.config.Base64Fields {
 		t.base64Extractors[i] = getExtractor(field)
 	}
 
-	t.hexExtractors = make([]ExtractorFunc, len(t.config.Extract.HexFields))
-	for i, field := range t.config.Extract.HexFields {
+	t.hexExtractors = make([]ExtractorFunc, len(t.config.HexFields))
+	for i, field := range t.config.HexFields {
 		t.hexExtractors[i] = getExtractor(field)
 	}
 }
@@ -84,13 +83,13 @@ func getExtractor(tag string) ExtractorFunc {
 
 func (t *ExtractTransform) GetTransforms() ([]Subtransform, error) {
 	subtransforms := []Subtransform{}
-	if t.config.Extract.AddPayload {
+	if t.config.AddPayload {
 		subtransforms = append(subtransforms, Subtransform{name: "extract:add-base64payload", processFunc: t.addBase64Payload})
 	}
-	if len(t.config.Extract.Base64Fields) > 0 {
+	if len(t.config.Base64Fields) > 0 {
 		subtransforms = append(subtransforms, Subtransform{name: "extract:base64-fields", processFunc: t.addBase64Fields})
 	}
-	if len(t.config.Extract.HexFields) > 0 {
+	if len(t.config.HexFields) > 0 {
 		subtransforms = append(subtransforms, Subtransform{name: "extract:hex-fields", processFunc: t.addHexFields})
 	}
 	return subtransforms, nil
@@ -130,10 +129,10 @@ func (t *ExtractTransform) addBase64Fields(dm *dnsutils.DNSMessage) (int, error)
 		dm.Extracted = &dnsutils.TransformExtracted{}
 	}
 	if dm.Extracted.Base64Fields == nil {
-		dm.Extracted.Base64Fields = make(map[string]interface{}, len(t.config.Extract.Base64Fields))
+		dm.Extracted.Base64Fields = make(map[string]interface{}, len(t.config.Base64Fields))
 	}
 
-	for i, field := range t.config.Extract.Base64Fields {
+	for i, field := range t.config.Base64Fields {
 		extractor := t.base64Extractors[i]
 		if val, found := extractor(dm); found {
 			switch v := val.(type) {
@@ -186,10 +185,10 @@ func (t *ExtractTransform) addHexFields(dm *dnsutils.DNSMessage) (int, error) {
 		dm.Extracted = &dnsutils.TransformExtracted{}
 	}
 	if dm.Extracted.HexFields == nil {
-		dm.Extracted.HexFields = make(map[string]interface{}, len(t.config.Extract.HexFields))
+		dm.Extracted.HexFields = make(map[string]interface{}, len(t.config.HexFields))
 	}
 
-	for i, field := range t.config.Extract.HexFields {
+	for i, field := range t.config.HexFields {
 		extractor := t.hexExtractors[i]
 		if val, found := extractor(dm); found {
 			switch v := val.(type) {

--- a/transformers/extract_bench_test.go
+++ b/transformers/extract_bench_test.go
@@ -9,10 +9,11 @@ import (
 )
 
 func BenchmarkExtract_AddBase64AndHexFields(b *testing.B) {
-	cfg := config.GetFakeConfigTransformers()
-	cfg.Extract.Enable = true
-	cfg.Extract.Base64Fields = []string{"dns.qname", "network.query-ip"}
-	cfg.Extract.HexFields = []string{"dns.qname", "network.query-ip"}
+	cfg := &config.TransformExtract{
+		Enable:       true,
+		Base64Fields: []string{"dns.qname", "network.query-ip"},
+		HexFields:    []string{"dns.qname", "network.query-ip"},
+	}
 
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 	extract := NewExtractTransform(cfg, logger.New(false), "test", 0, outChans)
@@ -31,9 +32,10 @@ func BenchmarkExtract_AddBase64AndHexFields(b *testing.B) {
 }
 
 func BenchmarkExtract_AddBase64Payload(b *testing.B) {
-	cfg := config.GetFakeConfigTransformers()
-	cfg.Extract.Enable = true
-	cfg.Extract.AddPayload = true
+	cfg := &config.TransformExtract{
+		Enable:     true,
+		AddPayload: true,
+	}
 
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 	extract := NewExtractTransform(cfg, logger.New(false), "test", 0, outChans)

--- a/transformers/extract_test.go
+++ b/transformers/extract_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestExtract_Json(t *testing.T) {
 	// enable feature
-	cfg := config.GetFakeConfigTransformers()
+	cfg := &config.TransformExtract{}
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 	outChans = append(outChans, make(chan *dnsutils.DNSMessageBatch, 1))
 
@@ -66,10 +66,11 @@ func TestExtract_Base64AndHexFields(t *testing.T) {
 	// the Data Extractor can still provide the original raw bytes via Base64 or Hex encoding.
 
 	// enable feature
-	cfg := config.GetFakeConfigTransformers()
-	cfg.Extract.Enable = true
-	cfg.Extract.Base64Fields = []string{"dns.qname"}
-	cfg.Extract.HexFields = []string{"dns.qname"}
+	cfg := &config.TransformExtract{
+		Enable:       true,
+		Base64Fields: []string{"dns.qname"},
+		HexFields:    []string{"dns.qname"},
+	}
 
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 	outChans = append(outChans, make(chan *dnsutils.DNSMessageBatch, 1))
@@ -122,10 +123,11 @@ func TestExtract_Base64AndHexFields(t *testing.T) {
 
 func TestExtract_WildcardSliceFields(t *testing.T) {
 	// enable feature
-	cfg := config.GetFakeConfigTransformers()
-	cfg.Extract.Enable = true
-	cfg.Extract.Base64Fields = []string{"dns.resource-records.an.*.rdata"}
-	cfg.Extract.HexFields = []string{"dns.resource-records.an.*.rdata"}
+	cfg := &config.TransformExtract{
+		Enable:       true,
+		Base64Fields: []string{"dns.resource-records.an.*.rdata"},
+		HexFields:    []string{"dns.resource-records.an.*.rdata"},
+	}
 
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 	outChans = append(outChans, make(chan *dnsutils.DNSMessageBatch, 1))

--- a/transformers/filtering.go
+++ b/transformers/filtering.go
@@ -15,6 +15,7 @@ import (
 
 type FilteringTransform struct {
 	GenericTransformer
+	config                                 *config.TransformFiltering
 	mapRcodes                              map[string]bool
 	ipsetDrop, ipsetKeep, rDataIpsetKeep   *netaddr.IPSet
 	listFqdns, listKeepFqdns               map[string]bool
@@ -23,8 +24,11 @@ type FilteringTransform struct {
 	downsample, downsampleCount            int
 }
 
-func NewFilteringTransform(cfg *config.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *FilteringTransform {
-	t := &FilteringTransform{GenericTransformer: NewTransformer(cfg, logger, "filtering", name, instance, nextWorkers)}
+func NewFilteringTransform(cfg *config.TransformFiltering, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *FilteringTransform {
+	t := &FilteringTransform{
+		GenericTransformer: NewTransformer(logger, "filtering", name, instance, nextWorkers),
+		config:             cfg,
+	}
 	t.mapRcodes = make(map[string]bool)
 	t.ipsetDrop = &netaddr.IPSet{}
 	t.ipsetKeep = &netaddr.IPSet{}
@@ -52,22 +56,22 @@ func (t *FilteringTransform) GetTransforms() ([]Subtransform, error) {
 		return nil, err
 	}
 
-	if !t.config.Filtering.LogQueries {
+	if !t.config.LogQueries {
 		subtransforms = append(subtransforms, Subtransform{name: "filtering:drop-queries", processFunc: t.dropQueryFilter})
 	}
-	if !t.config.Filtering.LogReplies {
+	if !t.config.LogReplies {
 		subtransforms = append(subtransforms, Subtransform{name: "filtering:drop-replies", processFunc: t.dropReplyFilter})
 	}
 	if len(t.mapRcodes) > 0 {
 		subtransforms = append(subtransforms, Subtransform{name: "filtering:drop-rcode", processFunc: t.dropRCodeFilter})
 	}
-	if len(t.config.Filtering.KeepQueryIPFile) > 0 {
+	if len(t.config.KeepQueryIPFile) > 0 {
 		subtransforms = append(subtransforms, Subtransform{name: "filtering:keep-queryip", processFunc: t.keepQueryIPFilter})
 	}
-	if len(t.config.Filtering.DropQueryIPFile) > 0 {
+	if len(t.config.DropQueryIPFile) > 0 {
 		subtransforms = append(subtransforms, Subtransform{name: "filtering:drop-queryip", processFunc: t.dropQueryIPFilter})
 	}
-	if len(t.config.Filtering.KeepRdataFile) > 0 {
+	if len(t.config.KeepRdataFile) > 0 {
 		subtransforms = append(subtransforms, Subtransform{name: "filtering:keep-rdata", processFunc: t.keepRdataFilter})
 	}
 	if len(t.listFqdns) > 0 {
@@ -82,8 +86,8 @@ func (t *FilteringTransform) GetTransforms() ([]Subtransform, error) {
 	if len(t.listKeepDomainsRegex) > 0 {
 		subtransforms = append(subtransforms, Subtransform{name: "filtering:keep-domain", processFunc: t.keepDomainRegexFilter})
 	}
-	if t.config.Filtering.Downsample > 0 {
-		t.downsample = t.config.Filtering.Downsample
+	if t.config.Downsample > 0 {
+		t.downsample = t.config.Downsample
 		t.downsampleCount = 0
 		subtransforms = append(subtransforms, Subtransform{name: "filtering:downsampling", processFunc: t.downsampleFilter})
 	}
@@ -97,7 +101,7 @@ func (t *FilteringTransform) LoadRcodes() error {
 	}
 
 	// add
-	for _, v := range t.config.Filtering.DropRcodes {
+	for _, v := range t.config.DropRcodes {
 		t.mapRcodes[v] = true
 	}
 	return nil
@@ -107,16 +111,16 @@ func (t *FilteringTransform) LoadQueryIPList() error {
 	t.ipsetDrop = nil
 	t.ipsetKeep = nil
 
-	if len(t.config.Filtering.DropQueryIPFile) > 0 {
-		read, err := t.loadQueryIPList(t.config.Filtering.DropQueryIPFile, true)
+	if len(t.config.DropQueryIPFile) > 0 {
+		read, err := t.loadQueryIPList(t.config.DropQueryIPFile, true)
 		if err != nil {
 			return fmt.Errorf("unable to open query ip file: %w", err)
 		}
 		t.LogInfo("loaded with %d query ip to the drop list", read)
 	}
 
-	if len(t.config.Filtering.KeepQueryIPFile) > 0 {
-		read, err := t.loadQueryIPList(t.config.Filtering.KeepQueryIPFile, false)
+	if len(t.config.KeepQueryIPFile) > 0 {
+		read, err := t.loadQueryIPList(t.config.KeepQueryIPFile, false)
 		if err != nil {
 			return fmt.Errorf("unable to open query ip file: %w", err)
 		}
@@ -128,8 +132,8 @@ func (t *FilteringTransform) LoadQueryIPList() error {
 func (t *FilteringTransform) LoadrDataIPList() error {
 	t.rDataIpsetKeep = nil
 
-	if len(t.config.Filtering.KeepRdataFile) > 0 {
-		read, err := t.loadKeepRdataIPList(t.config.Filtering.KeepRdataFile)
+	if len(t.config.KeepRdataFile) > 0 {
+		read, err := t.loadKeepRdataIPList(t.config.KeepRdataFile)
 		if err != nil {
 			return fmt.Errorf("unable to open rdata ip file: %w", err)
 		}
@@ -153,8 +157,8 @@ func (t *FilteringTransform) LoadDomainsList() error {
 		delete(t.listKeepDomainsRegex, key)
 	}
 
-	if len(t.config.Filtering.DropFqdnFile) > 0 {
-		file, err := os.Open(t.config.Filtering.DropFqdnFile)
+	if len(t.config.DropFqdnFile) > 0 {
+		file, err := os.Open(t.config.DropFqdnFile)
 		if err != nil {
 			return fmt.Errorf("unable to open fqdn file: %w", err)
 		} else {
@@ -169,8 +173,8 @@ func (t *FilteringTransform) LoadDomainsList() error {
 
 	}
 
-	if len(t.config.Filtering.DropDomainFile) > 0 {
-		file, err := os.Open(t.config.Filtering.DropDomainFile)
+	if len(t.config.DropDomainFile) > 0 {
+		file, err := os.Open(t.config.DropDomainFile)
 		if err != nil {
 			return fmt.Errorf("unable to open regex list file: %w", err)
 		} else {
@@ -184,8 +188,8 @@ func (t *FilteringTransform) LoadDomainsList() error {
 		}
 	}
 
-	if len(t.config.Filtering.KeepFqdnFile) > 0 {
-		file, err := os.Open(t.config.Filtering.KeepFqdnFile)
+	if len(t.config.KeepFqdnFile) > 0 {
+		file, err := os.Open(t.config.KeepFqdnFile)
 		if err != nil {
 			return fmt.Errorf("unable to open KeepFqdnFile file: %w", err)
 		} else {
@@ -198,8 +202,8 @@ func (t *FilteringTransform) LoadDomainsList() error {
 		}
 	}
 
-	if len(t.config.Filtering.KeepDomainFile) > 0 {
-		file, err := os.Open(t.config.Filtering.KeepDomainFile)
+	if len(t.config.KeepDomainFile) > 0 {
+		file, err := os.Open(t.config.KeepDomainFile)
 		if err != nil {
 			return fmt.Errorf("unable to open KeepDomainFile file: %w", err)
 		} else {

--- a/transformers/filtering_bench_test.go
+++ b/transformers/filtering_bench_test.go
@@ -28,7 +28,7 @@ func BenchmarkFiltering_DropDomainRegex(b *testing.B) {
 	cfg.Filtering.DropDomainFile = tmpFile.Name()
 
 	outChans := []chan *dnsutils.DNSMessageBatch{}
-	filtering := NewFilteringTransform(cfg, logger.New(false), "test", 0, outChans)
+	filtering := NewFilteringTransform(&cfg.Filtering, logger.New(false), "test", 0, outChans)
 	_, _ = filtering.GetTransforms()
 
 	dm := dnsutils.GetFakeDNSMessage()

--- a/transformers/filtering_test.go
+++ b/transformers/filtering_test.go
@@ -23,7 +23,7 @@ func TestFilteringQR(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	filtering := NewFilteringTransform(cfg, logger.New(false), "test", 0, outChans)
+	filtering := NewFilteringTransform(&cfg.Filtering, logger.New(false), "test", 0, outChans)
 
 	// get transforms
 	subtransforms, _ := filtering.GetTransforms()
@@ -51,7 +51,7 @@ func TestFilteringByRcodeNOERROR(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	filtering := NewFilteringTransform(cfg, logger.New(false), "test", 0, outChans)
+	filtering := NewFilteringTransform(&cfg.Filtering, logger.New(false), "test", 0, outChans)
 
 	// get transforms
 	subtransforms, _ := filtering.GetTransforms()
@@ -74,7 +74,7 @@ func TestFilteringByRcodeEmpty(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	filtering := NewFilteringTransform(cfg, logger.New(false), "test", 0, outChans)
+	filtering := NewFilteringTransform(&cfg.Filtering, logger.New(false), "test", 0, outChans)
 
 	// get transforms
 	subtransforms, _ := filtering.GetTransforms()
@@ -92,7 +92,7 @@ func TestFilteringByKeepQueryIp(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	filtering := NewFilteringTransform(cfg, logger.New(false), "test", 0, outChans)
+	filtering := NewFilteringTransform(&cfg.Filtering, logger.New(false), "test", 0, outChans)
 
 	// get transforms
 	subtransforms, _ := filtering.GetTransforms()
@@ -139,7 +139,7 @@ func TestFilteringByBothDropAndKeepQueryIp(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	filtering := NewFilteringTransform(cfg, logger.New(false), "test", 0, outChans)
+	filtering := NewFilteringTransform(&cfg.Filtering, logger.New(false), "test", 0, outChans)
 
 	// get transforms
 	subtransforms, err := filtering.GetTransforms()
@@ -181,7 +181,7 @@ func TestFilteringByDropQueryIp(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	filtering := NewFilteringTransform(cfg, logger.New(false), "test", 0, outChans)
+	filtering := NewFilteringTransform(&cfg.Filtering, logger.New(false), "test", 0, outChans)
 
 	// get transforms
 	subtransforms, _ := filtering.GetTransforms()
@@ -227,7 +227,7 @@ func TestFilteringByKeepRdataIp(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	filtering := NewFilteringTransform(cfg, logger.New(false), "test", 0, outChans)
+	filtering := NewFilteringTransform(&cfg.Filtering, logger.New(false), "test", 0, outChans)
 
 	// get transforms
 	subtransforms, _ := filtering.GetTransforms()
@@ -326,7 +326,7 @@ func TestFilteringByFqdn(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	filtering := NewFilteringTransform(cfg, logger.New(false), "test", 0, outChans)
+	filtering := NewFilteringTransform(&cfg.Filtering, logger.New(false), "test", 0, outChans)
 
 	// get transforms
 	subtransforms, _ := filtering.GetTransforms()
@@ -355,7 +355,7 @@ func TestFilteringByDomainRegex(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	filtering := NewFilteringTransform(cfg, logger.New(false), "test", 0, outChans)
+	filtering := NewFilteringTransform(&cfg.Filtering, logger.New(false), "test", 0, outChans)
 
 	// get transforms
 	subtransforms, _ := filtering.GetTransforms()
@@ -391,7 +391,7 @@ func TestFilteringByKeepDomain(t *testing.T) {
 	cfg.Filtering.KeepFqdnFile = "../tests/testsdata/filtering_keep_domains.txt"
 
 	// init subprocessor
-	filtering := NewFilteringTransform(cfg, logger.New(false), "test", 0, outChans)
+	filtering := NewFilteringTransform(&cfg.Filtering, logger.New(false), "test", 0, outChans)
 
 	// get transforms
 	subtransforms, _ := filtering.GetTransforms()
@@ -436,7 +436,7 @@ func TestFilteringByKeepDomainRegex(t *testing.T) {
 	cfg.Filtering.KeepDomainFile = "../tests/testsdata/filtering_keep_domains_regex.txt"
 
 	// init subprocessor
-	filtering := NewFilteringTransform(cfg, logger.New(false), "test", 0, outChans)
+	filtering := NewFilteringTransform(&cfg.Filtering, logger.New(false), "test", 0, outChans)
 
 	// get transforms
 	subtransforms, _ := filtering.GetTransforms()
@@ -478,7 +478,7 @@ func TestFilteringMultipleFilters(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	filtering := NewFilteringTransform(cfg, logger.New(false), "test", 0, outChans)
+	filtering := NewFilteringTransform(&cfg.Filtering, logger.New(false), "test", 0, outChans)
 	subtransforms, _ := filtering.GetTransforms()
 
 	if len(subtransforms) != 2 {
@@ -495,7 +495,7 @@ func TestFilteringDownsampleFilter(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init processor
-	filtering := NewFilteringTransform(cfg, logger.New(false), "test", 0, outChans)
+	filtering := NewFilteringTransform(&cfg.Filtering, logger.New(false), "test", 0, outChans)
 
 	// get transform function
 	subtransforms, _ := filtering.GetTransforms()

--- a/transformers/geoip.go
+++ b/transformers/geoip.go
@@ -54,17 +54,18 @@ type GeoRecord struct {
 
 type GeoIPTransform struct {
 	GenericTransformer
+	config                                 *config.TransformGeoIP
 	dbCountry, dbCity, dbAsn, dbCoordinate *maxminddb.Reader
 }
 
-func NewDNSGeoIPTransform(cfg *config.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *GeoIPTransform {
-	t := &GeoIPTransform{GenericTransformer: NewTransformer(cfg, logger, "geoip", name, instance, nextWorkers)}
+func NewDNSGeoIPTransform(cfg *config.TransformGeoIP, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *GeoIPTransform {
+	t := &GeoIPTransform{config: cfg, GenericTransformer: NewTransformer(logger, "geoip", name, instance, nextWorkers)}
 	return t
 }
 
 func (t *GeoIPTransform) GetTransforms() ([]Subtransform, error) {
 	subtransforms := []Subtransform{}
-	if t.config.GeoIP.Enable {
+	if t.config.Enable {
 		if err := t.Open(); err != nil {
 			return nil, fmt.Errorf("open error %w", err)
 		}
@@ -74,7 +75,7 @@ func (t *GeoIPTransform) GetTransforms() ([]Subtransform, error) {
 }
 
 func (t *GeoIPTransform) Reset() {
-	if t.config.GeoIP.Enable {
+	if t.config.Enable {
 		t.Close()
 	}
 }
@@ -85,32 +86,32 @@ func (t *GeoIPTransform) Open() (err error) {
 	t.Close()
 
 	// open files ?
-	if len(t.config.GeoIP.DBCountryFile) > 0 {
-		t.dbCountry, err = maxminddb.Open(t.config.GeoIP.DBCountryFile)
+	if len(t.config.DBCountryFile) > 0 {
+		t.dbCountry, err = maxminddb.Open(t.config.DBCountryFile)
 		if err != nil {
 			return err
 		}
 		t.LogInfo("country database loaded (%d records)", t.dbCountry.Metadata.NodeCount)
 	}
 
-	if len(t.config.GeoIP.DBCityFile) > 0 {
-		t.dbCity, err = maxminddb.Open(t.config.GeoIP.DBCityFile)
+	if len(t.config.DBCityFile) > 0 {
+		t.dbCity, err = maxminddb.Open(t.config.DBCityFile)
 		if err != nil {
 			return err
 		}
 		t.LogInfo("city database loaded (%d records)", t.dbCity.Metadata.NodeCount)
 	}
 
-	if len(t.config.GeoIP.DBASNFile) > 0 {
-		t.dbAsn, err = maxminddb.Open(t.config.GeoIP.DBASNFile)
+	if len(t.config.DBASNFile) > 0 {
+		t.dbAsn, err = maxminddb.Open(t.config.DBASNFile)
 		if err != nil {
 			return err
 		}
 		t.LogInfo("asn database loaded (%d records)", t.dbAsn.Metadata.NodeCount)
 	}
 
-	if len(t.config.GeoIP.DBCoordinateFile) > 0 {
-		t.dbCoordinate, err = maxminddb.Open(t.config.GeoIP.DBCoordinateFile)
+	if len(t.config.DBCoordinateFile) > 0 {
+		t.dbCoordinate, err = maxminddb.Open(t.config.DBCoordinateFile)
 		if err != nil {
 			return err
 		}
@@ -200,7 +201,7 @@ func (t *GeoIPTransform) geoipTransform(dm *dnsutils.DNSMessage) (int, error) {
 	var parsedIP net.IP
 
 	// lookup ecs ip instead of the query ip?
-	if t.config.GeoIP.LookupECS && len(dm.EDNS.Options) > 0 {
+	if t.config.LookupECS && len(dm.EDNS.Options) > 0 {
 		parsedIP = lookupECSIP(dm)
 	}
 

--- a/transformers/geoip_bench_test.go
+++ b/transformers/geoip_bench_test.go
@@ -15,7 +15,7 @@ func BenchmarkGeoIP_Lookup(b *testing.B) {
 	cfg.GeoIP.DBASNFile = "../tests/testsdata/GeoLite2-ASN.mmdb"
 
 	outChans := []chan *dnsutils.DNSMessageBatch{}
-	geoip := NewDNSGeoIPTransform(cfg, logger.New(false), "test", 0, outChans)
+	geoip := NewDNSGeoIPTransform(&cfg.GeoIP, logger.New(false), "test", 0, outChans)
 	if err := geoip.Open(); err != nil {
 		b.Fatalf("geoip init failed: %v", err)
 	}
@@ -37,7 +37,7 @@ func BenchmarkGeoIP_Lookup_ECS(b *testing.B) {
 	cfg.GeoIP.LookupECS = true
 
 	outChans := []chan *dnsutils.DNSMessageBatch{}
-	geoip := NewDNSGeoIPTransform(cfg, logger.New(false), "test", 0, outChans)
+	geoip := NewDNSGeoIPTransform(&cfg.GeoIP, logger.New(false), "test", 0, outChans)
 	if err := geoip.Open(); err != nil {
 		b.Fatalf("geoip init failed: %v", err)
 	}

--- a/transformers/geoip_test.go
+++ b/transformers/geoip_test.go
@@ -21,7 +21,7 @@ func TestGeoIP_Json(t *testing.T) {
 	dm.Init()
 
 	// init subprocessor
-	geoip := NewDNSGeoIPTransform(cfg, logger.New(true), "test", 0, outChans)
+	geoip := NewDNSGeoIPTransform(&cfg.GeoIP, logger.New(true), "test", 0, outChans)
 	if err := geoip.Open(); err != nil {
 		t.Fatalf("geoip init failed: %v+", err)
 	}
@@ -75,7 +75,7 @@ func TestGeoIP_LookupCountry(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
-	geoip := NewDNSGeoIPTransform(cfg, logger.New(false), "test", 0, outChans)
+	geoip := NewDNSGeoIPTransform(&cfg.GeoIP, logger.New(false), "test", 0, outChans)
 	_, err := geoip.GetTransforms()
 	if err != nil {
 		t.Fatalf("geoip init failed: %v+", err)
@@ -110,7 +110,7 @@ func TestGeoIP_LookupAsn(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
-	geoip := NewDNSGeoIPTransform(cfg, logger.New(false), "test", 0, outChans)
+	geoip := NewDNSGeoIPTransform(&cfg.GeoIP, logger.New(false), "test", 0, outChans)
 	if err := geoip.Open(); err != nil {
 		t.Fatalf("geoip init failed: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestGeoIP_Lookup_ECS(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
-	geoip := NewDNSGeoIPTransform(cfg, logger.New(false), "test", 0, outChans)
+	geoip := NewDNSGeoIPTransform(&cfg.GeoIP, logger.New(false), "test", 0, outChans)
 	_, err := geoip.GetTransforms()
 	if err != nil {
 		t.Fatalf("geoip init failed: %v+", err)
@@ -169,7 +169,7 @@ func TestGeoIP_LookupCoordinate(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
-	geoip := NewDNSGeoIPTransform(cfg, logger.New(false), "test", 0, outChans)
+	geoip := NewDNSGeoIPTransform(&cfg.GeoIP, logger.New(false), "test", 0, outChans)
 	if err := geoip.Open(); err != nil {
 		t.Fatalf("geoip init failed: %v", err)
 	}

--- a/transformers/latency.go
+++ b/transformers/latency.go
@@ -112,26 +112,27 @@ func (mp *HashQueries) Delete(key uint64) {
 // latency transformer
 type LatencyTransform struct {
 	GenericTransformer
+	config      *config.TransformLatency
 	hashQueries HashQueries
 	mapQueries  MapQueries
 }
 
-func NewLatencyTransform(cfg *config.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *LatencyTransform {
-	t := &LatencyTransform{GenericTransformer: NewTransformer(cfg, logger, "latency", name, instance, nextWorkers)}
-	t.hashQueries = NewHashQueries(time.Duration(cfg.Latency.QueriesTimeout) * time.Second)
-	t.mapQueries = NewMapQueries(time.Duration(cfg.Latency.QueriesTimeout)*time.Second, nextWorkers)
+func NewLatencyTransform(cfg *config.TransformLatency, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *LatencyTransform {
+	t := &LatencyTransform{config: cfg, GenericTransformer: NewTransformer(logger, "latency", name, instance, nextWorkers)}
+	t.hashQueries = NewHashQueries(time.Duration(cfg.QueriesTimeout) * time.Second)
+	t.mapQueries = NewMapQueries(time.Duration(cfg.QueriesTimeout)*time.Second, nextWorkers)
 	return t
 }
 
 func (t *LatencyTransform) GetTransforms() ([]Subtransform, error) {
-	t.hashQueries.SetTTL(time.Duration(t.config.Latency.QueriesTimeout) * time.Second)
-	t.mapQueries.SetTTL(time.Duration(t.config.Latency.QueriesTimeout) * time.Second)
+	t.hashQueries.SetTTL(time.Duration(t.config.QueriesTimeout) * time.Second)
+	t.mapQueries.SetTTL(time.Duration(t.config.QueriesTimeout) * time.Second)
 
 	subtransforms := []Subtransform{}
-	if t.config.Latency.MeasureLatency {
+	if t.config.MeasureLatency {
 		subtransforms = append(subtransforms, Subtransform{name: "latency:add", processFunc: t.measureLatency})
 	}
-	if t.config.Latency.UnansweredQueries {
+	if t.config.UnansweredQueries {
 		subtransforms = append(subtransforms, Subtransform{name: "latency:timeout", processFunc: t.detectEvictedTimeout})
 	}
 	return subtransforms, nil

--- a/transformers/latency_test.go
+++ b/transformers/latency_test.go
@@ -15,7 +15,7 @@ func TestLatency_MeasureLatencyAndMs(t *testing.T) {
 	outChannels := []chan *dnsutils.DNSMessageBatch{}
 
 	// init transformer
-	latency := NewLatencyTransform(cfg, logger.New(true), "test", 0, outChannels)
+	latency := NewLatencyTransform(&cfg.Latency, logger.New(true), "test", 0, outChannels)
 	latency.GetTransforms()
 
 	testcases := []struct {
@@ -75,7 +75,7 @@ func TestLatency_DetectEvictedTimeout(t *testing.T) {
 	outChannels = append(outChannels, make(chan *dnsutils.DNSMessageBatch, 1))
 
 	// init transformer
-	latency := NewLatencyTransform(cfg, logger.New(true), "test", 0, outChannels)
+	latency := NewLatencyTransform(&cfg.Latency, logger.New(true), "test", 0, outChannels)
 	latency.GetTransforms()
 
 	testcases := []struct {

--- a/transformers/machinelearning.go
+++ b/transformers/machinelearning.go
@@ -23,16 +23,17 @@ func isConsonant(char rune) bool {
 
 type MlTransform struct {
 	GenericTransformer
+	config *config.TransformMachineLearning
 }
 
-func NewMachineLearningTransform(cfg *config.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *MlTransform {
-	t := &MlTransform{GenericTransformer: NewTransformer(cfg, logger, "machinelearning", name, instance, nextWorkers)}
+func NewMachineLearningTransform(cfg *config.TransformMachineLearning, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *MlTransform {
+	t := &MlTransform{config: cfg, GenericTransformer: NewTransformer(logger, "machinelearning", name, instance, nextWorkers)}
 	return t
 }
 
 func (t *MlTransform) GetTransforms() ([]Subtransform, error) {
 	subtransforms := []Subtransform{}
-	if t.config.MachineLearning.Enable {
+	if t.config.Enable {
 		subtransforms = append(subtransforms, Subtransform{name: "machinelearning:add-feature", processFunc: t.addFeatures})
 	}
 	return subtransforms, nil

--- a/transformers/machinelearning_test.go
+++ b/transformers/machinelearning_test.go
@@ -15,7 +15,7 @@ func TestML_AddFeatures(t *testing.T) {
 
 	// init the processor
 	outChans := []chan *dnsutils.DNSMessageBatch{}
-	ml := NewMachineLearningTransform(cfg, logger.New(false), "test", 0, outChans)
+	ml := NewMachineLearningTransform(&cfg.MachineLearning, logger.New(false), "test", 0, outChans)
 
 	dm := dnsutils.GetFakeDNSMessage()
 

--- a/transformers/newdomaintracker.go
+++ b/transformers/newdomaintracker.go
@@ -116,37 +116,38 @@ func (ndt *NewDomainTracker) loadCacheFromDisk() error {
 // NewDomainTransform is the Transformer for DNS messages
 type NewDomainTrackerTransform struct {
 	GenericTransformer
+	config           *config.TransformNewDomainTracker
 	domainTracker    *NewDomainTracker
 	listDomainsRegex map[string]*regexp.Regexp
 }
 
 // NewNewDomainTransform creates a new instance of the transformer
-func NewNewDomainTrackerTransform(cfg *config.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *NewDomainTrackerTransform {
-	t := &NewDomainTrackerTransform{GenericTransformer: NewTransformer(cfg, logger, "new-domain-tracker", name, instance, nextWorkers)}
+func NewNewDomainTrackerTransform(cfg *config.TransformNewDomainTracker, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *NewDomainTrackerTransform {
+	t := &NewDomainTrackerTransform{config: cfg, GenericTransformer: NewTransformer(logger, "new-domain-tracker", name, instance, nextWorkers)}
 	t.listDomainsRegex = make(map[string]*regexp.Regexp)
 	return t
 }
 
 // ReloadConfig reloads the configuration
-func (t *NewDomainTrackerTransform) ReloadConfig(cfg *config.ConfigTransformers) {
-	t.GenericTransformer.ReloadConfig(cfg)
-	ttl := time.Duration(cfg.NewDomainTracker.TTL) * time.Second
+func (t *NewDomainTrackerTransform) ReloadConfig(cfg *config.TransformNewDomainTracker) {
+	t.config = cfg
+	ttl := time.Duration(cfg.TTL) * time.Second
 	t.domainTracker.ttl = ttl
 	t.LogInfo("new-domain-transformer configuration reloaded")
 }
 
 func (t *NewDomainTrackerTransform) GetTransforms() ([]Subtransform, error) {
 	subtransforms := []Subtransform{}
-	if t.config.NewDomainTracker.Enable {
+	if t.config.Enable {
 		// init whitelist
 		if err := t.LoadWhiteDomainsList(); err != nil {
 			return nil, err
 		}
 
 		// Initialize the domain tracker
-		ttl := time.Duration(t.config.NewDomainTracker.TTL) * time.Second
-		maxSize := t.config.NewDomainTracker.CacheSize
-		tracker, err := NewNewDomainTracker(ttl, maxSize, t.listDomainsRegex, t.config.NewDomainTracker.PersistenceFile, t.LogInfo, t.LogError)
+		ttl := time.Duration(t.config.TTL) * time.Second
+		maxSize := t.config.CacheSize
+		tracker, err := NewNewDomainTracker(ttl, maxSize, t.listDomainsRegex, t.config.PersistenceFile, t.LogInfo, t.LogError)
 		if err != nil {
 			return nil, err
 		}
@@ -163,8 +164,8 @@ func (t *NewDomainTrackerTransform) LoadWhiteDomainsList() error {
 		delete(t.listDomainsRegex, key)
 	}
 
-	if len(t.config.NewDomainTracker.WhiteDomainsFile) > 0 {
-		file, err := os.Open(t.config.NewDomainTracker.WhiteDomainsFile)
+	if len(t.config.WhiteDomainsFile) > 0 {
+		file, err := os.Open(t.config.WhiteDomainsFile)
 		if err != nil {
 			return fmt.Errorf("unable to open regex list file: %w", err)
 		} else {
@@ -183,7 +184,7 @@ func (t *NewDomainTrackerTransform) LoadWhiteDomainsList() error {
 // Process processes DNS messages and detects newly observed domains
 func (t *NewDomainTrackerTransform) trackNewDomain(dm *dnsutils.DNSMessage) (int, error) {
 	// Log a warning if the cache is full (before adding the new domain)
-	if t.domainTracker.cache.Len() == t.config.NewDomainTracker.CacheSize {
+	if t.domainTracker.cache.Len() == t.config.CacheSize {
 		return ReturnError, fmt.Errorf("LRU cache is full. Consider increasing cache-size to avoid frequent evictions")
 	}
 

--- a/transformers/newdomaintracker_test.go
+++ b/transformers/newdomaintracker_test.go
@@ -19,7 +19,7 @@ func TestNewDomainTracker_IsNew(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	tracker := NewNewDomainTrackerTransform(cfg, logger.New(false), "test", 0, outChans)
+	tracker := NewNewDomainTrackerTransform(&cfg.NewDomainTracker, logger.New(false), "test", 0, outChans)
 
 	// init transforms
 	_, err := tracker.GetTransforms()
@@ -55,7 +55,7 @@ func TestNewDomainTracker_Whitelist(t *testing.T) {
 
 	// init subprocessor
 	outChans := []chan *dnsutils.DNSMessageBatch{}
-	tracker := NewNewDomainTrackerTransform(cfg, logger.New(false), "test", 0, outChans)
+	tracker := NewNewDomainTrackerTransform(&cfg.NewDomainTracker, logger.New(false), "test", 0, outChans)
 	_, err := tracker.GetTransforms()
 	if err != nil {
 		t.Error("fail to init transform", err)
@@ -85,7 +85,7 @@ func TestNewDomainTracker_LRUCacheFull(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	tracker := NewNewDomainTrackerTransform(cfg, logger.New(false), "test", 0, outChans)
+	tracker := NewNewDomainTrackerTransform(&cfg.NewDomainTracker, logger.New(false), "test", 0, outChans)
 
 	// init transforms
 	_, err := tracker.GetTransforms()

--- a/transformers/normalize.go
+++ b/transformers/normalize.go
@@ -70,31 +70,32 @@ func processRecords(records []dnsutils.DNSAnswer) {
 
 type NormalizeTransform struct {
 	GenericTransformer
+	config *config.TransformNormalize
 }
 
-func NewNormalizeTransform(cfg *config.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *NormalizeTransform {
-	t := &NormalizeTransform{GenericTransformer: NewTransformer(cfg, logger, "normalize", name, instance, nextWorkers)}
+func NewNormalizeTransform(cfg *config.TransformNormalize, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *NormalizeTransform {
+	t := &NormalizeTransform{config: cfg, GenericTransformer: NewTransformer(logger, "normalize", name, instance, nextWorkers)}
 	return t
 }
 
 func (t *NormalizeTransform) GetTransforms() ([]Subtransform, error) {
 	subprocessors := []Subtransform{}
-	if t.config.Normalize.Enable && t.config.Normalize.ReplaceNonPrintable {
+	if t.config.Enable && t.config.ReplaceNonPrintable {
 		subprocessors = append(subprocessors, Subtransform{name: "normalize:qname-replace-nonprintable", processFunc: t.ReplaceNonprintable})
 	}
-	if t.config.Normalize.Enable && t.config.Normalize.RRLowerCase {
+	if t.config.Enable && t.config.RRLowerCase {
 		subprocessors = append(subprocessors, Subtransform{name: "normalize:rr-lowercase", processFunc: t.RRLowercase})
 	}
-	if t.config.Normalize.Enable && t.config.Normalize.QnameLowerCase {
+	if t.config.Enable && t.config.QnameLowerCase {
 		subprocessors = append(subprocessors, Subtransform{name: "normalize:qname-lowercase", processFunc: t.QnameLowercase})
 	}
-	if t.config.Normalize.Enable && t.config.Normalize.QuietText {
+	if t.config.Enable && t.config.QuietText {
 		subprocessors = append(subprocessors, Subtransform{name: "normalize:quiet", processFunc: t.QuietText})
 	}
-	if t.config.Normalize.Enable && t.config.Normalize.AddTld {
+	if t.config.Enable && t.config.AddTld {
 		subprocessors = append(subprocessors, Subtransform{name: "normalize:add-etld", processFunc: t.GetEffectiveTld})
 	}
-	if t.config.Normalize.Enable && t.config.Normalize.AddTldPlusOne {
+	if t.config.Enable && t.config.AddTldPlusOne {
 		subprocessors = append(subprocessors, Subtransform{name: "normalize:add-etld+1", processFunc: t.GetEffectiveTldPlusOne})
 	}
 	return subprocessors, nil

--- a/transformers/normalize_bench_test.go
+++ b/transformers/normalize_bench_test.go
@@ -12,7 +12,7 @@ func BenchmarkNormalize_GetEffectiveTld(b *testing.B) {
 	cfg := config.GetFakeConfigTransformers()
 	channels := []chan *dnsutils.DNSMessageBatch{}
 
-	subprocessor := NewNormalizeTransform(cfg, logger.New(false), "test", 0, channels)
+	subprocessor := NewNormalizeTransform(&cfg.Normalize, logger.New(false), "test", 0, channels)
 	dm := dnsutils.GetFakeDNSMessage()
 	dm.DNS.Qname = "en.wikipedia.org"
 
@@ -27,7 +27,7 @@ func BenchmarkNormalize_GetEffectiveTldPlusOne(b *testing.B) {
 	cfg := config.GetFakeConfigTransformers()
 	channels := []chan *dnsutils.DNSMessageBatch{}
 
-	subprocessor := NewNormalizeTransform(cfg, logger.New(false), "test", 0, channels)
+	subprocessor := NewNormalizeTransform(&cfg.Normalize, logger.New(false), "test", 0, channels)
 	dm := dnsutils.GetFakeDNSMessage()
 	dm.DNS.Qname = "en.wikipedia.org"
 
@@ -42,7 +42,7 @@ func BenchmarkNormalize_QnameLowercase_MixedCase(b *testing.B) {
 	cfg := config.GetFakeConfigTransformers()
 	channels := []chan *dnsutils.DNSMessageBatch{}
 
-	subprocessor := NewNormalizeTransform(cfg, logger.New(false), "test", 0, channels)
+	subprocessor := NewNormalizeTransform(&cfg.Normalize, logger.New(false), "test", 0, channels)
 	dm := dnsutils.GetFakeDNSMessage()
 
 	b.ReportAllocs()
@@ -57,7 +57,7 @@ func BenchmarkNormalize_QnameLowercase_AlreadyLower(b *testing.B) {
 	cfg := config.GetFakeConfigTransformers()
 	channels := []chan *dnsutils.DNSMessageBatch{}
 
-	subprocessor := NewNormalizeTransform(cfg, logger.New(false), "test", 0, channels)
+	subprocessor := NewNormalizeTransform(&cfg.Normalize, logger.New(false), "test", 0, channels)
 	dm := dnsutils.GetFakeDNSMessage()
 
 	b.ReportAllocs()
@@ -72,7 +72,7 @@ func BenchmarkNormalize_RRLowercase_MixedCase(b *testing.B) {
 	cfg := config.GetFakeConfigTransformers()
 	channels := []chan *dnsutils.DNSMessageBatch{}
 
-	transform := NewNormalizeTransform(cfg, logger.New(false), "test", 0, channels)
+	transform := NewNormalizeTransform(&cfg.Normalize, logger.New(false), "test", 0, channels)
 	dm := dnsutils.GetFakeDNSMessage()
 	dm.DNS.DNSRRs.Answers = []dnsutils.DNSAnswer{{Name: "En.Wikipedia.Org", Rdatatype: "CNAME", Rdata: "Target.Domain.Com"}}
 	dm.DNS.DNSRRs.Nameservers = []dnsutils.DNSAnswer{{Name: "Ns1.Domain.Org", Rdatatype: "NS", Rdata: "Ns1.Other.Com"}}
@@ -94,7 +94,7 @@ func BenchmarkNormalize_RRLowercase_AlreadyLower(b *testing.B) {
 	cfg := config.GetFakeConfigTransformers()
 	channels := []chan *dnsutils.DNSMessageBatch{}
 
-	transform := NewNormalizeTransform(cfg, logger.New(false), "test", 0, channels)
+	transform := NewNormalizeTransform(&cfg.Normalize, logger.New(false), "test", 0, channels)
 	dm := dnsutils.GetFakeDNSMessage()
 	dm.DNS.DNSRRs.Answers = []dnsutils.DNSAnswer{{Name: "en.wikipedia.org", Rdatatype: "CNAME", Rdata: "target.domain.com"}}
 	dm.DNS.DNSRRs.Nameservers = []dnsutils.DNSAnswer{{Name: "ns1.domain.org", Rdatatype: "NS", Rdata: "ns1.other.com"}}
@@ -111,7 +111,7 @@ func BenchmarkNormalize_QuietText(b *testing.B) {
 	cfg := config.GetFakeConfigTransformers()
 	channels := []chan *dnsutils.DNSMessageBatch{}
 
-	subprocessor := NewNormalizeTransform(cfg, logger.New(false), "test", 0, channels)
+	subprocessor := NewNormalizeTransform(&cfg.Normalize, logger.New(false), "test", 0, channels)
 	dm := dnsutils.GetFakeDNSMessage()
 	dm.DNS.Qname = "EN.Wikipedia.Org"
 
@@ -126,7 +126,7 @@ func BenchmarkNormalize_ReplaceNonprintable_Printable(b *testing.B) {
 	cfg := config.GetFakeConfigTransformers()
 	channels := []chan *dnsutils.DNSMessageBatch{}
 
-	subprocessor := NewNormalizeTransform(cfg, logger.New(false), "test", 0, channels)
+	subprocessor := NewNormalizeTransform(&cfg.Normalize, logger.New(false), "test", 0, channels)
 	dm := dnsutils.GetFakeDNSMessage()
 
 	b.ReportAllocs()
@@ -141,7 +141,7 @@ func BenchmarkNormalize_ReplaceNonprintable_WithSpecial(b *testing.B) {
 	cfg := config.GetFakeConfigTransformers()
 	channels := []chan *dnsutils.DNSMessageBatch{}
 
-	subprocessor := NewNormalizeTransform(cfg, logger.New(false), "test", 0, channels)
+	subprocessor := NewNormalizeTransform(&cfg.Normalize, logger.New(false), "test", 0, channels)
 	dm := dnsutils.GetFakeDNSMessage()
 
 	b.ReportAllocs()

--- a/transformers/normalize_test.go
+++ b/transformers/normalize_test.go
@@ -18,7 +18,7 @@ func TestNormalize_LowercaseQname(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
-	normTransformer := NewNormalizeTransform(cfg, logger.New(false), "test", 0, outChans)
+	normTransformer := NewNormalizeTransform(&cfg.Normalize, logger.New(false), "test", 0, outChans)
 
 	qname := "www.Google.Com"
 	dm := dnsutils.GetFakeDNSMessage()
@@ -45,7 +45,7 @@ func TestNormalize_RRLowercaseQname(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
-	normTransformer := NewNormalizeTransform(cfg, logger.New(false), "test", 0, outChans)
+	normTransformer := NewNormalizeTransform(&cfg.Normalize, logger.New(false), "test", 0, outChans)
 
 	// create DNSMessage with answers
 	rrqname := "www.RRGoogle.Com"
@@ -87,7 +87,7 @@ func TestNormalize_QuietText(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
-	norm := NewNormalizeTransform(cfg, logger.New(false), "test", 0, outChans)
+	norm := NewNormalizeTransform(&cfg.Normalize, logger.New(false), "test", 0, outChans)
 
 	dm := dnsutils.GetFakeDNSMessage()
 	norm.QuietText(&dm)
@@ -110,7 +110,7 @@ func TestNormalize_AddTLD(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
-	psl := NewNormalizeTransform(cfg, logger.New(false), "test", 0, outChans)
+	psl := NewNormalizeTransform(&cfg.Normalize, logger.New(false), "test", 0, outChans)
 
 	tt := []struct {
 		name  string
@@ -160,7 +160,7 @@ func TestNormalize_AddTldPlusOne(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
-	psl := NewNormalizeTransform(cfg, logger.New(false), "test", 0, outChans)
+	psl := NewNormalizeTransform(&cfg.Normalize, logger.New(false), "test", 0, outChans)
 
 	tt := []struct {
 		name  string
@@ -202,7 +202,7 @@ func TestNormalize_SuffixUnmanaged(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
-	psl := NewNormalizeTransform(cfg, logger.New(true), "test", 0, outChans)
+	psl := NewNormalizeTransform(&cfg.Normalize, logger.New(true), "test", 0, outChans)
 
 	dm := dnsutils.GetFakeDNSMessage()
 	// https://publicsuffix.org/list/effective_tld_names.dat
@@ -227,7 +227,7 @@ func TestNormalize_SuffixICANNManaged(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
-	psl := NewNormalizeTransform(cfg, logger.New(true), "test", 0, outChans)
+	psl := NewNormalizeTransform(&cfg.Normalize, logger.New(true), "test", 0, outChans)
 
 	dm := dnsutils.GetFakeDNSMessage()
 	// https://publicsuffix.org/list/effective_tld_names.dat
@@ -251,7 +251,7 @@ func TestNormalize_ReplaceNonprintable(t *testing.T) {
 	cfg.Normalize.ReplaceNonPrintable = true
 
 	outChans := []chan *dnsutils.DNSMessageBatch{}
-	norm := NewNormalizeTransform(cfg, logger.New(false), "test", 0, outChans)
+	norm := NewNormalizeTransform(&cfg.Normalize, logger.New(false), "test", 0, outChans)
 
 	tests := []struct {
 		name     string

--- a/transformers/reducer.go
+++ b/transformers/reducer.go
@@ -263,14 +263,15 @@ func appendField(f fieldSpec, dm *dnsutils.DNSMessage, buf []byte) []byte {
 
 type ReducerTransform struct {
 	GenericTransformer
+	config     *config.TransformReducer
 	mapTraffic *MapTraffic
 	fields     []fieldSpec
 }
 
-func NewReducerTransform(cfg *config.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *ReducerTransform {
-	t := &ReducerTransform{GenericTransformer: NewTransformer(cfg, logger, "reducer", name, instance, nextWorkers)}
-	t.mapTraffic = NewMapTraffic(time.Duration(cfg.Reducer.WatchInterval)*time.Second, nextWorkers, t.LogInfo, t.LogError)
-	t.initFields(cfg.Reducer.UniqueFields)
+func NewReducerTransform(cfg *config.TransformReducer, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *ReducerTransform {
+	t := &ReducerTransform{config: cfg, GenericTransformer: NewTransformer(logger, "reducer", name, instance, nextWorkers)}
+	t.mapTraffic = NewMapTraffic(time.Duration(cfg.WatchInterval)*time.Second, nextWorkers, t.LogInfo, t.LogError)
+	t.initFields(cfg.UniqueFields)
 	return t
 }
 
@@ -281,16 +282,16 @@ func (t *ReducerTransform) initFields(fields []string) {
 	}
 }
 
-func (t *ReducerTransform) ReloadConfig(cfg *config.ConfigTransformers) {
-	t.GenericTransformer.ReloadConfig(cfg)
-	t.mapTraffic.SetTTL(time.Duration(cfg.Reducer.WatchInterval) * time.Second)
-	t.initFields(cfg.Reducer.UniqueFields)
+func (t *ReducerTransform) ReloadConfig(cfg *config.TransformReducer) {
+	t.config = cfg
+	t.mapTraffic.SetTTL(time.Duration(cfg.WatchInterval) * time.Second)
+	t.initFields(cfg.UniqueFields)
 	t.GetTransforms()
 }
 
 func (t *ReducerTransform) GetTransforms() ([]Subtransform, error) {
 	subtransforms := []Subtransform{}
-	if t.config.Reducer.RepetitiveTrafficDetector {
+	if t.config.RepetitiveTrafficDetector {
 		subtransforms = append(subtransforms, Subtransform{name: "reducer", processFunc: t.repetitiveTrafficDetector})
 		go t.mapTraffic.Run()
 	}
@@ -303,7 +304,7 @@ func (t *ReducerTransform) repetitiveTrafficDetector(dm *dnsutils.DNSMessage) (i
 	}
 
 	// update qname ?
-	if t.config.Reducer.QnamePlusOne {
+	if t.config.QnamePlusOne {
 		qname := strings.ToLower(dm.DNS.Qname)
 		qname = strings.TrimSuffix(qname, ".")
 		if etld, err := publicsuffixlist.EffectiveTLDPlusOne(qname); err == nil {

--- a/transformers/reducer_bench_test.go
+++ b/transformers/reducer_bench_test.go
@@ -18,7 +18,7 @@ func BenchmarkReducer_RepetitiveTrafficDetector(b *testing.B) {
 	cfg.Reducer.UniqueFields = []string{"dns.qname", "dns.qtype", "network.query-ip"}
 
 	outChan := make(chan *dnsutils.DNSMessageBatch, 100000)
-	reducer := NewReducerTransform(cfg, logger.New(false), "test", 0, []chan *dnsutils.DNSMessageBatch{outChan})
+	reducer := NewReducerTransform(&cfg.Reducer, logger.New(false), "test", 0, []chan *dnsutils.DNSMessageBatch{outChan})
 
 	dm := dnsutils.DNSMessage{
 		DNSTap:      dnsutils.DNSTap{Operation: "CLIENT_QUERY"},
@@ -41,7 +41,7 @@ func BenchmarkReducer_RepetitiveTrafficDetectorParallel(b *testing.B) {
 	cfg.Reducer.UniqueFields = []string{"dns.qname", "dns.qtype", "network.query-ip"}
 
 	outChan := make(chan *dnsutils.DNSMessageBatch, 1000000)
-	reducer := NewReducerTransform(cfg, logger.New(false), "test", 0, []chan *dnsutils.DNSMessageBatch{outChan})
+	reducer := NewReducerTransform(&cfg.Reducer, logger.New(false), "test", 0, []chan *dnsutils.DNSMessageBatch{outChan})
 
 	dm := dnsutils.DNSMessage{
 		DNSTap:      dnsutils.DNSTap{Operation: "CLIENT_QUERY"},

--- a/transformers/reducer_test.go
+++ b/transformers/reducer_test.go
@@ -23,7 +23,7 @@ func TestReducer_Json(t *testing.T) {
 
 	// init subprocessor
 
-	reducer := NewReducerTransform(cfg, logger.New(false), "test", 0, outChans)
+	reducer := NewReducerTransform(&cfg.Reducer, logger.New(false), "test", 0, outChans)
 	reducer.repetitiveTrafficDetector(&dm)
 
 	// expected json
@@ -68,7 +68,7 @@ func TestReducer_RepetitiveTrafficDetector(t *testing.T) {
 	outChans = append(outChans, outChan)
 
 	// init subprocessor
-	reducer := NewReducerTransform(cfg, logger.New(false), "test", 0, outChans)
+	reducer := NewReducerTransform(&cfg.Reducer, logger.New(false), "test", 0, outChans)
 	subtransforms, _ := reducer.GetTransforms()
 	if len(subtransforms) != 1 {
 		t.Errorf("invalid number of subtransforms enabled")
@@ -212,7 +212,7 @@ func TestReducer_QnamePlusOne(t *testing.T) {
 	outChans = append(outChans, outChan)
 
 	// init subprocessor
-	reducer := NewReducerTransform(cfg, logger.New(false), "test", 0, outChans)
+	reducer := NewReducerTransform(&cfg.Reducer, logger.New(false), "test", 0, outChans)
 	subtransforms, _ := reducer.GetTransforms()
 	if len(subtransforms) != 1 {
 		t.Errorf("invalid number of subtransforms enabled")

--- a/transformers/relabeling.go
+++ b/transformers/relabeling.go
@@ -10,17 +10,18 @@ import (
 
 type RelabelTransform struct {
 	GenericTransformer
+	config          *config.TransformRelabeling
 	RelabelingRules []dnsutils.RelabelingRule
 }
 
-func NewRelabelTransform(cfg *config.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *RelabelTransform {
-	t := &RelabelTransform{GenericTransformer: NewTransformer(cfg, logger, "relabeling", name, instance, nextWorkers)}
+func NewRelabelTransform(cfg *config.TransformRelabeling, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *RelabelTransform {
+	t := &RelabelTransform{config: cfg, GenericTransformer: NewTransformer(logger, "relabeling", name, instance, nextWorkers)}
 	return t
 }
 
 func (t *RelabelTransform) GetTransforms() ([]Subtransform, error) {
 	subtransforms := []Subtransform{}
-	if len(t.config.Relabeling.Rename) > 0 || len(t.config.Relabeling.Remove) > 0 {
+	if len(t.config.Rename) > 0 || len(t.config.Remove) > 0 {
 		actions := t.Precompile()
 		subtransforms = append(subtransforms, Subtransform{name: "relabeling:" + actions, processFunc: t.AddRules})
 	}
@@ -31,7 +32,7 @@ func (t *RelabelTransform) GetTransforms() ([]Subtransform, error) {
 func (t *RelabelTransform) Precompile() string {
 	actionRename := false
 	actionRemove := false
-	for _, label := range t.config.Relabeling.Rename {
+	for _, label := range t.config.Rename {
 		t.RelabelingRules = append(t.RelabelingRules, dnsutils.RelabelingRule{
 			Regex:       regexp.MustCompile(label.Regex),
 			Replacement: label.Replacement,
@@ -39,7 +40,7 @@ func (t *RelabelTransform) Precompile() string {
 		})
 		actionRename = true
 	}
-	for _, label := range t.config.Relabeling.Remove {
+	for _, label := range t.config.Remove {
 		t.RelabelingRules = append(t.RelabelingRules, dnsutils.RelabelingRule{
 			Regex:       regexp.MustCompile(label.Regex),
 			Replacement: label.Replacement,

--- a/transformers/relabeling_test.go
+++ b/transformers/relabeling_test.go
@@ -22,7 +22,7 @@ func TestRelabeling_CompileRegex(t *testing.T) {
 
 	// init the processor
 	outChans := []chan *dnsutils.DNSMessageBatch{}
-	relabeling := NewRelabelTransform(cfg, logger.New(false), "test", 0, outChans)
+	relabeling := NewRelabelTransform(&cfg.Relabeling, logger.New(false), "test", 0, outChans)
 	relabeling.GetTransforms()
 
 	if len(relabeling.RelabelingRules) != 2 {

--- a/transformers/reordering.go
+++ b/transformers/reordering.go
@@ -13,6 +13,7 @@ import (
 
 type ReorderingTransform struct {
 	GenericTransformer
+	config      *config.TransformReordering
 	buffer      []*dnsutils.DNSMessage
 	backBuffer  []*dnsutils.DNSMessage
 	mutex       sync.Mutex
@@ -23,12 +24,12 @@ type ReorderingTransform struct {
 }
 
 // NewLogReorderTransform creates an instance of the transformer.
-func NewReorderingTransform(cfg *config.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *ReorderingTransform {
+func NewReorderingTransform(cfg *config.TransformReordering, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *ReorderingTransform {
 	t := &ReorderingTransform{
-		GenericTransformer: NewTransformer(cfg, logger, "reordering", name, instance, nextWorkers),
-		stopChan:           make(chan struct{}),
-		flushSignal:        make(chan struct{}),
-		nextWorkers:        nextWorkers,
+		config: cfg, GenericTransformer: NewTransformer(logger, "reordering", name, instance, nextWorkers),
+		stopChan:    make(chan struct{}),
+		flushSignal: make(chan struct{}),
+		nextWorkers: nextWorkers,
 	}
 
 	return t
@@ -37,12 +38,12 @@ func NewReorderingTransform(cfg *config.ConfigTransformers, logger *logger.Logge
 // GetTransforms returns the available subtransformations.
 func (t *ReorderingTransform) GetTransforms() ([]Subtransform, error) {
 	subtransforms := []Subtransform{}
-	if t.config.Reordering.Enable {
+	if t.config.Enable {
 		subtransforms = append(subtransforms, Subtransform{name: "reordering:sort-by-timestamp", processFunc: t.ReorderLogs})
 		// Start a goroutine to handle periodic flushing.
-		t.flushTicker = time.NewTicker(time.Duration(t.config.Reordering.FlushInterval) * time.Second)
-		t.buffer = make([]*dnsutils.DNSMessage, 0, t.config.Reordering.MaxBufferSize)
-		t.backBuffer = make([]*dnsutils.DNSMessage, 0, t.config.Reordering.MaxBufferSize)
+		t.flushTicker = time.NewTicker(time.Duration(t.config.FlushInterval) * time.Second)
+		t.buffer = make([]*dnsutils.DNSMessage, 0, t.config.MaxBufferSize)
+		t.backBuffer = make([]*dnsutils.DNSMessage, 0, t.config.MaxBufferSize)
 		go t.flushPeriodically()
 
 	}
@@ -62,7 +63,7 @@ func (t *ReorderingTransform) ReorderLogs(dm *dnsutils.DNSMessage) (int, error) 
 	t.mutex.Lock()
 	dm.Retain(1)
 	t.buffer = append(t.buffer, dm)
-	isFull := len(t.buffer) >= t.config.Reordering.MaxBufferSize
+	isFull := len(t.buffer) >= t.config.MaxBufferSize
 	t.mutex.Unlock()
 
 	// If the buffer exceeds a certain size, flush it.

--- a/transformers/reordering_bench_test.go
+++ b/transformers/reordering_bench_test.go
@@ -105,7 +105,7 @@ func Benchmark_Reordering_FlushBuffer_1000(b *testing.B) {
 	cfg.Reordering.MaxBufferSize = 1000
 	log := logger.New(false)
 	outChans := []chan *dnsutils.DNSMessageBatch{make(chan *dnsutils.DNSMessageBatch, 2000)}
-	reorder := NewReorderingTransform(cfg, log, "bench", 0, outChans)
+	reorder := NewReorderingTransform(&cfg.Reordering, log, "bench", 0, outChans)
 
 	template := generateMessages(1000, 50_000_000) // nearly sorted
 

--- a/transformers/reordering_test.go
+++ b/transformers/reordering_test.go
@@ -23,7 +23,7 @@ func TestReorderingTransform_SortByTimestamp(t *testing.T) {
 	}
 
 	// initialize transformer
-	reorder := NewReorderingTransform(cfg, log, "test", 0, outChans)
+	reorder := NewReorderingTransform(&cfg.Reordering, log, "test", 0, outChans)
 
 	dm1 := dnsutils.GetFakeDNSMessage()
 	dm1.DNSTap.TimestampRFC3339 = "2024-12-20T21:12:14.786109Z"

--- a/transformers/rest.go
+++ b/transformers/rest.go
@@ -14,17 +14,18 @@ import (
 
 type RestTransform struct {
 	GenericTransformer
+	config     *config.TransformRest
 	httpclient *http.Client
 }
 
-func NewRestTransform(cfg *config.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *RestTransform {
-	t := &RestTransform{GenericTransformer: NewTransformer(cfg, logger, "rest", name, instance, nextWorkers)}
+func NewRestTransform(cfg *config.TransformRest, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *RestTransform {
+	t := &RestTransform{config: cfg, GenericTransformer: NewTransformer(logger, "rest", name, instance, nextWorkers)}
 	return t
 }
 
 func (t *RestTransform) GetTransforms() ([]Subtransform, error) {
 	subtransforms := []Subtransform{}
-	if t.config.Rest.Enable {
+	if t.config.Enable {
 		t.Setup()
 		subtransforms = append(subtransforms, Subtransform{name: "rest:request", processFunc: t.Request})
 	}
@@ -39,7 +40,7 @@ func (t *RestTransform) Setup() {
 	}
 
 	t.httpclient = &http.Client{
-		Timeout:   time.Duration(t.config.Rest.Timeout) * time.Second,
+		Timeout:   time.Duration(t.config.Timeout) * time.Second,
 		Transport: tr,
 	}
 }
@@ -55,7 +56,7 @@ func (t *RestTransform) Request(dm *dnsutils.DNSMessage) (int, error) {
 		return ReturnKeep, nil
 	}
 
-	post, err := http.NewRequest("POST", t.config.Rest.URL, bytes.NewBuffer(payload))
+	post, err := http.NewRequest("POST", t.config.URL, bytes.NewBuffer(payload))
 	if err != nil {
 		t.LogError("HTTP error: %s", err)
 		return ReturnKeep, nil
@@ -63,8 +64,8 @@ func (t *RestTransform) Request(dm *dnsutils.DNSMessage) (int, error) {
 
 	post.Header.Set("Content-Type", "application/json")
 
-	if t.config.Rest.BasicAuthEnabled {
-		post.SetBasicAuth(t.config.Rest.BasicAuthLogin, t.config.Rest.BasicAuthPwd)
+	if t.config.BasicAuthEnabled {
+		post.SetBasicAuth(t.config.BasicAuthLogin, t.config.BasicAuthPwd)
 	}
 
 	resp, err := t.httpclient.Do(post)

--- a/transformers/rest_test.go
+++ b/transformers/rest_test.go
@@ -40,7 +40,7 @@ func TestRest_Request(t *testing.T) {
 
 	// init the processor
 	outChans := []chan *dnsutils.DNSMessageBatch{}
-	rest := NewRestTransform(cfg, logger.New(false), "test", 0, outChans)
+	rest := NewRestTransform(&cfg.Rest, logger.New(false), "test", 0, outChans)
 	rest.GetTransforms()
 
 	// send message

--- a/transformers/rewrite.go
+++ b/transformers/rewrite.go
@@ -14,23 +14,24 @@ type MutatorFunc func(dm *dnsutils.DNSMessage) error
 
 type RewriteTransform struct {
 	GenericTransformer
+	config   *config.TransformRewrite
 	mutators []MutatorFunc
 }
 
-func NewRewriteTransform(cfg *config.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *RewriteTransform {
-	t := &RewriteTransform{GenericTransformer: NewTransformer(cfg, logger, "rewrite", name, instance, nextWorkers)}
+func NewRewriteTransform(cfg *config.TransformRewrite, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *RewriteTransform {
+	t := &RewriteTransform{config: cfg, GenericTransformer: NewTransformer(logger, "rewrite", name, instance, nextWorkers)}
 	t.initMutators()
 	return t
 }
 
-func (t *RewriteTransform) ReloadConfig(cfg *config.ConfigTransformers) {
-	t.GenericTransformer.ReloadConfig(cfg)
+func (t *RewriteTransform) ReloadConfig(cfg *config.TransformRewrite) {
+	t.config = cfg
 	t.initMutators()
 }
 
 func (t *RewriteTransform) initMutators() {
-	t.mutators = make([]MutatorFunc, 0, len(t.config.Rewrite.Identifiers))
-	for nestedKeys, value := range t.config.Rewrite.Identifiers {
+	t.mutators = make([]MutatorFunc, 0, len(t.config.Identifiers))
+	for nestedKeys, value := range t.config.Identifiers {
 		t.mutators = append(t.mutators, getMutator(nestedKeys, value))
 	}
 }
@@ -119,7 +120,7 @@ func getMutator(nestedKeys string, val interface{}) MutatorFunc {
 
 func (t *RewriteTransform) GetTransforms() ([]Subtransform, error) {
 	subtransforms := []Subtransform{}
-	if len(t.config.Rewrite.Identifiers) > 0 {
+	if len(t.config.Identifiers) > 0 {
 		subtransforms = append(subtransforms, Subtransform{name: "rewrite", processFunc: t.UpdateValues})
 	}
 	return subtransforms, nil

--- a/transformers/rewrite_bench_test.go
+++ b/transformers/rewrite_bench_test.go
@@ -16,7 +16,7 @@ func BenchmarkRewrite_UpdateValues(b *testing.B) {
 	cfg.Rewrite.Identifiers["network.query-ip"] = "1.1.1.1"
 
 	outChans := []chan *dnsutils.DNSMessageBatch{}
-	rewrite := NewRewriteTransform(cfg, logger.New(false), "test", 0, outChans)
+	rewrite := NewRewriteTransform(&cfg.Rewrite, logger.New(false), "test", 0, outChans)
 	rewrite.GetTransforms()
 
 	dm := dnsutils.GetFakeDNSMessage()

--- a/transformers/rewrite_test.go
+++ b/transformers/rewrite_test.go
@@ -18,7 +18,7 @@ func TestRewrite_UpdateFields(t *testing.T) {
 
 	// init the processor
 	outChans := []chan *dnsutils.DNSMessageBatch{}
-	rewrite := NewRewriteTransform(cfg, logger.New(false), "test", 0, outChans)
+	rewrite := NewRewriteTransform(&cfg.Rewrite, logger.New(false), "test", 0, outChans)
 
 	// get fake
 	dm := dnsutils.GetFakeDNSMessage()
@@ -46,7 +46,7 @@ func TestRewrite_UpdateFields_InvalidType(t *testing.T) {
 
 	// init the processor
 	outChans := []chan *dnsutils.DNSMessageBatch{}
-	rewrite := NewRewriteTransform(cfg, logger.New(false), "test", 0, outChans)
+	rewrite := NewRewriteTransform(&cfg.Rewrite, logger.New(false), "test", 0, outChans)
 
 	// get fake
 	dm := dnsutils.GetFakeDNSMessage()

--- a/transformers/suspicious.go
+++ b/transformers/suspicious.go
@@ -11,12 +11,13 @@ import (
 
 type SuspiciousTransform struct {
 	GenericTransformer
+	config                *config.TransformSuspicious
 	commonQtypes          map[string]bool
 	whitelistDomainsRegex map[string]*regexp.Regexp
 }
 
-func NewSuspiciousTransform(cfg *config.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *SuspiciousTransform {
-	t := &SuspiciousTransform{GenericTransformer: NewTransformer(cfg, logger, "suspicious", name, instance, nextWorkers)}
+func NewSuspiciousTransform(cfg *config.TransformSuspicious, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *SuspiciousTransform {
+	t := &SuspiciousTransform{config: cfg, GenericTransformer: NewTransformer(logger, "suspicious", name, instance, nextWorkers)}
 	t.commonQtypes = make(map[string]bool)
 	t.whitelistDomainsRegex = make(map[string]*regexp.Regexp)
 	return t
@@ -34,14 +35,14 @@ func (t *SuspiciousTransform) GetTransforms() ([]Subtransform, error) {
 	}
 
 	// load maps
-	for _, v := range t.config.Suspicious.CommonQtypes {
+	for _, v := range t.config.CommonQtypes {
 		t.commonQtypes[v] = true
 	}
-	for _, v := range t.config.Suspicious.WhitelistDomains {
+	for _, v := range t.config.WhitelistDomains {
 		t.whitelistDomainsRegex[v] = regexp.MustCompile(v)
 	}
 
-	if t.config.Suspicious.Enable {
+	if t.config.Enable {
 		subtransforms = append(subtransforms, Subtransform{name: "suspicious:check", processFunc: t.checkIfSuspicious})
 	}
 	return subtransforms, nil
@@ -67,19 +68,19 @@ func (t *SuspiciousTransform) checkIfSuspicious(dm *dnsutils.DNSMessage) (int, e
 	}
 
 	// long domain name ?
-	if len(dm.DNS.Qname) > t.config.Suspicious.ThresholdQnameLen {
+	if len(dm.DNS.Qname) > t.config.ThresholdQnameLen {
 		dm.Suspicious.Score += 1.0
 		dm.Suspicious.LongDomain = true
 	}
 
 	// large packet size ?
-	if dm.DNS.Length > t.config.Suspicious.ThresholdPacketLen {
+	if dm.DNS.Length > t.config.ThresholdPacketLen {
 		dm.Suspicious.Score += 1.0
 		dm.Suspicious.LargePacket = true
 	}
 
 	// slow domain name resolution ?
-	if dm.DNSTap.Latency > t.config.Suspicious.ThresholdSlow {
+	if dm.DNSTap.Latency > t.config.ThresholdSlow {
 		dm.Suspicious.Score += 1.0
 		dm.Suspicious.SlowDomain = true
 	}
@@ -91,13 +92,13 @@ func (t *SuspiciousTransform) checkIfSuspicious(dm *dnsutils.DNSMessage) (int, e
 	}
 
 	// count the number of labels in qname
-	if strings.Count(dm.DNS.Qname, ".") > t.config.Suspicious.ThresholdMaxLabels {
+	if strings.Count(dm.DNS.Qname, ".") > t.config.ThresholdMaxLabels {
 		dm.Suspicious.Score += 1.0
 		dm.Suspicious.ExcessiveNumberLabels = true
 	}
 
 	// search for unallowed characters
-	for _, v := range t.config.Suspicious.UnallowedChars {
+	for _, v := range t.config.UnallowedChars {
 		if strings.Contains(dm.DNS.Qname, v) {
 			dm.Suspicious.Score += 1.0
 			dm.Suspicious.UnallowedChars = true

--- a/transformers/suspicious_test.go
+++ b/transformers/suspicious_test.go
@@ -20,7 +20,7 @@ func TestSuspicious_Json(t *testing.T) {
 	dm := dnsutils.GetFakeDNSMessage()
 
 	// init subprocessor
-	suspicious := NewSuspiciousTransform(cfg, logger.New(false), "test", 0, outChans)
+	suspicious := NewSuspiciousTransform(&cfg.Suspicious, logger.New(false), "test", 0, outChans)
 
 	// init transforms and check
 	suspicious.GetTransforms()
@@ -77,7 +77,7 @@ func TestSuspicious_MalformedPacket(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	suspicious := NewSuspiciousTransform(cfg, logger.New(false), "test", 0, outChans)
+	suspicious := NewSuspiciousTransform(&cfg.Suspicious, logger.New(false), "test", 0, outChans)
 
 	// malformed DNS message
 	dm := dnsutils.GetFakeDNSMessage()
@@ -112,7 +112,7 @@ func TestSuspicious_LongDomain(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	suspicious := NewSuspiciousTransform(cfg, logger.New(false), "test", 0, outChans)
+	suspicious := NewSuspiciousTransform(&cfg.Suspicious, logger.New(false), "test", 0, outChans)
 
 	// malformed DNS message
 	dm := dnsutils.GetFakeDNSMessage()
@@ -146,7 +146,7 @@ func TestSuspicious_SlowDomain(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	suspicious := NewSuspiciousTransform(cfg, logger.New(false), "test", 0, outChans)
+	suspicious := NewSuspiciousTransform(&cfg.Suspicious, logger.New(false), "test", 0, outChans)
 
 	// malformed DNS message
 	dm := dnsutils.GetFakeDNSMessage()
@@ -180,7 +180,7 @@ func TestSuspicious_LargePacket(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	suspicious := NewSuspiciousTransform(cfg, logger.New(false), "test", 0, outChans)
+	suspicious := NewSuspiciousTransform(&cfg.Suspicious, logger.New(false), "test", 0, outChans)
 
 	// malformed DNS message
 	dm := dnsutils.GetFakeDNSMessage()
@@ -213,7 +213,7 @@ func TestSuspicious_UncommonQtype(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	suspicious := NewSuspiciousTransform(cfg, logger.New(false), "test", 0, outChans)
+	suspicious := NewSuspiciousTransform(&cfg.Suspicious, logger.New(false), "test", 0, outChans)
 
 	// malformed DNS message
 	dm := dnsutils.GetFakeDNSMessage()
@@ -247,7 +247,7 @@ func TestSuspicious_ExceedMaxLabels(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	suspicious := NewSuspiciousTransform(cfg, logger.New(false), "test", 0, outChans)
+	suspicious := NewSuspiciousTransform(&cfg.Suspicious, logger.New(false), "test", 0, outChans)
 
 	// malformed DNS message
 	dm := dnsutils.GetFakeDNSMessage()
@@ -280,7 +280,7 @@ func TestSuspicious_UnallowedChars(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	suspicious := NewSuspiciousTransform(cfg, logger.New(false), "test", 0, outChans)
+	suspicious := NewSuspiciousTransform(&cfg.Suspicious, logger.New(false), "test", 0, outChans)
 
 	// malformed DNS message
 	dm := dnsutils.GetFakeDNSMessage()
@@ -313,7 +313,7 @@ func TestSuspicious_WhitelistDomains(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init subprocessor
-	suspicious := NewSuspiciousTransform(cfg, logger.New(false), "test", 0, outChans)
+	suspicious := NewSuspiciousTransform(&cfg.Suspicious, logger.New(false), "test", 0, outChans)
 
 	// IPv6 DNS message PTR
 	dm := dnsutils.GetFakeDNSMessage()

--- a/transformers/transformers.go
+++ b/transformers/transformers.go
@@ -21,20 +21,18 @@ type Subtransform struct {
 
 type Transformation interface {
 	GetTransforms() ([]Subtransform, error)
-	ReloadConfig(cfg *config.ConfigTransformers)
 	Reset()
 }
 
 type GenericTransformer struct {
-	config            *config.ConfigTransformers
 	logger            *logger.Logger
 	name              string
 	nextWorkers       []chan *dnsutils.DNSMessageBatch
 	LogInfo, LogError func(msg string, v ...interface{})
 }
 
-func NewTransformer(cfg *config.ConfigTransformers, logger *logger.Logger, name string, workerName string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) GenericTransformer {
-	t := GenericTransformer{config: cfg, logger: logger, nextWorkers: nextWorkers, name: name}
+func NewTransformer(logger *logger.Logger, name string, workerName string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) GenericTransformer {
+	t := GenericTransformer{logger: logger, nextWorkers: nextWorkers, name: name}
 
 	t.LogInfo = func(msg string, v ...interface{}) {
 		log := fmt.Sprintf("worker - [%s] (conn #%d) [transform=%s] - ", workerName, instance, name)
@@ -48,10 +46,6 @@ func NewTransformer(cfg *config.ConfigTransformers, logger *logger.Logger, name 
 	return t
 }
 
-func (t *GenericTransformer) ReloadConfig(cfg *config.ConfigTransformers) {
-	t.config = cfg
-}
-
 func (t *GenericTransformer) Reset() {}
 
 type TransformEntry struct {
@@ -59,10 +53,11 @@ type TransformEntry struct {
 }
 
 type Transforms struct {
-	config   *config.ConfigTransformers
-	logger   *logger.Logger
-	name     string
-	instance int
+	config      *config.ConfigTransformers
+	logger      *logger.Logger
+	name        string
+	instance    int
+	nextWorkers []chan *dnsutils.DNSMessageBatch
 
 	availableTransforms     []TransformEntry
 	activeTransforms        []TransformEntry
@@ -71,7 +66,7 @@ type Transforms struct {
 
 func NewTransforms(cfg *config.ConfigTransformers, logger *logger.Logger, name string, nextWorkers []chan *dnsutils.DNSMessageBatch, instance int) Transforms {
 
-	d := Transforms{config: cfg, logger: logger, name: name, instance: instance}
+	d := Transforms{config: cfg, logger: logger, name: name, instance: instance, nextWorkers: nextWorkers}
 
 	// order definition
 	pipelineOrder := cfg.Order
@@ -82,39 +77,39 @@ func NewTransforms(cfg *config.ConfigTransformers, logger *logger.Logger, name s
 	for _, nameTransform := range pipelineOrder {
 		switch nameTransform {
 		case "extract":
-			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewExtractTransform(cfg, logger, name, instance, nextWorkers)})
+			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewExtractTransform(&cfg.Extract, logger, name, instance, nextWorkers)})
 		case "normalize":
-			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewNormalizeTransform(cfg, logger, name, instance, nextWorkers)})
+			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewNormalizeTransform(&cfg.Normalize, logger, name, instance, nextWorkers)})
 		case "filtering":
-			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewFilteringTransform(cfg, logger, name, instance, nextWorkers)})
+			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewFilteringTransform(&cfg.Filtering, logger, name, instance, nextWorkers)})
 		case "geoip":
-			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewDNSGeoIPTransform(cfg, logger, name, instance, nextWorkers)})
+			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewDNSGeoIPTransform(&cfg.GeoIP, logger, name, instance, nextWorkers)})
 		case "bgp":
-			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewDNSBGPTransform(cfg, logger, name, instance, nextWorkers)})
+			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewDNSBGPTransform(&cfg.BGP, logger, name, instance, nextWorkers)})
 		case "atags":
-			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewATagsTransform(cfg, logger, name, instance, nextWorkers)})
+			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewATagsTransform(&cfg.ATags, logger, name, instance, nextWorkers)})
 		case "suspicious":
-			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewSuspiciousTransform(cfg, logger, name, instance, nextWorkers)})
+			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewSuspiciousTransform(&cfg.Suspicious, logger, name, instance, nextWorkers)})
 		case "user-privacy":
-			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewUserPrivacyTransform(cfg, logger, name, instance, nextWorkers)})
+			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewUserPrivacyTransform(&cfg.UserPrivacy, logger, name, instance, nextWorkers)})
 		case "machine-learning":
-			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewMachineLearningTransform(cfg, logger, name, instance, nextWorkers)})
+			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewMachineLearningTransform(&cfg.MachineLearning, logger, name, instance, nextWorkers)})
 		case "rest":
-			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewRestTransform(cfg, logger, name, instance, nextWorkers)})
+			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewRestTransform(&cfg.Rest, logger, name, instance, nextWorkers)})
 		case "relabeling":
-			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewRelabelTransform(cfg, logger, name, instance, nextWorkers)})
+			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewRelabelTransform(&cfg.Relabeling, logger, name, instance, nextWorkers)})
 		case "latency":
-			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewLatencyTransform(cfg, logger, name, instance, nextWorkers)})
+			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewLatencyTransform(&cfg.Latency, logger, name, instance, nextWorkers)})
 		case "rewrite":
-			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewRewriteTransform(cfg, logger, name, instance, nextWorkers)})
+			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewRewriteTransform(&cfg.Rewrite, logger, name, instance, nextWorkers)})
 		case "new-domain-tracker":
-			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewNewDomainTrackerTransform(cfg, logger, name, instance, nextWorkers)})
+			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewNewDomainTrackerTransform(&cfg.NewDomainTracker, logger, name, instance, nextWorkers)})
 		case "unique-response-tracker":
-			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewUniqueResponseTrackerTransform(cfg, logger, name, instance, nextWorkers)})
+			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewUniqueResponseTrackerTransform(&cfg.UniqueResponseTracker, logger, name, instance, nextWorkers)})
 		case "reducer":
-			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewReducerTransform(cfg, logger, name, instance, nextWorkers)})
+			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewReducerTransform(&cfg.Reducer, logger, name, instance, nextWorkers)})
 		case "reordering":
-			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewReorderingTransform(cfg, logger, name, instance, nextWorkers)})
+			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewReorderingTransform(&cfg.Reordering, logger, name, instance, nextWorkers)})
 		default:
 			d.LogError("unknown transformer name in order list: %s", nameTransform)
 		}
@@ -125,13 +120,7 @@ func NewTransforms(cfg *config.ConfigTransformers, logger *logger.Logger, name s
 }
 
 func (p *Transforms) ReloadConfig(cfg *config.ConfigTransformers) {
-	p.config = cfg
-
-	for _, transform := range p.availableTransforms {
-		transform.ReloadConfig(cfg)
-	}
-
-	p.Prepare()
+	*p = NewTransforms(cfg, p.logger, p.name, p.nextWorkers, p.instance)
 }
 
 func (p *Transforms) Prepare() error {

--- a/transformers/uniqueresponsetracker.go
+++ b/transformers/uniqueresponsetracker.go
@@ -140,35 +140,36 @@ func (urt *UniqueResponseTracker) Close() {
 
 type UniqueResponseTrackerTransform struct {
 	GenericTransformer
+	config           *config.TransformUniqueResponseTracker
 	responseTracker  *UniqueResponseTracker
 	listDomainsRegex map[string]*regexp.Regexp
 }
 
-func NewUniqueResponseTrackerTransform(cfg *config.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *UniqueResponseTrackerTransform {
-	t := &UniqueResponseTrackerTransform{GenericTransformer: NewTransformer(cfg, logger, "unique-response-tracker", name, instance, nextWorkers)}
+func NewUniqueResponseTrackerTransform(cfg *config.TransformUniqueResponseTracker, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *UniqueResponseTrackerTransform {
+	t := &UniqueResponseTrackerTransform{config: cfg, GenericTransformer: NewTransformer(logger, "unique-response-tracker", name, instance, nextWorkers)}
 	t.listDomainsRegex = make(map[string]*regexp.Regexp)
 	return t
 }
 
-func (t *UniqueResponseTrackerTransform) ReloadConfig(cfg *config.ConfigTransformers) {
-	t.GenericTransformer.ReloadConfig(cfg)
-	ttl := time.Duration(cfg.UniqueResponseTracker.TTL) * time.Second
+func (t *UniqueResponseTrackerTransform) ReloadConfig(cfg *config.TransformUniqueResponseTracker) {
+	t.config = cfg
+	ttl := time.Duration(cfg.TTL) * time.Second
 	t.responseTracker.ttl = ttl
 	t.LogInfo("unique-response-tracker configuration reloaded")
 }
 
 func (t *UniqueResponseTrackerTransform) GetTransforms() ([]Subtransform, error) {
 	subtransforms := []Subtransform{}
-	if t.config.UniqueResponseTracker.Enable {
+	if t.config.Enable {
 		if err := t.LoadWhiteDomainsList(); err != nil {
 			return nil, err
 		}
 
-		ttl := time.Duration(t.config.UniqueResponseTracker.TTL) * time.Second
-		maxSize := t.config.UniqueResponseTracker.CacheSize
-		engine := t.config.UniqueResponseTracker.StorageEngine
-		fpBits := t.config.UniqueResponseTracker.CuckooFingerprintBits
-		tracker, err := NewUniqueResponseTracker(ttl, maxSize, engine, fpBits, t.listDomainsRegex, t.config.UniqueResponseTracker.PersistenceFile, t.LogInfo, t.LogError)
+		ttl := time.Duration(t.config.TTL) * time.Second
+		maxSize := t.config.CacheSize
+		engine := t.config.StorageEngine
+		fpBits := t.config.CuckooFingerprintBits
+		tracker, err := NewUniqueResponseTracker(ttl, maxSize, engine, fpBits, t.listDomainsRegex, t.config.PersistenceFile, t.LogInfo, t.LogError)
 		if err != nil {
 			return nil, err
 		}
@@ -184,8 +185,8 @@ func (t *UniqueResponseTrackerTransform) LoadWhiteDomainsList() error {
 		delete(t.listDomainsRegex, key)
 	}
 
-	if len(t.config.UniqueResponseTracker.WhiteDomainsFile) > 0 {
-		file, err := os.Open(t.config.UniqueResponseTracker.WhiteDomainsFile)
+	if len(t.config.WhiteDomainsFile) > 0 {
+		file, err := os.Open(t.config.WhiteDomainsFile)
 		if err != nil {
 			return fmt.Errorf("unable to open regex list file: %w", err)
 		}
@@ -209,7 +210,7 @@ func (t *UniqueResponseTrackerTransform) trackUniqueResponse(dm *dnsutils.DNSMes
 	}
 
 	if t.responseTracker.storageEngine == "lru" && t.responseTracker.lruCache != nil {
-		if t.responseTracker.lruCache.Len() == t.config.UniqueResponseTracker.CacheSize {
+		if t.responseTracker.lruCache.Len() == t.config.CacheSize {
 			return ReturnError, fmt.Errorf("LRU cache is full. Consider increasing cache-size to avoid frequent evictions")
 		}
 	}

--- a/transformers/uniqueresponsetracker_test.go
+++ b/transformers/uniqueresponsetracker_test.go
@@ -17,7 +17,7 @@ func TestUniqueResponseTracker_IsNewResponse(t *testing.T) {
 	cfg.UniqueResponseTracker.CacheSize = 100
 
 	outChans := []chan *dnsutils.DNSMessageBatch{}
-	tracker := NewUniqueResponseTrackerTransform(cfg, logger.New(false), "test", 0, outChans)
+	tracker := NewUniqueResponseTrackerTransform(&cfg.UniqueResponseTracker, logger.New(false), "test", 0, outChans)
 
 	_, err := tracker.GetTransforms()
 	if err != nil {
@@ -78,7 +78,7 @@ func TestUniqueResponseTracker_NoAnswers(t *testing.T) {
 	cfg.UniqueResponseTracker.CacheSize = 100
 
 	outChans := []chan *dnsutils.DNSMessageBatch{}
-	tracker := NewUniqueResponseTrackerTransform(cfg, logger.New(false), "test", 0, outChans)
+	tracker := NewUniqueResponseTrackerTransform(&cfg.UniqueResponseTracker, logger.New(false), "test", 0, outChans)
 
 	_, err := tracker.GetTransforms()
 	if err != nil {
@@ -101,7 +101,7 @@ func TestUniqueResponseTracker_Whitelist(t *testing.T) {
 	cfg.UniqueResponseTracker.WhiteDomainsFile = "../tests/testsdata/newdomain_whitelist_regex.txt"
 
 	outChans := []chan *dnsutils.DNSMessageBatch{}
-	tracker := NewUniqueResponseTrackerTransform(cfg, logger.New(false), "test", 0, outChans)
+	tracker := NewUniqueResponseTrackerTransform(&cfg.UniqueResponseTracker, logger.New(false), "test", 0, outChans)
 
 	_, err := tracker.GetTransforms()
 	if err != nil {
@@ -142,7 +142,7 @@ func TestUniqueResponseTracker_Persistence(t *testing.T) {
 	cfg.UniqueResponseTracker.PersistenceFile = persistFile
 
 	outChans := []chan *dnsutils.DNSMessageBatch{}
-	tracker := NewUniqueResponseTrackerTransform(cfg, logger.New(false), "test", 0, outChans)
+	tracker := NewUniqueResponseTrackerTransform(&cfg.UniqueResponseTracker, logger.New(false), "test", 0, outChans)
 
 	_, err := tracker.GetTransforms()
 	if err != nil {
@@ -164,7 +164,7 @@ func TestUniqueResponseTracker_Persistence(t *testing.T) {
 	tracker.Reset()
 
 	// New tracker instance loading state from disk
-	tracker2 := NewUniqueResponseTrackerTransform(cfg, logger.New(false), "test2", 0, outChans)
+	tracker2 := NewUniqueResponseTrackerTransform(&cfg.UniqueResponseTracker, logger.New(false), "test2", 0, outChans)
 	_, err = tracker2.GetTransforms()
 	if err != nil {
 		t.Fatalf("fail to init second transform: %v", err)
@@ -183,7 +183,7 @@ func TestUniqueResponseTracker_LRUCacheFull(t *testing.T) {
 	cfg.UniqueResponseTracker.CacheSize = 1
 
 	outChans := []chan *dnsutils.DNSMessageBatch{}
-	tracker := NewUniqueResponseTrackerTransform(cfg, logger.New(false), "test", 0, outChans)
+	tracker := NewUniqueResponseTrackerTransform(&cfg.UniqueResponseTracker, logger.New(false), "test", 0, outChans)
 
 	_, err := tracker.GetTransforms()
 	if err != nil {
@@ -215,7 +215,7 @@ func TestUniqueResponseTracker_Cuckoo_IsNewResponse(t *testing.T) {
 	cfg.UniqueResponseTracker.StorageEngine = "cuckoo"
 
 	outChans := []chan *dnsutils.DNSMessageBatch{}
-	tracker := NewUniqueResponseTrackerTransform(cfg, logger.New(false), "test-cuckoo", 0, outChans)
+	tracker := NewUniqueResponseTrackerTransform(&cfg.UniqueResponseTracker, logger.New(false), "test-cuckoo", 0, outChans)
 
 	_, err := tracker.GetTransforms()
 	if err != nil {

--- a/transformers/userprivacy.go
+++ b/transformers/userprivacy.go
@@ -34,45 +34,46 @@ func HashIP(ip string, algo string) string {
 
 type UserPrivacyTransform struct {
 	GenericTransformer
+	config    *config.TransformUserPrivacy
 	v4MaskArr [4]byte
 	v6MaskArr [16]byte
 }
 
-func NewUserPrivacyTransform(cfg *config.ConfigTransformers, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *UserPrivacyTransform {
-	t := &UserPrivacyTransform{GenericTransformer: NewTransformer(cfg, logger, "userprivacy", name, instance, nextWorkers)}
+func NewUserPrivacyTransform(cfg *config.TransformUserPrivacy, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *UserPrivacyTransform {
+	t := &UserPrivacyTransform{config: cfg, GenericTransformer: NewTransformer(logger, "userprivacy", name, instance, nextWorkers)}
 	return t
 }
 
 func (t *UserPrivacyTransform) GetTransforms() ([]Subtransform, error) {
 	subprocessors := []Subtransform{}
 
-	v4Mask, err := netutils.ParseCIDRMask(t.config.UserPrivacy.AnonymizeIPV4Bits)
+	v4Mask, err := netutils.ParseCIDRMask(t.config.AnonymizeIPV4Bits)
 	if err != nil {
 		return nil, fmt.Errorf("unable to init v4 mask: %w", err)
 	}
 	copy(t.v4MaskArr[:], v4Mask)
 
-	if !strings.Contains(t.config.UserPrivacy.AnonymizeIPV6Bits, ":") {
+	if !strings.Contains(t.config.AnonymizeIPV6Bits, ":") {
 		return nil, fmt.Errorf("invalid v6 mask, expect format ::/integer")
 	}
-	v6Mask, err := netutils.ParseCIDRMask(t.config.UserPrivacy.AnonymizeIPV6Bits)
+	v6Mask, err := netutils.ParseCIDRMask(t.config.AnonymizeIPV6Bits)
 	if err != nil {
 		return nil, fmt.Errorf("unable to init v6 mask: %w", err)
 	}
 	copy(t.v6MaskArr[:], v6Mask)
 
-	if t.config.UserPrivacy.AnonymizeIP {
+	if t.config.AnonymizeIP {
 		subprocessors = append(subprocessors, Subtransform{name: "userprivacy:ip-anonymization", processFunc: t.anonymizeQueryIP})
 	}
 
-	if t.config.UserPrivacy.MinimizeQname {
+	if t.config.MinimizeQname {
 		subprocessors = append(subprocessors, Subtransform{name: "userprivacy:minimize-qname", processFunc: t.minimizeQname})
 	}
 
-	if t.config.UserPrivacy.HashQueryIP {
+	if t.config.HashQueryIP {
 		subprocessors = append(subprocessors, Subtransform{name: "userprivacy:hash-query-ip", processFunc: t.hashQueryIP})
 	}
-	if t.config.UserPrivacy.HashReplyIP {
+	if t.config.HashReplyIP {
 		subprocessors = append(subprocessors, Subtransform{name: "userprivacy:hash-reply-ip", processFunc: t.hashReplyIP})
 	}
 
@@ -129,12 +130,12 @@ func (t *UserPrivacyTransform) anonymizeQueryIP(dm *dnsutils.DNSMessage) (int, e
 }
 
 func (t *UserPrivacyTransform) hashQueryIP(dm *dnsutils.DNSMessage) (int, error) {
-	dm.NetworkInfo.QueryIP = HashIP(dm.NetworkInfo.GetQueryIP(), t.config.UserPrivacy.HashIPAlgo)
+	dm.NetworkInfo.QueryIP = HashIP(dm.NetworkInfo.GetQueryIP(), t.config.HashIPAlgo)
 	return ReturnKeep, nil
 }
 
 func (t *UserPrivacyTransform) hashReplyIP(dm *dnsutils.DNSMessage) (int, error) {
-	dm.NetworkInfo.ResponseIP = HashIP(dm.NetworkInfo.GetResponseIP(), t.config.UserPrivacy.HashIPAlgo)
+	dm.NetworkInfo.ResponseIP = HashIP(dm.NetworkInfo.GetResponseIP(), t.config.HashIPAlgo)
 	return ReturnKeep, nil
 }
 

--- a/transformers/userprivacy_bench_test.go
+++ b/transformers/userprivacy_bench_test.go
@@ -12,7 +12,7 @@ func Benchmark_UserPrivacy_AnonymizeIPv4_Binary(b *testing.B) {
 	cfg := config.GetFakeConfigTransformers()
 	cfg.UserPrivacy.Enable = true
 	cfg.UserPrivacy.AnonymizeIP = true
-	userPrivacy := NewUserPrivacyTransform(cfg, logger.New(false), "test", 0, nil)
+	userPrivacy := NewUserPrivacyTransform(&cfg.UserPrivacy, logger.New(false), "test", 0, nil)
 	userPrivacy.GetTransforms()
 
 	dm := dnsutils.GetFakeDNSMessage()
@@ -31,7 +31,7 @@ func Benchmark_UserPrivacy_AnonymizeIPv4_String(b *testing.B) {
 	cfg := config.GetFakeConfigTransformers()
 	cfg.UserPrivacy.Enable = true
 	cfg.UserPrivacy.AnonymizeIP = true
-	userPrivacy := NewUserPrivacyTransform(cfg, logger.New(false), "test", 0, nil)
+	userPrivacy := NewUserPrivacyTransform(&cfg.UserPrivacy, logger.New(false), "test", 0, nil)
 	userPrivacy.GetTransforms()
 
 	dm := dnsutils.GetFakeDNSMessage()
@@ -50,7 +50,7 @@ func Benchmark_UserPrivacy_AnonymizeIPv6_String(b *testing.B) {
 	cfg := config.GetFakeConfigTransformers()
 	cfg.UserPrivacy.Enable = true
 	cfg.UserPrivacy.AnonymizeIP = true
-	userPrivacy := NewUserPrivacyTransform(cfg, logger.New(false), "test", 0, nil)
+	userPrivacy := NewUserPrivacyTransform(&cfg.UserPrivacy, logger.New(false), "test", 0, nil)
 	userPrivacy.GetTransforms()
 
 	dm := dnsutils.GetFakeDNSMessage()
@@ -69,7 +69,7 @@ func Benchmark_UserPrivacy_AnonymizeIPv6_Binary(b *testing.B) {
 	cfg := config.GetFakeConfigTransformers()
 	cfg.UserPrivacy.Enable = true
 	cfg.UserPrivacy.AnonymizeIP = true
-	userPrivacy := NewUserPrivacyTransform(cfg, logger.New(false), "test", 0, nil)
+	userPrivacy := NewUserPrivacyTransform(&cfg.UserPrivacy, logger.New(false), "test", 0, nil)
 	userPrivacy.GetTransforms()
 
 	dm := dnsutils.GetFakeDNSMessage()

--- a/transformers/userprivacy_test.go
+++ b/transformers/userprivacy_test.go
@@ -23,7 +23,7 @@ func TestUserPrivacy_ReduceQname(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// init the processor
-	userPrivacy := NewUserPrivacyTransform(cfg, logger.New(false), "test", 0, outChans)
+	userPrivacy := NewUserPrivacyTransform(&cfg.UserPrivacy, logger.New(false), "test", 0, outChans)
 	userPrivacy.GetTransforms()
 
 	// Define test cases
@@ -87,7 +87,7 @@ func TestUserPrivacy_HashIP(t *testing.T) {
 			outChans := []chan *dnsutils.DNSMessageBatch{}
 
 			// Init the processor
-			userPrivacy := NewUserPrivacyTransform(cfg, logger.New(false), "test", 0, outChans)
+			userPrivacy := NewUserPrivacyTransform(&cfg.UserPrivacy, logger.New(false), "test", 0, outChans)
 			userPrivacy.GetTransforms()
 
 			dm := dnsutils.GetFakeDNSMessage()
@@ -118,7 +118,7 @@ func TestUserPrivacy_AnonymizeIP(t *testing.T) {
 	outChans := []chan *dnsutils.DNSMessageBatch{}
 
 	// Init the processor
-	userPrivacy := NewUserPrivacyTransform(cfg, logger.New(false), "test", 0, outChans)
+	userPrivacy := NewUserPrivacyTransform(&cfg.UserPrivacy, logger.New(false), "test", 0, outChans)
 	userPrivacy.GetTransforms()
 
 	// Define test cases
@@ -179,7 +179,7 @@ func TestUserPrivacy_AnonymizeIPRemove(t *testing.T) {
 	cfg.UserPrivacy.AnonymizeIPV6Bits = "::/0"
 
 	// Init the processor
-	userPrivacy := NewUserPrivacyTransform(cfg, logger.New(false), "test", 0, []chan *dnsutils.DNSMessageBatch{})
+	userPrivacy := NewUserPrivacyTransform(&cfg.UserPrivacy, logger.New(false), "test", 0, []chan *dnsutils.DNSMessageBatch{})
 	userPrivacy.GetTransforms()
 
 	// Define test cases


### PR DESCRIPTION
Replaced the in-memory `yaml.Marshal` + `yaml.Unmarshal` cycle with direct struct decoding using `mapstructure` in `GetStanzaConfig`.