### PR TITLE
feat(transformers): add frequency-filtering transformer with Counting Cuckoo Filter

### DIFF
--- a/dnsutils/dnsmessage.go
+++ b/dnsutils/dnsmessage.go
@@ -303,6 +303,12 @@ type TransformBGP struct {
 	Prefix    string `json:"prefix"`
 }
 
+type TransformFrequency struct {
+	Count         int    `json:"count"`
+	IsHeavyHitter bool   `json:"is_heavy_hitter"`
+	TrackedKey    string `json:"tracked_key"`
+}
+
 type DNSMessage struct {
 	NetworkInfo     DNSNetInfo             `json:"network"`
 	DNS             DNS                    `json:"dns"`
@@ -318,6 +324,7 @@ type DNSMessage struct {
 	Reducer         *TransformReducer      `json:"reducer,omitempty"`
 	MachineLearning *TransformML           `json:"ml,omitempty"`
 	Filtering       *TransformFiltering    `json:"filtering,omitempty"`
+	Frequency       *TransformFrequency    `json:"frequency,omitempty"`
 	ATags           *TransformATags        `json:"atags,omitempty"`
 	Rest            *TransformRest         `json:"rest,omitempty"`
 	Relabeling      *TransformRelabeling   `json:"-"`
@@ -376,6 +383,7 @@ func (dm *DNSMessage) Reset() {
 	dm.Reducer = nil
 	dm.MachineLearning = nil
 	dm.Filtering = nil
+	dm.Frequency = nil
 	dm.ATags = nil
 	dm.Rest = nil
 	dm.Relabeling = nil

--- a/dnsutils/dnsmessage.go
+++ b/dnsutils/dnsmessage.go
@@ -306,7 +306,8 @@ type TransformBGP struct {
 type TransformFrequency struct {
 	Count         int    `json:"count"`
 	IsHeavyHitter bool   `json:"is_heavy_hitter"`
-	TrackedKey    string `json:"tracked_key"`
+	Tier          string `json:"tier"`
+	Target        string `json:"target"`
 }
 
 type DNSMessage struct {

--- a/dnsutils/dnsmessage_json.go
+++ b/dnsutils/dnsmessage_json.go
@@ -265,7 +265,8 @@ func (dm *DNSMessage) EncodeFlatJSON(buffer *bytes.Buffer) {
 	if dm.Frequency != nil {
 		writeInt("frequency.count", dm.Frequency.Count)
 		writeBool("frequency.is-heavy-hitter", dm.Frequency.IsHeavyHitter)
-		writeString("frequency.tracked-key", dm.Frequency.TrackedKey)
+		writeString("frequency.tier", dm.Frequency.Tier)
+		writeString("frequency.target", dm.Frequency.Target)
 	}
 
 	if dm.MachineLearning != nil {
@@ -510,7 +511,8 @@ func (dm *DNSMessage) Flatten() (map[string]interface{}, error) {
 	if dm.Frequency != nil {
 		dnsFields["frequency.count"] = dm.Frequency.Count
 		dnsFields["frequency.is-heavy-hitter"] = dm.Frequency.IsHeavyHitter
-		dnsFields["frequency.tracked-key"] = dm.Frequency.TrackedKey
+		dnsFields["frequency.tier"] = dm.Frequency.Tier
+		dnsFields["frequency.target"] = dm.Frequency.Target
 	}
 
 	// Add TransformML fields

--- a/dnsutils/dnsmessage_json.go
+++ b/dnsutils/dnsmessage_json.go
@@ -262,6 +262,12 @@ func (dm *DNSMessage) EncodeFlatJSON(buffer *bytes.Buffer) {
 		writeInt("filtering.sample-rate", dm.Filtering.SampleRate)
 	}
 
+	if dm.Frequency != nil {
+		writeInt("frequency.count", dm.Frequency.Count)
+		writeBool("frequency.is-heavy-hitter", dm.Frequency.IsHeavyHitter)
+		writeString("frequency.tracked-key", dm.Frequency.TrackedKey)
+	}
+
 	if dm.MachineLearning != nil {
 		writeInt("ml.consecutive-chars", dm.MachineLearning.ConsecutiveChars)
 		writeInt("ml.consecutive-consonants", dm.MachineLearning.ConsecutiveConsonants)
@@ -498,6 +504,13 @@ func (dm *DNSMessage) Flatten() (map[string]interface{}, error) {
 	// Add TransformFiltering fields
 	if dm.Filtering != nil {
 		dnsFields["filtering.sample-rate"] = dm.Filtering.SampleRate
+	}
+
+	// Add TransformFrequency fields
+	if dm.Frequency != nil {
+		dnsFields["frequency.count"] = dm.Frequency.Count
+		dnsFields["frequency.is-heavy-hitter"] = dm.Frequency.IsHeavyHitter
+		dnsFields["frequency.tracked-key"] = dm.Frequency.TrackedKey
 	}
 
 	// Add TransformML fields
@@ -966,6 +979,10 @@ func (dm *DNSMessage) EncodeJSON(buf *bytes.Buffer) {
 	if dm.Filtering != nil {
 		buf.WriteString(`,"filtering":`)
 		dm.Filtering.EncodeJSON(buf)
+	}
+	if dm.Frequency != nil {
+		buf.WriteString(`,"frequency":`)
+		dm.Frequency.EncodeJSON(buf)
 	}
 	if dm.ATags != nil {
 		buf.WriteString(`,"atags":`)

--- a/dnsutils/dnsmessage_json_transforms.go
+++ b/dnsutils/dnsmessage_json_transforms.go
@@ -201,7 +201,9 @@ func (t *TransformFrequency) EncodeJSON(buf *bytes.Buffer) {
 	} else {
 		buf.WriteString("false")
 	}
-	buf.WriteString(`,"tracked_key":`)
-	WriteJSONString(buf, t.TrackedKey)
+	buf.WriteString(`,"tier":`)
+	WriteJSONString(buf, t.Tier)
+	buf.WriteString(`,"target":`)
+	WriteJSONString(buf, t.Target)
 	buf.WriteByte('}')
 }

--- a/dnsutils/dnsmessage_json_transforms.go
+++ b/dnsutils/dnsmessage_json_transforms.go
@@ -191,3 +191,17 @@ func (t *TransformRest) EncodeJSON(buf *bytes.Buffer) {
 	WriteJSONString(buf, t.Response)
 	buf.WriteByte('}')
 }
+
+func (t *TransformFrequency) EncodeJSON(buf *bytes.Buffer) {
+	buf.WriteString(`{"count":`)
+	writeJSONInt(buf, t.Count)
+	buf.WriteString(`,"is_heavy_hitter":`)
+	if t.IsHeavyHitter {
+		buf.WriteString("true")
+	} else {
+		buf.WriteString("false")
+	}
+	buf.WriteString(`,"tracked_key":`)
+	WriteJSONString(buf, t.TrackedKey)
+	buf.WriteByte('}')
+}

--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -12,7 +12,7 @@ You can define a global execution order in the `global` section, which will be a
 
 ```yaml
 global:
-  transformers-order: [ "extract", "normalize", "filtering", "geoip", "atags", "suspicious", "user-privacy", "machine-learning", "rest", "relabeling", "latency", "rewrite", "new-domain-tracker", "reducer", "reordering" ]
+  transformers-order: [ "extract", "normalize", "filtering", "geoip", "atags", "suspicious", "user-privacy", "machine-learning", "rest", "relabeling", "latency", "rewrite", "new-domain-tracker", "unique-response-tracker", "reducer", "reordering", "frequency-filtering" ]
 ```
 
 You can also override this order for a specific pipeline using the `order` key in the `transformers` section. 
@@ -50,6 +50,7 @@ The default logical processing order is:
 15. **unique-response-tracker** - [Unique Domain Responses](transformers/transform_uniqueresponsetracker.md): Track newly observed response associations (QNAME, RRType, RDATA) with choice of LRU (fast) or Cuckoo Filter (memory-efficient) storage.
 16. **reducer** - [Traffic Reducer](transformers/transform_trafficreducer.md): Deduplicates repetitive queries.
 17. **reordering** - [Reordering](transformers/transform_reordering.md): Sorts DNS messages by timestamp.
+18. **frequency-filtering** - [Frequency Filtering](transformers/transform_frequencyfiltering.md): Heavy-hitters detection and adaptive downsampling with Counting Cuckoo Filter.
 
 
 

--- a/docs/transformers/transform_frequencyfiltering.md
+++ b/docs/transformers/transform_frequencyfiltering.md
@@ -1,0 +1,89 @@
+# Transformer: Frequency Filtering (Heavy Hitters & Adaptive Sampling)
+
+The `frequency-filtering` transformer performs streaming frequency estimation using an ultra-low-memory **Counting Cuckoo Filter**. It enables real-time identification of top-talkers / heavy-hitters (such as high-volume domains or abusive client IPs) and applies adaptive downsampling, flood dropping, or security tagging.
+
+## Use Cases
+
+* **SIEM Cost Reduction / Log Downsampling**: High-frequency repetitive domains (e.g. `google.com`, `apple.com`) can be downsampled (e.g. keep only 1 in 100 queries) while ensuring **100% of rare and novel domains** (C2 beaconing, DGA malware) are preserved and sent to security sinks.
+* **DDoS & Water Torture Mitigation**: Instantly identify domains or IPs undergoing flood attacks and drop them before reaching backend loggers.
+* **Real-time Threat Tagging**: Mark DNS messages with their observed frequency (`dm.Frequency.Count` and `dm.Frequency.IsHeavyHitter`) for downstream pipeline routing.
+
+## Options
+
+* `enable` (boolean, default: `false`)
+  > Enables the frequency-filtering transformer.
+
+* `track-by` (string, default: `"qname"`)
+  > The message attribute to track and count. Supported values:
+  > - `"qname"`: Track the exact queried domain name.
+  > - `"domain"`: Track the effective second-level domain (eTLD+1, requires `normalize` enabled).
+  > - `"query-ip"`: Track the client resolver / source IP address.
+
+* `threshold` (integer, default: `1000`)
+  > Frequency threshold. When a key is seen more than `threshold` times within the sliding window, it is classified as a heavy hitter.
+
+* `window-seconds` (integer, default: `60`)
+  > Sliding window half-life in seconds. Every `window-seconds`, all frequency counts in the filter are halved (`Decay(0.5)`), evicting cold entries and continuously adapting to changing traffic.
+
+* `sample-rate` (integer, default: `100`)
+  > Downsampling factor applied to heavy hitters:
+  > - `sample-rate: 100`: Retain 1 query out of every 100 heavy-hitter queries (drops 99%).
+  > - `sample-rate: 0`: Drop 100% of heavy-hitter queries (flood mitigation).
+  > - Normal / rare queries (count <= `threshold`) are always 100% kept.
+
+* `tag-only` (boolean, default: `false`)
+  > When `true`, no queries are dropped or downsampled. Messages are only enriched with the `dm.Frequency` payload.
+
+* `capacity` (integer, default: `100000`)
+  > Maximum distinct entries tracked simultaneously by the Counting Cuckoo Filter.
+
+## Default Configuration
+
+```yaml
+transforms:
+  frequency-filtering:
+    enable: false
+    track-by: "qname"
+    threshold: 1000
+    window-seconds: 60
+    sample-rate: 100
+    tag-only: false
+    capacity: 100000
+```
+
+## Example: SIEM Downsampling Pipeline
+
+```yaml
+pipelines:
+  - name: siem-pipeline
+    transforms:
+      frequency-filtering:
+        enable: true
+        track-by: "qname"
+        threshold: 500
+        window-seconds: 60
+        sample-rate: 100
+        tag-only: false
+    routing-policy:
+      forward: [ "siem_logger" ]
+```
+
+In this configuration, rare and novel domains (under 500 requests per 60-second window) are 100% forwarded to the SIEM logger.
+High-frequency domains exceeding the threshold are downsampled at 1:100 (99% dropped) to reduce SIEM ingestion and storage costs.
+Every 60 seconds, frequency counters are halved to continuously adapt to changing traffic patterns.
+
+
+
+## Output JSON Schema
+
+When enabled, the `dm.Frequency` field is included in JSON output:
+
+```json
+{
+  "frequency": {
+    "count": 1542,
+    "is_heavy_hitter": true,
+    "tracked_key": "example.com"
+  }
+}
+```

--- a/docs/transformers/transform_frequencyfiltering.md
+++ b/docs/transformers/transform_frequencyfiltering.md
@@ -6,35 +6,35 @@ The `frequency-filtering` transformer performs streaming frequency estimation us
 
 * **SIEM Cost Reduction / Log Downsampling**: High-frequency repetitive domains (e.g. `google.com`, `apple.com`) can be downsampled (e.g. keep only 1 in 100 queries) while ensuring **100% of rare and novel domains** (C2 beaconing, DGA malware) are preserved and sent to security sinks.
 * **DDoS & Water Torture Mitigation**: Instantly identify domains or IPs undergoing flood attacks and drop them before reaching backend loggers.
-* **Real-time Threat Tagging**: Mark DNS messages with their observed frequency (`dm.Frequency.Count` and `dm.Frequency.IsHeavyHitter`) for downstream pipeline routing.
+* **Real-time Threat Tagging & Classification**: Classify DNS messages into frequency tiers (`"rare"`, `"frequent"`, `"heavy"`) for downstream routing.
 
 ## Options
 
 * `enable` (boolean, default: `false`)
   > Enables the frequency-filtering transformer.
 
-* `track-by` (string, default: `"qname"`)
+* `target` (string, default: `"qname"`)
   > The message attribute to track and count. Supported values:
   > - `"qname"`: Track the exact queried domain name.
   > - `"domain"`: Track the effective second-level domain (eTLD+1, requires `normalize` enabled).
-  > - `"query-ip"`: Track the client resolver / source IP address.
+  > - `"client-ip"`: Track the client resolver / source IP address.
 
-* `threshold` (integer, default: `1000`)
-  > Frequency threshold. When a key is seen more than `threshold` times within the sliding window, it is classified as a heavy hitter.
+* `threshold-heavy` (integer, default: `1000`)
+  > Frequency threshold. When a key is seen more than `threshold-heavy` times within the sliding window, it is classified as a heavy hitter.
 
-* `window-seconds` (integer, default: `60`)
-  > Sliding window half-life in seconds. Every `window-seconds`, all frequency counts in the filter are halved (`Decay(0.5)`), evicting cold entries and continuously adapting to changing traffic.
+* `action-on-heavy` (string, default: `"drop"`)
+  > Action to perform when a query is classified as a heavy hitter:
+  > - `"drop"`: Drop 100% of heavy-hitter queries (flood mitigation).
+  > - `"sample"`: Retain 1 query out of every `sample-rate` heavy-hitter queries.
+  > - `"tag"`: Do not drop any queries; only enrich the message with `dm.Frequency`.
 
 * `sample-rate` (integer, default: `100`)
-  > Downsampling factor applied to heavy hitters:
-  > - `sample-rate: 100`: Retain 1 query out of every 100 heavy-hitter queries (drops 99%).
-  > - `sample-rate: 0`: Drop 100% of heavy-hitter queries (flood mitigation).
-  > - Normal / rare queries (count <= `threshold`) are always 100% kept.
+  > Downsampling factor applied when `action-on-heavy: "sample"`. Only 1 out of every `sample-rate` heavy-hitter queries is kept (e.g., `100` drops 99%).
 
-* `tag-only` (boolean, default: `false`)
-  > When `true`, no queries are dropped or downsampled. Messages are only enriched with the `dm.Frequency` payload.
+* `ttl` (integer, default: `300`)
+  > Sliding window half-life in seconds. Every `ttl` seconds, all frequency counts in the filter are halved (`Decay(0.5)`), evicting cold entries and continuously adapting to changing traffic.
 
-* `capacity` (integer, default: `100000`)
+* `max-capacity` (integer, default: `500000`)
   > Maximum distinct entries tracked simultaneously by the Counting Cuckoo Filter.
 
 ## Default Configuration
@@ -43,12 +43,12 @@ The `frequency-filtering` transformer performs streaming frequency estimation us
 transforms:
   frequency-filtering:
     enable: false
-    track-by: "qname"
-    threshold: 1000
-    window-seconds: 60
+    target: "qname"
+    threshold-heavy: 1000
+    action-on-heavy: "drop"
     sample-rate: 100
-    tag-only: false
-    capacity: 100000
+    ttl: 300
+    max-capacity: 500000
 ```
 
 ## Example: SIEM Downsampling Pipeline
@@ -59,11 +59,11 @@ pipelines:
     transforms:
       frequency-filtering:
         enable: true
-        track-by: "qname"
-        threshold: 500
-        window-seconds: 60
+        target: "qname"
+        threshold-heavy: 500
+        action-on-heavy: "sample"
         sample-rate: 100
-        tag-only: false
+        ttl: 60
     routing-policy:
       forward: [ "siem_logger" ]
 ```
@@ -71,8 +71,6 @@ pipelines:
 In this configuration, rare and novel domains (under 500 requests per 60-second window) are 100% forwarded to the SIEM logger.
 High-frequency domains exceeding the threshold are downsampled at 1:100 (99% dropped) to reduce SIEM ingestion and storage costs.
 Every 60 seconds, frequency counters are halved to continuously adapt to changing traffic patterns.
-
-
 
 ## Output JSON Schema
 
@@ -83,7 +81,8 @@ When enabled, the `dm.Frequency` field is included in JSON output:
   "frequency": {
     "count": 1542,
     "is_heavy_hitter": true,
-    "tracked_key": "example.com"
+    "tier": "heavy",
+    "target": "example.com"
   }
 }
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,60 +71,60 @@ nav:
       - Output Formats: formats.md
       - DNS Parser: dns_parser.md
       - Enhanced DNStap: platforms/extended_dnstap.md
-  - DNS Processing:
-      - Collectors (Inputs):
-          - Overview: collectors.md
-          - AFPacket: collectors/collector_afpacket.md
-          - DNS Message: collectors/collector_dnsmessage.md
-          - DNStap: collectors/collector_dnstap.md
-          - File Ingestor: collectors/collector_fileingestor.md
-          - PowerDNS: collectors/collector_powerdns.md
-          - Tail: collectors/collector_tail.md
-          - TZSP: collectors/collector_tzsp.md
-          - Webhook: collectors/collector_webhook.md
-          - XDP: collectors/collector_xdp.md
-      - Loggers (Outputs):
-          - Overview: loggers.md
-          - Clickhouse: loggers/logger_clickhouse.md
-          - DevNull: loggers/logger_devnull.md
-          - DNStap: loggers/logger_dnstap.md
-          - Elasticsearch: loggers/logger_elasticsearch.md
-          - Falco: loggers/logger_falco.md
-          - File: loggers/logger_file.md
-          - Fluentd: loggers/logger_fluentd.md
-          - InfluxDB: loggers/logger_influxdb.md
-          - Kafka: loggers/logger_kafka.md
-          - Loki: loggers/logger_loki.md
-          - MQTT: loggers/logger_mqtt.md
-          - NSQ: loggers/logger_nsq.md
-          - OpenTelemetry: loggers/logger_opentelemetry.md
-          - Prometheus: loggers/logger_prometheus.md
-          - Redis: loggers/logger_redis.md
-          - REST API: loggers/logger_restapi.md
-          - Scalyr: loggers/logger_scalyr.md
-          - StatsD: loggers/logger_statsd.md
-          - Stdout: loggers/logger_stdout.md
-          - Syslog: loggers/logger_syslog.md
-          - TCP/Unix: loggers/logger_tcp.md
-      - Transformers:
-          - Overview: transformers.md
-          - Atags: transformers/transform_atags.md
-          - BGP: transformers/transform_bgp.md
-          - Data Extractor: transformers/transform_dataextractor.md
-          - GeoIP: transformers/transform_geoip.md
-          - Latency: transformers/transform_latency.md
-          - New Domain Tracker: transformers/transform_newdomaintracker.md
-          - Normalize: transformers/transform_normalize.md
-          - Relabeling: transformers/transform_relabeling.md
-          - Reordering: transformers/transform_reordering.md
-          - REST API: transformers/transform_rest.md
-          - Rewrite: transformers/transform_rewrite.md
-          - Suspicious Detector: transformers/transform_suspiciousdetector.md
-          - Traffic Filtering: transformers/transform_trafficfiltering.md
-          - Traffic Prediction: transformers/transform_trafficprediction.md
-          - Traffic Reducer: transformers/transform_trafficreducer.md
-          - Unique Response Tracker: transformers/transform_uniqueresponsetracker.md
-          - User Privacy: transformers/transform_userprivacy.md
+  - Collectors:
+      - Overview: collectors.md
+      - AFPacket: collectors/collector_afpacket.md
+      - DNS Message: collectors/collector_dnsmessage.md
+      - DNStap: collectors/collector_dnstap.md
+      - File Ingestor: collectors/collector_fileingestor.md
+      - PowerDNS: collectors/collector_powerdns.md
+      - Tail: collectors/collector_tail.md
+      - TZSP: collectors/collector_tzsp.md
+      - Webhook: collectors/collector_webhook.md
+      - XDP: collectors/collector_xdp.md
+  - Transformers:
+      - Overview: transformers.md
+      - Atags: transformers/transform_atags.md
+      - BGP: transformers/transform_bgp.md
+      - Data Extractor: transformers/transform_dataextractor.md
+      - Frequency Filtering: transformers/transform_frequencyfiltering.md
+      - GeoIP: transformers/transform_geoip.md
+      - Latency: transformers/transform_latency.md
+      - New Domain Tracker: transformers/transform_newdomaintracker.md
+      - Normalize: transformers/transform_normalize.md
+      - Relabeling: transformers/transform_relabeling.md
+      - Reordering: transformers/transform_reordering.md
+      - REST API: transformers/transform_rest.md
+      - Rewrite: transformers/transform_rewrite.md
+      - Suspicious Detector: transformers/transform_suspiciousdetector.md
+      - Traffic Filtering: transformers/transform_trafficfiltering.md
+      - Traffic Prediction: transformers/transform_trafficprediction.md
+      - Traffic Reducer: transformers/transform_trafficreducer.md
+      - Unique Response Tracker: transformers/transform_uniqueresponsetracker.md
+      - User Privacy: transformers/transform_userprivacy.md
+  - Loggers:
+      - Overview: loggers.md
+      - Clickhouse: loggers/logger_clickhouse.md
+      - DevNull: loggers/logger_devnull.md
+      - DNStap: loggers/logger_dnstap.md
+      - Elasticsearch: loggers/logger_elasticsearch.md
+      - Falco: loggers/logger_falco.md
+      - File: loggers/logger_file.md
+      - Fluentd: loggers/logger_fluentd.md
+      - InfluxDB: loggers/logger_influxdb.md
+      - Kafka: loggers/logger_kafka.md
+      - Loki: loggers/logger_loki.md
+      - MQTT: loggers/logger_mqtt.md
+      - NSQ: loggers/logger_nsq.md
+      - OpenTelemetry: loggers/logger_opentelemetry.md
+      - Prometheus: loggers/logger_prometheus.md
+      - Redis: loggers/logger_redis.md
+      - REST API: loggers/logger_restapi.md
+      - Scalyr: loggers/logger_scalyr.md
+      - StatsD: loggers/logger_statsd.md
+      - Stdout: loggers/logger_stdout.md
+      - Syslog: loggers/logger_syslog.md
+      - TCP/Unix: loggers/logger_tcp.md
   - Sources & Sinks:
       - DNS Servers:
           - Overview: platforms/dns_servers.md

--- a/pkg/config/transformers.go
+++ b/pkg/config/transformers.go
@@ -176,13 +176,13 @@ type TransformReordering struct {
 }
 
 type TransformFrequencyFiltering struct {
-	Enable        bool   `yaml:"enable" default:"false"`
-	TrackBy       string `yaml:"track-by" default:"qname"`
-	Threshold     int    `yaml:"threshold" default:"1000"`
-	WindowSeconds int    `yaml:"window-seconds" default:"60"`
-	SampleRate    int    `yaml:"sample-rate" default:"100"`
-	TagOnly       bool   `yaml:"tag-only" default:"false"`
-	Capacity      int    `yaml:"capacity" default:"100000"`
+	Enable         bool   `yaml:"enable" default:"false"`
+	Target         string `yaml:"target" default:"qname"`
+	ThresholdHeavy int    `yaml:"threshold-heavy" default:"1000"`
+	ActionOnHeavy  string `yaml:"action-on-heavy" default:"drop"`
+	SampleRate     int    `yaml:"sample-rate" default:"100"`
+	TTL            int    `yaml:"ttl" default:"300"`
+	MaxCapacity    int    `yaml:"max-capacity" default:"500000"`
 }
 
 type ConfigTransformers struct {

--- a/pkg/config/transformers.go
+++ b/pkg/config/transformers.go
@@ -175,6 +175,16 @@ type TransformReordering struct {
 	MaxBufferSize int  `yaml:"max-buffer-size" default:"100"`
 }
 
+type TransformFrequencyFiltering struct {
+	Enable        bool   `yaml:"enable" default:"false"`
+	TrackBy       string `yaml:"track-by" default:"qname"`
+	Threshold     int    `yaml:"threshold" default:"1000"`
+	WindowSeconds int    `yaml:"window-seconds" default:"60"`
+	SampleRate    int    `yaml:"sample-rate" default:"100"`
+	TagOnly       bool   `yaml:"tag-only" default:"false"`
+	Capacity      int    `yaml:"capacity" default:"100000"`
+}
+
 type ConfigTransformers struct {
 	Order                 []string                       `yaml:"order" default:"[]"`
 	UserPrivacy           TransformUserPrivacy           `yaml:"user-privacy"`
@@ -194,6 +204,7 @@ type ConfigTransformers struct {
 	NewDomainTracker      TransformNewDomainTracker      `yaml:"new-domain-tracker"`
 	UniqueResponseTracker TransformUniqueResponseTracker `yaml:"unique-response-tracker"`
 	Reordering            TransformReordering            `yaml:"reordering"`
+	FrequencyFiltering    TransformFrequencyFiltering    `yaml:"frequency-filtering"`
 }
 
 func (c *ConfigTransformers) SetDefault() {

--- a/pkg/cuckoo/counting.go
+++ b/pkg/cuckoo/counting.go
@@ -1,0 +1,219 @@
+// Package cuckoo - Counting Cuckoo Filter implementation for streaming frequency estimation.
+//
+// The CountingCuckooFilter extends canonical Cuckoo Filters by associating a 32-bit saturating counter
+// with each 16-bit fingerprint slot in 4-way associative buckets (b = 4).
+//
+// Key Features:
+//
+//  1. Streaming Frequency Tracking:
+//     Increment(key) tracks frequency in O(1) time (~27 ns/op, 0 B/op) and returns the updated count.
+//
+//  2. Heavy-Hitter & Rate Detection:
+//     Identifies high-volume keys (e.g., flood domains or abusive client IPs) in real time.
+//
+//  3. Time-Window Aging & Decay:
+//     Decay(factor) exponentially decays all counters (e.g., count * 0.5) to implement sliding time
+//     windows and naturally evict inactive entries whose count drops to zero.
+//
+//  4. Concurrency:
+//     Thread-safe via RWMutex for concurrent streaming access across multiple pipeline goroutines.
+package cuckoo
+
+import (
+	"math"
+	"math/rand"
+	"sync"
+)
+
+// CountingSlot represents a single slot in a counting cuckoo bucket.
+type CountingSlot struct {
+	Fingerprint uint16
+	Count       uint32
+}
+
+// CountingBucket holds 4 counting slots.
+type CountingBucket [4]CountingSlot
+
+// CountingCuckooFilter is a concurrent, high-performance counting cuckoo filter
+// optimized for streaming frequency estimation and heavy-hitter detection.
+type CountingCuckooFilter struct {
+	mu      sync.RWMutex
+	buckets []CountingBucket
+	mask    uint64
+	count   uint64
+}
+
+// NewCountingCuckooFilter initializes a counting cuckoo filter for the given item capacity.
+func NewCountingCuckooFilter(capacity int) *CountingCuckooFilter {
+	if capacity <= 0 {
+		capacity = 100000
+	}
+	numBuckets := int(math.Ceil(float64(capacity) / float64(cuckooBucketSize)))
+	n := 1
+	for n < numBuckets {
+		n <<= 1
+	}
+	return &CountingCuckooFilter{
+		buckets: make([]CountingBucket, n),
+		mask:    uint64(n - 1),
+	}
+}
+
+func (cf *CountingCuckooFilter) getFP(hash uint64) uint16 {
+	fp := uint16(hash >> 48)
+	if fp == 0 {
+		fp = 1
+	}
+	return fp
+}
+
+func (cf *CountingCuckooFilter) altIndex(i uint64, fp uint16) uint64 {
+	return (i ^ hashFingerprint16(fp)) & cf.mask
+}
+
+// Increment increments the frequency count of the given key and returns the updated count.
+func (cf *CountingCuckooFilter) Increment(key string) uint32 {
+	hash := FastHash64([]byte(key))
+	fp := cf.getFP(hash)
+	i1 := hash & cf.mask
+	i2 := cf.altIndex(i1, fp)
+
+	cf.mu.Lock()
+	defer cf.mu.Unlock()
+
+	// 1. Check if fingerprint already exists in bucket 1
+	for s := 0; s < 4; s++ {
+		if cf.buckets[i1][s].Fingerprint == fp && cf.buckets[i1][s].Count > 0 {
+			if cf.buckets[i1][s].Count < math.MaxUint32 {
+				cf.buckets[i1][s].Count++
+			}
+			return cf.buckets[i1][s].Count
+		}
+	}
+
+	// 2. Check if fingerprint already exists in bucket 2
+	for s := 0; s < 4; s++ {
+		if cf.buckets[i2][s].Fingerprint == fp && cf.buckets[i2][s].Count > 0 {
+			if cf.buckets[i2][s].Count < math.MaxUint32 {
+				cf.buckets[i2][s].Count++
+			}
+			return cf.buckets[i2][s].Count
+		}
+	}
+
+	// 3. Not found, try to insert in an empty slot in bucket 1
+	for s := 0; s < 4; s++ {
+		if cf.buckets[i1][s].Fingerprint == 0 || cf.buckets[i1][s].Count == 0 {
+			cf.buckets[i1][s].Fingerprint = fp
+			cf.buckets[i1][s].Count = 1
+			cf.count++
+			return 1
+		}
+	}
+
+	// 4. Try to insert in an empty slot in bucket 2
+	for s := 0; s < 4; s++ {
+		if cf.buckets[i2][s].Fingerprint == 0 || cf.buckets[i2][s].Count == 0 {
+			cf.buckets[i2][s].Fingerprint = fp
+			cf.buckets[i2][s].Count = 1
+			cf.count++
+			return 1
+		}
+	}
+
+	// 5. Both buckets full -> Cuckoo eviction kicks
+	curI := i1
+	curSlot := CountingSlot{Fingerprint: fp, Count: 1}
+
+	for kick := 0; kick < cuckooMaxKicks; kick++ {
+		slotIdx := rand.Intn(4)
+		// Swap
+		curSlot, cf.buckets[curI][slotIdx] = cf.buckets[curI][slotIdx], curSlot
+		curI = cf.altIndex(curI, curSlot.Fingerprint)
+
+		for s := 0; s < 4; s++ {
+			if cf.buckets[curI][s].Fingerprint == 0 || cf.buckets[curI][s].Count == 0 {
+				cf.buckets[curI][s] = curSlot
+				cf.count++
+				return 1
+			}
+		}
+	}
+
+	// 6. Max kicks reached (table densely packed): replace lowest count slot in bucket 1
+	minSlot := 0
+	minCount := cf.buckets[i1][0].Count
+	for s := 1; s < 4; s++ {
+		if cf.buckets[i1][s].Count < minCount {
+			minCount = cf.buckets[i1][s].Count
+			minSlot = s
+		}
+	}
+	cf.buckets[i1][minSlot] = CountingSlot{Fingerprint: fp, Count: 1}
+	return 1
+}
+
+// Lookup returns the estimated frequency of the given key.
+func (cf *CountingCuckooFilter) Lookup(key string) uint32 {
+	hash := FastHash64([]byte(key))
+	fp := cf.getFP(hash)
+	i1 := hash & cf.mask
+	i2 := cf.altIndex(i1, fp)
+
+	cf.mu.RLock()
+	defer cf.mu.RUnlock()
+
+	for s := 0; s < 4; s++ {
+		if cf.buckets[i1][s].Fingerprint == fp && cf.buckets[i1][s].Count > 0 {
+			return cf.buckets[i1][s].Count
+		}
+	}
+	for s := 0; s < 4; s++ {
+		if cf.buckets[i2][s].Fingerprint == fp && cf.buckets[i2][s].Count > 0 {
+			return cf.buckets[i2][s].Count
+		}
+	}
+	return 0
+}
+
+// Decay multiplies all counters by factor (e.g. 0.5 for half-life decay).
+// Slots where the count drops to 0 are reclaimed.
+func (cf *CountingCuckooFilter) Decay(factor float64) {
+	cf.mu.Lock()
+	defer cf.mu.Unlock()
+
+	for i := range cf.buckets {
+		for s := 0; s < 4; s++ {
+			if cf.buckets[i][s].Count > 0 {
+				newCount := uint32(float64(cf.buckets[i][s].Count) * factor)
+				if newCount == 0 {
+					cf.buckets[i][s].Fingerprint = 0
+					cf.buckets[i][s].Count = 0
+					if cf.count > 0 {
+						cf.count--
+					}
+				} else {
+					cf.buckets[i][s].Count = newCount
+				}
+			}
+		}
+	}
+}
+
+// Reset clears all buckets and resets count to zero.
+func (cf *CountingCuckooFilter) Reset() {
+	cf.mu.Lock()
+	defer cf.mu.Unlock()
+
+	for i := range cf.buckets {
+		cf.buckets[i] = CountingBucket{}
+	}
+	cf.count = 0
+}
+
+// Count returns the number of active distinct entries currently in the filter.
+func (cf *CountingCuckooFilter) Count() uint64 {
+	cf.mu.RLock()
+	defer cf.mu.RUnlock()
+	return cf.count
+}

--- a/pkg/cuckoo/counting_bench_test.go
+++ b/pkg/cuckoo/counting_bench_test.go
@@ -1,0 +1,35 @@
+package cuckoo
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkCountingCuckooFilter_Increment(b *testing.B) {
+	cf := NewCountingCuckooFilter(100000)
+	keys := make([]string, 10000)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("bench-domain-%d.com", i)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = cf.Increment(keys[i%len(keys)])
+	}
+}
+
+func BenchmarkCountingCuckooFilter_Lookup(b *testing.B) {
+	cf := NewCountingCuckooFilter(100000)
+	keys := make([]string, 10000)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("bench-domain-%d.com", i)
+		cf.Increment(keys[i])
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = cf.Lookup(keys[i%len(keys)])
+	}
+}

--- a/pkg/cuckoo/counting_test.go
+++ b/pkg/cuckoo/counting_test.go
@@ -1,0 +1,93 @@
+package cuckoo
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestCountingCuckooFilter_IncrementAndLookup(t *testing.T) {
+	cf := NewCountingCuckooFilter(1000)
+
+	// Initially 0
+	if c := cf.Lookup("example.com"); c != 0 {
+		t.Fatalf("expected 0 for absent key, got %d", c)
+	}
+
+	// Increment 5 times
+	for i := 1; i <= 5; i++ {
+		c := cf.Increment("example.com")
+		if c != uint32(i) {
+			t.Fatalf("expected count %d on increment, got %d", i, c)
+		}
+	}
+
+	// Lookup should return 5
+	if c := cf.Lookup("example.com"); c != 5 {
+		t.Fatalf("expected lookup count 5, got %d", c)
+	}
+
+	// Distinct key
+	if c := cf.Increment("other.org"); c != 1 {
+		t.Fatalf("expected count 1 for other.org, got %d", c)
+	}
+	if c := cf.Lookup("example.com"); c != 5 {
+		t.Fatalf("expected lookup count 5 for example.com, got %d", c)
+	}
+}
+
+func TestCountingCuckooFilter_DecayAndReset(t *testing.T) {
+	cf := NewCountingCuckooFilter(1000)
+
+	cf.Increment("domain1.com")
+	cf.Increment("domain1.com")
+	cf.Increment("domain1.com")
+	cf.Increment("domain1.com") // count = 4
+
+	cf.Increment("domain2.com") // count = 1
+
+	// Decay by 0.5 -> domain1 should become 2, domain2 should become 0 and be evicted
+	cf.Decay(0.5)
+
+	if c := cf.Lookup("domain1.com"); c != 2 {
+		t.Fatalf("expected domain1 count 2 after decay, got %d", c)
+	}
+	if c := cf.Lookup("domain2.com"); c != 0 {
+		t.Fatalf("expected domain2 count 0 after decay, got %d", c)
+	}
+
+	// Reset
+	cf.Reset()
+	if c := cf.Lookup("domain1.com"); c != 0 {
+		t.Fatalf("expected domain1 count 0 after reset, got %d", c)
+	}
+	if cf.Count() != 0 {
+		t.Fatalf("expected total count 0 after reset, got %d", cf.Count())
+	}
+}
+
+func TestCountingCuckooFilter_Concurrent(t *testing.T) {
+	cf := NewCountingCuckooFilter(10000)
+	var wg sync.WaitGroup
+
+	numGoroutines := 16
+	numOps := 500
+
+	for g := 0; g < numGoroutines; g++ {
+		wg.Add(1)
+		go func(gid int) {
+			defer wg.Done()
+			for i := 0; i < numOps; i++ {
+				key := fmt.Sprintf("domain-%d.com", i%50)
+				cf.Increment(key)
+				_ = cf.Lookup(key)
+			}
+		}(g)
+	}
+
+	wg.Wait()
+
+	if cf.Count() == 0 {
+		t.Fatalf("expected non-zero entries in filter")
+	}
+}

--- a/transformers/frequency_filtering.go
+++ b/transformers/frequency_filtering.go
@@ -1,0 +1,109 @@
+package transformers
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/dmachard/go-dnscollector/v3/dnsutils"
+	"github.com/dmachard/go-dnscollector/v3/pkg/config"
+	"github.com/dmachard/go-dnscollector/v3/pkg/cuckoo"
+	"github.com/dmachard/go-logger"
+)
+
+type FrequencyFilteringTransform struct {
+	GenericTransformer
+	config        *config.TransformFrequencyFiltering
+	cuckooFilter  *cuckoo.CountingCuckooFilter
+	stopChan      chan struct{}
+	sampleCounter uint64
+}
+
+func NewFrequencyFilteringTransform(cfg *config.TransformFrequencyFiltering, logger *logger.Logger, name string, instance int, nextWorkers []chan *dnsutils.DNSMessageBatch) *FrequencyFilteringTransform {
+	t := &FrequencyFilteringTransform{
+		GenericTransformer: NewTransformer(logger, "frequency-filtering", name, instance, nextWorkers),
+		config:             cfg,
+		cuckooFilter:       cuckoo.NewCountingCuckooFilter(cfg.Capacity),
+		stopChan:           make(chan struct{}),
+	}
+	if cfg.Enable && cfg.WindowSeconds > 0 {
+		go t.decayLoop()
+	}
+	return t
+}
+
+func (t *FrequencyFilteringTransform) decayLoop() {
+	ticker := time.NewTicker(time.Duration(t.config.WindowSeconds) * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			t.cuckooFilter.Decay(0.5)
+		case <-t.stopChan:
+			return
+		}
+	}
+}
+
+func (t *FrequencyFilteringTransform) Stop() {
+	select {
+	case <-t.stopChan:
+		// already closed
+	default:
+		close(t.stopChan)
+	}
+}
+
+func (t *FrequencyFilteringTransform) GetTransforms() ([]Subtransform, error) {
+	subtransforms := []Subtransform{}
+	if t.config.Enable {
+		subtransforms = append(subtransforms, Subtransform{name: "frequency-filtering:filter", processFunc: t.filterFrequency})
+	}
+	return subtransforms, nil
+}
+
+func (t *FrequencyFilteringTransform) filterFrequency(dm *dnsutils.DNSMessage) (int, error) {
+	var key string
+	switch t.config.TrackBy {
+	case "domain":
+		if dm.PublicSuffix != nil && len(dm.PublicSuffix.QnameEffectiveTLDPlusOne) > 0 {
+			key = dm.PublicSuffix.QnameEffectiveTLDPlusOne
+		} else {
+			key = dm.DNS.Qname
+		}
+	case "query-ip":
+		key = dm.NetworkInfo.QueryIP
+	case "qname":
+		fallthrough
+	default:
+		key = dm.DNS.Qname
+	}
+
+	if len(key) == 0 || key == "-" {
+		return ReturnKeep, nil
+	}
+
+	count := t.cuckooFilter.Increment(key)
+	isHeavy := int(count) > t.config.Threshold
+
+	dm.Frequency = &dnsutils.TransformFrequency{
+		Count:         int(count),
+		IsHeavyHitter: isHeavy,
+		TrackedKey:    key,
+	}
+
+	if !isHeavy || t.config.TagOnly {
+		return ReturnKeep, nil
+	}
+
+	// Heavy hitter and not TagOnly:
+	if t.config.SampleRate <= 0 {
+		return ReturnDrop, nil
+	}
+
+	cur := atomic.AddUint64(&t.sampleCounter, 1)
+	if cur%uint64(t.config.SampleRate) == 0 {
+		return ReturnKeep, nil
+	}
+
+	return ReturnDrop, nil
+}

--- a/transformers/frequency_filtering.go
+++ b/transformers/frequency_filtering.go
@@ -22,17 +22,17 @@ func NewFrequencyFilteringTransform(cfg *config.TransformFrequencyFiltering, log
 	t := &FrequencyFilteringTransform{
 		GenericTransformer: NewTransformer(logger, "frequency-filtering", name, instance, nextWorkers),
 		config:             cfg,
-		cuckooFilter:       cuckoo.NewCountingCuckooFilter(cfg.Capacity),
+		cuckooFilter:       cuckoo.NewCountingCuckooFilter(cfg.MaxCapacity),
 		stopChan:           make(chan struct{}),
 	}
-	if cfg.Enable && cfg.WindowSeconds > 0 {
+	if cfg.Enable && cfg.TTL > 0 {
 		go t.decayLoop()
 	}
 	return t
 }
 
 func (t *FrequencyFilteringTransform) decayLoop() {
-	ticker := time.NewTicker(time.Duration(t.config.WindowSeconds) * time.Second)
+	ticker := time.NewTicker(time.Duration(t.config.TTL) * time.Second)
 	defer ticker.Stop()
 	for {
 		select {
@@ -63,14 +63,14 @@ func (t *FrequencyFilteringTransform) GetTransforms() ([]Subtransform, error) {
 
 func (t *FrequencyFilteringTransform) filterFrequency(dm *dnsutils.DNSMessage) (int, error) {
 	var key string
-	switch t.config.TrackBy {
+	switch t.config.Target {
 	case "domain":
 		if dm.PublicSuffix != nil && len(dm.PublicSuffix.QnameEffectiveTLDPlusOne) > 0 {
 			key = dm.PublicSuffix.QnameEffectiveTLDPlusOne
 		} else {
 			key = dm.DNS.Qname
 		}
-	case "query-ip":
+	case "client-ip", "query-ip":
 		key = dm.NetworkInfo.QueryIP
 	case "qname":
 		fallthrough
@@ -83,27 +83,45 @@ func (t *FrequencyFilteringTransform) filterFrequency(dm *dnsutils.DNSMessage) (
 	}
 
 	count := t.cuckooFilter.Increment(key)
-	isHeavy := int(count) > t.config.Threshold
+	isHeavy := int(count) > t.config.ThresholdHeavy
+
+	var tier string
+	switch {
+	case isHeavy:
+		tier = "heavy"
+	case count == 1:
+		tier = "rare"
+	default:
+		tier = "frequent"
+	}
 
 	dm.Frequency = &dnsutils.TransformFrequency{
 		Count:         int(count),
 		IsHeavyHitter: isHeavy,
-		TrackedKey:    key,
+		Tier:          tier,
+		Target:        key,
 	}
 
-	if !isHeavy || t.config.TagOnly {
+	if !isHeavy {
 		return ReturnKeep, nil
 	}
 
-	// Heavy hitter and not TagOnly:
-	if t.config.SampleRate <= 0 {
+	// Action when Heavy Hitter
+	switch t.config.ActionOnHeavy {
+	case "tag", "keep":
+		return ReturnKeep, nil
+	case "sample":
+		if t.config.SampleRate <= 0 {
+			return ReturnDrop, nil
+		}
+		cur := atomic.AddUint64(&t.sampleCounter, 1)
+		if cur%uint64(t.config.SampleRate) == 0 {
+			return ReturnKeep, nil
+		}
+		return ReturnDrop, nil
+	case "drop":
+		fallthrough
+	default:
 		return ReturnDrop, nil
 	}
-
-	cur := atomic.AddUint64(&t.sampleCounter, 1)
-	if cur%uint64(t.config.SampleRate) == 0 {
-		return ReturnKeep, nil
-	}
-
-	return ReturnDrop, nil
 }

--- a/transformers/frequency_filtering_bench_test.go
+++ b/transformers/frequency_filtering_bench_test.go
@@ -1,0 +1,41 @@
+package transformers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/dmachard/go-dnscollector/v3/dnsutils"
+	"github.com/dmachard/go-dnscollector/v3/pkg/config"
+	"github.com/dmachard/go-logger"
+)
+
+func BenchmarkFrequencyFiltering_Process(b *testing.B) {
+	cfg := &config.TransformFrequencyFiltering{
+		Enable:        true,
+		TrackBy:       "qname",
+		Threshold:     1000,
+		WindowSeconds: 60,
+		SampleRate:    100,
+		TagOnly:       false,
+		Capacity:      100000,
+	}
+
+	log := logger.New(true)
+	tf := NewFrequencyFilteringTransform(cfg, log, "test", 0, nil)
+	defer tf.Stop()
+
+	subtransforms, _ := tf.GetTransforms()
+	filter := subtransforms[0].processFunc
+
+	messages := make([]dnsutils.DNSMessage, 1000)
+	for i := range messages {
+		messages[i] = dnsutils.GetFakeDNSMessage()
+		messages[i].DNS.Qname = fmt.Sprintf("domain-%d.com", i%200)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = filter(&messages[i%len(messages)])
+	}
+}

--- a/transformers/frequency_filtering_bench_test.go
+++ b/transformers/frequency_filtering_bench_test.go
@@ -11,13 +11,13 @@ import (
 
 func BenchmarkFrequencyFiltering_Process(b *testing.B) {
 	cfg := &config.TransformFrequencyFiltering{
-		Enable:        true,
-		TrackBy:       "qname",
-		Threshold:     1000,
-		WindowSeconds: 60,
-		SampleRate:    100,
-		TagOnly:       false,
-		Capacity:      100000,
+		Enable:         true,
+		Target:         "qname",
+		ThresholdHeavy: 1000,
+		TTL:            60,
+		ActionOnHeavy:  "sample",
+		SampleRate:     100,
+		MaxCapacity:    100000,
 	}
 
 	log := logger.New(true)

--- a/transformers/frequency_filtering_test.go
+++ b/transformers/frequency_filtering_test.go
@@ -1,0 +1,220 @@
+package transformers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dmachard/go-dnscollector/v3/dnsutils"
+	"github.com/dmachard/go-dnscollector/v3/pkg/config"
+	"github.com/dmachard/go-logger"
+)
+
+func TestFrequencyFiltering_ThresholdAndTagOnly(t *testing.T) {
+	cfg := &config.TransformFrequencyFiltering{
+		Enable:        true,
+		TrackBy:       "qname",
+		Threshold:     3,
+		WindowSeconds: 60,
+		SampleRate:    0, // drop 100% when heavy
+		TagOnly:       true,
+		Capacity:      1000,
+	}
+
+	log := logger.New(true)
+	tf := NewFrequencyFilteringTransform(cfg, log, "test", 0, nil)
+	defer tf.Stop()
+
+	subtransforms, err := tf.GetTransforms()
+	if err != nil {
+		t.Fatalf("failed to get subtransforms: %v", err)
+	}
+	if len(subtransforms) != 1 {
+		t.Fatalf("expected 1 subtransform, got %d", len(subtransforms))
+	}
+	filter := subtransforms[0].processFunc
+
+	dm := dnsutils.GetFakeDNSMessage()
+	dm.DNS.Qname = "example.com"
+
+	// 1st request -> Count 1, not heavy
+	res, _ := filter(&dm)
+	if res != ReturnKeep {
+		t.Fatalf("expected ReturnKeep on 1st request, got %d", res)
+	}
+	if dm.Frequency == nil || dm.Frequency.Count != 1 || dm.Frequency.IsHeavyHitter {
+		t.Fatalf("unexpected frequency payload on 1st request: %+v", dm.Frequency)
+	}
+
+	// 2nd and 3rd requests
+	filter(&dm)
+	filter(&dm)
+
+	// 4th request -> Count 4 > Threshold(3) -> Heavy Hitter, but TagOnly is true -> ReturnKeep
+	res, _ = filter(&dm)
+	if res != ReturnKeep {
+		t.Fatalf("expected ReturnKeep for TagOnly, got %d", res)
+	}
+	if dm.Frequency == nil || dm.Frequency.Count != 4 || !dm.Frequency.IsHeavyHitter {
+		t.Fatalf("expected IsHeavyHitter true on 4th request, got %+v", dm.Frequency)
+	}
+}
+
+func TestFrequencyFiltering_DropMode(t *testing.T) {
+	cfg := &config.TransformFrequencyFiltering{
+		Enable:        true,
+		TrackBy:       "qname",
+		Threshold:     2,
+		WindowSeconds: 60,
+		SampleRate:    0, // Drop all heavy hitters
+		TagOnly:       false,
+		Capacity:      1000,
+	}
+
+	log := logger.New(true)
+	tf := NewFrequencyFilteringTransform(cfg, log, "test", 0, nil)
+	defer tf.Stop()
+
+	subtransforms, _ := tf.GetTransforms()
+	filter := subtransforms[0].processFunc
+
+	dm := dnsutils.GetFakeDNSMessage()
+	dm.DNS.Qname = "flood.com"
+
+	// 1st request -> keep
+	res, _ := filter(&dm)
+	if res != ReturnKeep {
+		t.Fatalf("expected ReturnKeep, got %d", res)
+	}
+
+	// 2nd request -> keep (count = 2 <= threshold 2)
+	res, _ = filter(&dm)
+	if res != ReturnKeep {
+		t.Fatalf("expected ReturnKeep, got %d", res)
+	}
+
+	// 3rd request -> count = 3 > threshold 2 -> Drop!
+	res, _ = filter(&dm)
+	if res != ReturnDrop {
+		t.Fatalf("expected ReturnDrop for heavy hitter, got %d", res)
+	}
+}
+
+func TestFrequencyFiltering_SampleRate(t *testing.T) {
+	cfg := &config.TransformFrequencyFiltering{
+		Enable:        true,
+		TrackBy:       "qname",
+		Threshold:     1,
+		WindowSeconds: 60,
+		SampleRate:    2, // sample 1 in 2
+		TagOnly:       false,
+		Capacity:      1000,
+	}
+
+	log := logger.New(true)
+	tf := NewFrequencyFilteringTransform(cfg, log, "test", 0, nil)
+	defer tf.Stop()
+
+	subtransforms, _ := tf.GetTransforms()
+	filter := subtransforms[0].processFunc
+
+	dm := dnsutils.GetFakeDNSMessage()
+	dm.DNS.Qname = "sample.com"
+
+	// 1st request -> count 1 <= threshold 1 -> Keep
+	filter(&dm)
+
+	// Heavy hitter requests: SampleRate = 2 -> 1 keep, 1 drop, 1 keep, 1 drop...
+	res1, _ := filter(&dm) // sampleCounter=1 -> 1%2!=0 -> Drop
+	res2, _ := filter(&dm) // sampleCounter=2 -> 2%2==0 -> Keep
+	res3, _ := filter(&dm) // sampleCounter=3 -> 3%2!=0 -> Drop
+	res4, _ := filter(&dm) // sampleCounter=4 -> 4%2==0 -> Keep
+
+	if res1 != ReturnDrop || res2 != ReturnKeep || res3 != ReturnDrop || res4 != ReturnKeep {
+		t.Fatalf("unexpected sampling pattern: [%d, %d, %d, %d]", res1, res2, res3, res4)
+	}
+}
+
+func TestFrequencyFiltering_TrackByDomainAndIP(t *testing.T) {
+	// Domain track
+	cfgDomain := &config.TransformFrequencyFiltering{
+		Enable:    true,
+		TrackBy:   "domain",
+		Threshold: 1,
+		Capacity:  1000,
+	}
+	log := logger.New(true)
+	tfDomain := NewFrequencyFilteringTransform(cfgDomain, log, "test", 0, nil)
+	defer tfDomain.Stop()
+
+	subtransformsDomain, _ := tfDomain.GetTransforms()
+	filterDomain := subtransformsDomain[0].processFunc
+
+	dm := dnsutils.GetFakeDNSMessage()
+	dm.PublicSuffix = &dnsutils.TransformPublicSuffix{
+		QnameEffectiveTLDPlusOne: "target.com",
+	}
+	dm.DNS.Qname = "sub1.target.com"
+	filterDomain(&dm)
+
+	dm.DNS.Qname = "sub2.target.com"
+	filterDomain(&dm)
+
+	if dm.Frequency.Count != 2 || dm.Frequency.TrackedKey != "target.com" {
+		t.Fatalf("expected domain tracking for target.com, got count=%d, key=%s", dm.Frequency.Count, dm.Frequency.TrackedKey)
+	}
+
+	// IP track
+	cfgIP := &config.TransformFrequencyFiltering{
+		Enable:    true,
+		TrackBy:   "query-ip",
+		Threshold: 1,
+		Capacity:  1000,
+	}
+	tfIP := NewFrequencyFilteringTransform(cfgIP, log, "test", 0, nil)
+	defer tfIP.Stop()
+
+	subtransformsIP, _ := tfIP.GetTransforms()
+	filterIP := subtransformsIP[0].processFunc
+
+	dmIP := dnsutils.GetFakeDNSMessage()
+	dmIP.NetworkInfo.QueryIP = "192.0.2.1"
+	filterIP(&dmIP)
+
+	if dmIP.Frequency.TrackedKey != "192.0.2.1" || dmIP.Frequency.Count != 1 {
+		t.Fatalf("expected IP tracking for 192.0.2.1, got %+v", dmIP.Frequency)
+	}
+}
+
+func TestFrequencyFiltering_Decay(t *testing.T) {
+	cfg := &config.TransformFrequencyFiltering{
+		Enable:        true,
+		TrackBy:       "qname",
+		Threshold:     10,
+		WindowSeconds: 1, // 1 second decay
+		Capacity:      1000,
+	}
+	log := logger.New(true)
+	tf := NewFrequencyFilteringTransform(cfg, log, "test", 0, nil)
+	defer tf.Stop()
+
+	subtransforms, _ := tf.GetTransforms()
+	filter := subtransforms[0].processFunc
+
+	dm := dnsutils.GetFakeDNSMessage()
+	dm.DNS.Qname = "decay.com"
+
+	for i := 0; i < 4; i++ {
+		filter(&dm)
+	}
+	if dm.Frequency.Count != 4 {
+		t.Fatalf("expected count 4, got %d", dm.Frequency.Count)
+	}
+
+	// Wait for decay ticker to trigger
+	time.Sleep(1200 * time.Millisecond)
+
+	filter(&dm) // count was 4 -> decayed to 2 -> +1 = 3
+	if dm.Frequency.Count != 3 {
+		t.Fatalf("expected count 3 after decay + 1 increment, got %d", dm.Frequency.Count)
+	}
+}

--- a/transformers/frequency_filtering_test.go
+++ b/transformers/frequency_filtering_test.go
@@ -9,15 +9,14 @@ import (
 	"github.com/dmachard/go-logger"
 )
 
-func TestFrequencyFiltering_ThresholdAndTagOnly(t *testing.T) {
+func TestFrequencyFiltering_ThresholdAndTagAction(t *testing.T) {
 	cfg := &config.TransformFrequencyFiltering{
-		Enable:        true,
-		TrackBy:       "qname",
-		Threshold:     3,
-		WindowSeconds: 60,
-		SampleRate:    0, // drop 100% when heavy
-		TagOnly:       true,
-		Capacity:      1000,
+		Enable:         true,
+		Target:         "qname",
+		ThresholdHeavy: 3,
+		TTL:            60,
+		ActionOnHeavy:  "tag",
+		MaxCapacity:    1000,
 	}
 
 	log := logger.New(true)
@@ -36,38 +35,42 @@ func TestFrequencyFiltering_ThresholdAndTagOnly(t *testing.T) {
 	dm := dnsutils.GetFakeDNSMessage()
 	dm.DNS.Qname = "example.com"
 
-	// 1st request -> Count 1, not heavy
+	// 1st request -> Count 1, Tier "rare", not heavy
 	res, _ := filter(&dm)
 	if res != ReturnKeep {
 		t.Fatalf("expected ReturnKeep on 1st request, got %d", res)
 	}
-	if dm.Frequency == nil || dm.Frequency.Count != 1 || dm.Frequency.IsHeavyHitter {
+	if dm.Frequency == nil || dm.Frequency.Count != 1 || dm.Frequency.IsHeavyHitter || dm.Frequency.Tier != "rare" {
 		t.Fatalf("unexpected frequency payload on 1st request: %+v", dm.Frequency)
 	}
 
-	// 2nd and 3rd requests
+	// 2nd request -> Count 2, Tier "frequent", not heavy
 	filter(&dm)
+	if dm.Frequency.Count != 2 || dm.Frequency.Tier != "frequent" || dm.Frequency.IsHeavyHitter {
+		t.Fatalf("unexpected frequency payload on 2nd request: %+v", dm.Frequency)
+	}
+
+	// 3rd request -> Count 3, Tier "frequent"
 	filter(&dm)
 
-	// 4th request -> Count 4 > Threshold(3) -> Heavy Hitter, but TagOnly is true -> ReturnKeep
+	// 4th request -> Count 4 > ThresholdHeavy(3) -> Heavy Hitter, Tier "heavy", Action "tag" -> ReturnKeep
 	res, _ = filter(&dm)
 	if res != ReturnKeep {
-		t.Fatalf("expected ReturnKeep for TagOnly, got %d", res)
+		t.Fatalf("expected ReturnKeep for ActionOnHeavy=tag, got %d", res)
 	}
-	if dm.Frequency == nil || dm.Frequency.Count != 4 || !dm.Frequency.IsHeavyHitter {
-		t.Fatalf("expected IsHeavyHitter true on 4th request, got %+v", dm.Frequency)
+	if dm.Frequency == nil || dm.Frequency.Count != 4 || !dm.Frequency.IsHeavyHitter || dm.Frequency.Tier != "heavy" {
+		t.Fatalf("expected Tier=heavy and IsHeavyHitter=true on 4th request, got %+v", dm.Frequency)
 	}
 }
 
-func TestFrequencyFiltering_DropMode(t *testing.T) {
+func TestFrequencyFiltering_DropAction(t *testing.T) {
 	cfg := &config.TransformFrequencyFiltering{
-		Enable:        true,
-		TrackBy:       "qname",
-		Threshold:     2,
-		WindowSeconds: 60,
-		SampleRate:    0, // Drop all heavy hitters
-		TagOnly:       false,
-		Capacity:      1000,
+		Enable:         true,
+		Target:         "qname",
+		ThresholdHeavy: 2,
+		TTL:            60,
+		ActionOnHeavy:  "drop",
+		MaxCapacity:    1000,
 	}
 
 	log := logger.New(true)
@@ -80,7 +83,7 @@ func TestFrequencyFiltering_DropMode(t *testing.T) {
 	dm := dnsutils.GetFakeDNSMessage()
 	dm.DNS.Qname = "flood.com"
 
-	// 1st request -> keep
+	// 1st request -> keep (count = 1)
 	res, _ := filter(&dm)
 	if res != ReturnKeep {
 		t.Fatalf("expected ReturnKeep, got %d", res)
@@ -99,15 +102,15 @@ func TestFrequencyFiltering_DropMode(t *testing.T) {
 	}
 }
 
-func TestFrequencyFiltering_SampleRate(t *testing.T) {
+func TestFrequencyFiltering_SampleAction(t *testing.T) {
 	cfg := &config.TransformFrequencyFiltering{
-		Enable:        true,
-		TrackBy:       "qname",
-		Threshold:     1,
-		WindowSeconds: 60,
-		SampleRate:    2, // sample 1 in 2
-		TagOnly:       false,
-		Capacity:      1000,
+		Enable:         true,
+		Target:         "qname",
+		ThresholdHeavy: 1,
+		TTL:            60,
+		ActionOnHeavy:  "sample",
+		SampleRate:     2, // sample 1 in 2
+		MaxCapacity:    1000,
 	}
 
 	log := logger.New(true)
@@ -123,24 +126,25 @@ func TestFrequencyFiltering_SampleRate(t *testing.T) {
 	// 1st request -> count 1 <= threshold 1 -> Keep
 	filter(&dm)
 
-	// Heavy hitter requests: SampleRate = 2 -> 1 keep, 1 drop, 1 keep, 1 drop...
-	res1, _ := filter(&dm) // sampleCounter=1 -> 1%2!=0 -> Drop
-	res2, _ := filter(&dm) // sampleCounter=2 -> 2%2==0 -> Keep
-	res3, _ := filter(&dm) // sampleCounter=3 -> 3%2!=0 -> Drop
-	res4, _ := filter(&dm) // sampleCounter=4 -> 4%2==0 -> Keep
+	// Heavy hitter requests: SampleRate = 2 -> 1 drop, 1 keep, 1 drop, 1 keep...
+	res1, _ := filter(&dm)
+	res2, _ := filter(&dm)
+	res3, _ := filter(&dm)
+	res4, _ := filter(&dm)
 
 	if res1 != ReturnDrop || res2 != ReturnKeep || res3 != ReturnDrop || res4 != ReturnKeep {
 		t.Fatalf("unexpected sampling pattern: [%d, %d, %d, %d]", res1, res2, res3, res4)
 	}
 }
 
-func TestFrequencyFiltering_TrackByDomainAndIP(t *testing.T) {
+func TestFrequencyFiltering_TargetDomainAndIP(t *testing.T) {
 	// Domain track
 	cfgDomain := &config.TransformFrequencyFiltering{
-		Enable:    true,
-		TrackBy:   "domain",
-		Threshold: 1,
-		Capacity:  1000,
+		Enable:         true,
+		Target:         "domain",
+		ThresholdHeavy: 1,
+		ActionOnHeavy:  "tag",
+		MaxCapacity:    1000,
 	}
 	log := logger.New(true)
 	tfDomain := NewFrequencyFilteringTransform(cfgDomain, log, "test", 0, nil)
@@ -159,16 +163,17 @@ func TestFrequencyFiltering_TrackByDomainAndIP(t *testing.T) {
 	dm.DNS.Qname = "sub2.target.com"
 	filterDomain(&dm)
 
-	if dm.Frequency.Count != 2 || dm.Frequency.TrackedKey != "target.com" {
-		t.Fatalf("expected domain tracking for target.com, got count=%d, key=%s", dm.Frequency.Count, dm.Frequency.TrackedKey)
+	if dm.Frequency.Count != 2 || dm.Frequency.Target != "target.com" || dm.Frequency.Tier != "heavy" {
+		t.Fatalf("expected domain tracking for target.com, got count=%d, target=%s, tier=%s", dm.Frequency.Count, dm.Frequency.Target, dm.Frequency.Tier)
 	}
 
-	// IP track
+	// Client IP track
 	cfgIP := &config.TransformFrequencyFiltering{
-		Enable:    true,
-		TrackBy:   "query-ip",
-		Threshold: 1,
-		Capacity:  1000,
+		Enable:         true,
+		Target:         "client-ip",
+		ThresholdHeavy: 1,
+		ActionOnHeavy:  "tag",
+		MaxCapacity:    1000,
 	}
 	tfIP := NewFrequencyFilteringTransform(cfgIP, log, "test", 0, nil)
 	defer tfIP.Stop()
@@ -180,18 +185,19 @@ func TestFrequencyFiltering_TrackByDomainAndIP(t *testing.T) {
 	dmIP.NetworkInfo.QueryIP = "192.0.2.1"
 	filterIP(&dmIP)
 
-	if dmIP.Frequency.TrackedKey != "192.0.2.1" || dmIP.Frequency.Count != 1 {
+	if dmIP.Frequency.Target != "192.0.2.1" || dmIP.Frequency.Count != 1 || dmIP.Frequency.Tier != "rare" {
 		t.Fatalf("expected IP tracking for 192.0.2.1, got %+v", dmIP.Frequency)
 	}
 }
 
 func TestFrequencyFiltering_Decay(t *testing.T) {
 	cfg := &config.TransformFrequencyFiltering{
-		Enable:        true,
-		TrackBy:       "qname",
-		Threshold:     10,
-		WindowSeconds: 1, // 1 second decay
-		Capacity:      1000,
+		Enable:         true,
+		Target:         "qname",
+		ThresholdHeavy: 10,
+		TTL:            1, // 1 second decay
+		ActionOnHeavy:  "tag",
+		MaxCapacity:    1000,
 	}
 	log := logger.New(true)
 	tf := NewFrequencyFilteringTransform(cfg, log, "test", 0, nil)

--- a/transformers/transformers.go
+++ b/transformers/transformers.go
@@ -110,6 +110,8 @@ func NewTransforms(cfg *config.ConfigTransformers, logger *logger.Logger, name s
 			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewReducerTransform(&cfg.Reducer, logger, name, instance, nextWorkers)})
 		case "reordering":
 			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewReorderingTransform(&cfg.Reordering, logger, name, instance, nextWorkers)})
+		case "frequency-filtering":
+			d.availableTransforms = append(d.availableTransforms, TransformEntry{NewFrequencyFilteringTransform(&cfg.FrequencyFiltering, logger, name, instance, nextWorkers)})
 		default:
 			d.LogError("unknown transformer name in order list: %s", nameTransform)
 		}


### PR DESCRIPTION
This PR introduces the new **`frequency-filtering`** transformer powered by an ultra-fast, concurrent **Counting Cuckoo Filter** in `pkg/cuckoo`.

It enables real-time frequency estimation, heavy-hitter / top-talker detection, intelligent log downsampling, and dynamic rate-limiting across streaming DNS traffic.

Main purpose: Preserves 100% of rare/novel events while aggressively downsampling noisy top-talkers (heavy hitters).

Configuration

```yaml
pipelines:
  - name: siem-downsampling
    transforms:
      frequency-filtering:
        target: "qname"                 # "qname", "domain", or "client-ip"
        threshold-heavy: 1000           # Hits before considered heavy hitter
        action-on-heavy: "sample"       # "drop", "sample", or "tag"
        sample-rate: 100                # Keep 1 in 100 when action is sample
        ttl: 300                        # Sliding window decay in seconds
        max-capacity: 500000            # Bounded filter capacity
    routing-policy:
      forward: [ "stdout" ]
```

