### PR TITLE
perf(dnsutils): add zero-allocation IPv6 formatting

### DIFF
--- a/dnsutils/dns_parser.go
+++ b/dnsutils/dns_parser.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"strings"
 
 	"github.com/dmachard/go-dnscollector/v3/pkg/config"
@@ -103,6 +104,9 @@ func DnstapOperationToString(op int) string {
 
 func FastIPv4ToString(ip []byte) string {
 	if len(ip) != 4 {
+		if len(ip) == 16 {
+			return FastIPv6ToString(ip)
+		}
 		return net.IP(ip).String()
 	}
 	var buf [15]byte
@@ -129,6 +133,27 @@ func FastIPv4ToString(ip []byte) string {
 		n++
 	}
 	return string(buf[:n])
+}
+
+// FastIPv6ToString converts a 16-byte IPv6 slice to string with zero intermediate heap allocations.
+func FastIPv6ToString(ip []byte) string {
+	if len(ip) != 16 {
+		return net.IP(ip).String()
+	}
+	addr := netip.AddrFrom16([16]byte(ip))
+	return addr.String()
+}
+
+// FastIPToString converts an IPv4 (4-byte) or IPv6 (16-byte) slice to string.
+func FastIPToString(ip []byte) string {
+	switch len(ip) {
+	case 4:
+		return FastIPv4ToString(ip)
+	case 16:
+		return FastIPv6ToString(ip)
+	default:
+		return net.IP(ip).String()
+	}
 }
 
 // WriteIPv4 formats a 4-byte IPv4 slice directly into a bytes.Buffer without any heap allocation.
@@ -163,13 +188,25 @@ func WriteIPv4(buf *bytes.Buffer, ip []byte) {
 	buf.Write(tmp[:n])
 }
 
+// WriteIPv6 formats a 16-byte IPv6 slice directly into a bytes.Buffer without any heap allocation.
+func WriteIPv6(buf *bytes.Buffer, ip []byte) {
+	if len(ip) != 16 {
+		buf.WriteString(net.IP(ip).String())
+		return
+	}
+	var tmp [40]byte
+	addr := netip.AddrFrom16([16]byte(ip))
+	b := addr.AppendTo(tmp[:0])
+	buf.Write(b)
+}
+
 // WriteIP writes an IPv4 or IPv6 byte slice into a bytes.Buffer without heap allocation.
 func WriteIP(buf *bytes.Buffer, ip []byte) {
 	switch len(ip) {
 	case 4:
 		WriteIPv4(buf, ip)
 	case 16:
-		buf.WriteString(net.IP(ip).String())
+		WriteIPv6(buf, ip)
 	default:
 		if len(ip) > 0 {
 			buf.WriteString(net.IP(ip).String())

--- a/dnsutils/dns_parser_bench_test.go
+++ b/dnsutils/dns_parser_bench_test.go
@@ -1,6 +1,7 @@
 package dnsutils
 
 import (
+	"bytes"
 	"net"
 	"testing"
 	"time"
@@ -173,6 +174,46 @@ func Benchmark_FastIPv4ToString(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_ = FastIPv4ToString(ip)
+	}
+}
+
+func Benchmark_IPv6_NetIPString(b *testing.B) {
+	ip := net.ParseIP("2001:db8:85a3::8a2e:370:7334")
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = ip.String()
+	}
+}
+
+func Benchmark_FastIPv6ToString(b *testing.B) {
+	ip := []byte{0x20, 0x01, 0x0d, 0xb8, 0x85, 0xa3, 0, 0, 0, 0, 0x8a, 0x2e, 0x03, 0x70, 0x73, 0x34}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = FastIPv6ToString(ip)
+	}
+}
+
+func Benchmark_WriteIP_IPv4(b *testing.B) {
+	ip := []byte{192, 168, 1, 100}
+	var buf bytes.Buffer
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		WriteIP(&buf, ip)
+	}
+}
+
+func Benchmark_WriteIP_IPv6(b *testing.B) {
+	ip := []byte{0x20, 0x01, 0x0d, 0xb8, 0x85, 0xa3, 0, 0, 0, 0, 0x8a, 0x2e, 0x03, 0x70, 0x73, 0x34}
+	var buf bytes.Buffer
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		WriteIP(&buf, ip)
 	}
 }
 

--- a/dnsutils/dns_parser_test.go
+++ b/dnsutils/dns_parser_test.go
@@ -155,3 +155,42 @@ func TestWriteIP(t *testing.T) {
 		})
 	}
 }
+
+func TestFastIPv6ToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"Loopback", "::1", "::1"},
+		{"All zeros", "::", "::"},
+		{"Google DNS", "2001:4860:4860::8888", "2001:4860:4860::8888"},
+		{"Cloudflare DNS", "2606:4700:4700::1111", "2606:4700:4700::1111"},
+		{"Link local", "fe80::1", "fe80::1"},
+		{"Complex", "2001:db8:85a3::8a2e:370:7334", "2001:db8:85a3::8a2e:370:7334"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.input).To16()
+			got := FastIPv6ToString(ip)
+			if got != tt.expected {
+				t.Errorf("FastIPv6ToString(%s) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFastIPToString(t *testing.T) {
+	// IPv4
+	ipv4 := []byte{192, 168, 1, 1}
+	if got := FastIPToString(ipv4); got != "192.168.1.1" {
+		t.Errorf("FastIPToString(IPv4) = %q, want %q", got, "192.168.1.1")
+	}
+
+	// IPv6
+	ipv6 := net.ParseIP("2001:4860:4860::8888").To16()
+	if got := FastIPToString(ipv6); got != "2001:4860:4860::8888" {
+		t.Errorf("FastIPToString(IPv6) = %q, want %q", got, "2001:4860:4860::8888")
+	}
+}

--- a/dnsutils/dnsmessage.go
+++ b/dnsutils/dnsmessage.go
@@ -51,14 +51,14 @@ type DNSNetInfo struct {
 
 func (net *DNSNetInfo) GetQueryIP() string {
 	if net.QueryIP == "-" && net.QueryIPLen > 0 {
-		net.QueryIP = FastIPv4ToString(net.QueryIPBuf[:net.QueryIPLen])
+		net.QueryIP = FastIPToString(net.QueryIPBuf[:net.QueryIPLen])
 	}
 	return net.QueryIP
 }
 
 func (net *DNSNetInfo) GetResponseIP() string {
 	if net.ResponseIP == "-" && net.ResponseIPLen > 0 {
-		net.ResponseIP = FastIPv4ToString(net.ResponseIPBuf[:net.ResponseIPLen])
+		net.ResponseIP = FastIPToString(net.ResponseIPBuf[:net.ResponseIPLen])
 	}
 	return net.ResponseIP
 }


### PR DESCRIPTION
## 🎯 Description

This PR introduces zero-allocation IPv6 buffer formatting and unified fast IP string helpers in `dnsutils`, eliminating heap allocations on the hot serialization path for all IPv6 traffic.

### 🔍 Background & Problem
Previously, while IPv4 addresses benefited from a dedicated stack-based formatter (`WriteIPv4`), IPv6 serialization in `WriteIP` and `FastIPv4ToString` fell back to `net.IP(ip).String()`. For high-throughput DNS pipelines handling IPv6 traffic (DNStap, AFPacket, etc.), this created an intermediate 32-byte heap allocation per DNS message during text/JSON buffer writing, generating unnecessary GC pressure under high traffic.

---

## ⚡ Key Changes

- **`WriteIPv6(buf *bytes.Buffer, ip []byte)`**: Implemented stack-buffered (`var tmp [40]byte`) direct IPv6 formatting with zero heap allocations.
- **`WriteIP(buf *bytes.Buffer, ip []byte)`**: Updated to route 16-byte slices through `WriteIPv6`, achieving **0 B/op and 0 allocs/op** for both IPv4 and IPv6.
- **`FastIPv6ToString(ip []byte)` & `FastIPToString(ip []byte)`**: Added unified fast IP-to-string conversion helpers supporting transparent 4-byte and 16-byte inputs.
- **`DNSNetInfo.GetQueryIP()` & `GetResponseIP()`**: Updated to use `FastIPToString`.
- **Unit Tests & Benchmarks**: Added RFC 5952 compliance test cases (loopback, compressed zero runs `::`, link-local, dual-stack public resolvers) and side-by-side microbenchmarks in `dns_parser_bench_test.go`.

---

## 📊 Benchmark Results

```bash
goos: linux
goarch: amd64
pkg: github.com/dmachard/go-dnscollector/v3/dnsutils
cpu: AMD Ryzen 9 9900X 12-Core Processor

Benchmark_WriteIP_IPv4-24          156650888          7.65 ns/op        0 B/op        0 allocs/op
Benchmark_WriteIP_IPv6-24           37650247         31.68 ns/op        0 B/op        0 allocs/op
Benchmark_FastIPv6ToString-24       30129642         39.30 ns/op       32 B/op        1 allocs/op
