### PR TITLE
perf(dnsutils): eliminate heap allocations in PCAP and DNSTap IP parsing using netip.ParseAddr

### DIFF
--- a/dnsutils/dns_parser.go
+++ b/dnsutils/dns_parser.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"strings"
 
 	"github.com/dmachard/go-dnscollector/v3/pkg/config"
@@ -103,6 +104,9 @@ func DnstapOperationToString(op int) string {
 
 func FastIPv4ToString(ip []byte) string {
 	if len(ip) != 4 {
+		if len(ip) == 16 {
+			return FastIPv6ToString(ip)
+		}
 		return net.IP(ip).String()
 	}
 	var buf [15]byte
@@ -129,6 +133,27 @@ func FastIPv4ToString(ip []byte) string {
 		n++
 	}
 	return string(buf[:n])
+}
+
+// FastIPv6ToString converts a 16-byte IPv6 slice to string with zero intermediate heap allocations.
+func FastIPv6ToString(ip []byte) string {
+	if len(ip) != 16 {
+		return net.IP(ip).String()
+	}
+	addr := netip.AddrFrom16([16]byte(ip))
+	return addr.String()
+}
+
+// FastIPToString converts an IPv4 (4-byte) or IPv6 (16-byte) slice to string.
+func FastIPToString(ip []byte) string {
+	switch len(ip) {
+	case 4:
+		return FastIPv4ToString(ip)
+	case 16:
+		return FastIPv6ToString(ip)
+	default:
+		return net.IP(ip).String()
+	}
 }
 
 // WriteIPv4 formats a 4-byte IPv4 slice directly into a bytes.Buffer without any heap allocation.
@@ -163,13 +188,25 @@ func WriteIPv4(buf *bytes.Buffer, ip []byte) {
 	buf.Write(tmp[:n])
 }
 
+// WriteIPv6 formats a 16-byte IPv6 slice directly into a bytes.Buffer without any heap allocation.
+func WriteIPv6(buf *bytes.Buffer, ip []byte) {
+	if len(ip) != 16 {
+		buf.WriteString(net.IP(ip).String())
+		return
+	}
+	var tmp [40]byte
+	addr := netip.AddrFrom16([16]byte(ip))
+	b := addr.AppendTo(tmp[:0])
+	buf.Write(b)
+}
+
 // WriteIP writes an IPv4 or IPv6 byte slice into a bytes.Buffer without heap allocation.
 func WriteIP(buf *bytes.Buffer, ip []byte) {
 	switch len(ip) {
 	case 4:
 		WriteIPv4(buf, ip)
 	case 16:
-		buf.WriteString(net.IP(ip).String())
+		WriteIPv6(buf, ip)
 	default:
 		if len(ip) > 0 {
 			buf.WriteString(net.IP(ip).String())

--- a/dnsutils/dns_parser.go
+++ b/dnsutils/dns_parser.go
@@ -907,7 +907,7 @@ func ParseIP(r []byte, size int) (string, error) {
 
 		return string(buf[:n]), nil
 	}
-	return net.IP(r[:size]).String(), nil
+	return FastIPv6ToString(r[:size]), nil
 }
 
 /*

--- a/dnsutils/dns_parser_bench_test.go
+++ b/dnsutils/dns_parser_bench_test.go
@@ -1,6 +1,7 @@
 package dnsutils
 
 import (
+	"bytes"
 	"net"
 	"testing"
 	"time"
@@ -173,6 +174,46 @@ func Benchmark_FastIPv4ToString(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_ = FastIPv4ToString(ip)
+	}
+}
+
+func Benchmark_IPv6_NetIPString(b *testing.B) {
+	ip := net.ParseIP("2001:db8:85a3::8a2e:370:7334")
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = ip.String()
+	}
+}
+
+func Benchmark_FastIPv6ToString(b *testing.B) {
+	ip := []byte{0x20, 0x01, 0x0d, 0xb8, 0x85, 0xa3, 0, 0, 0, 0, 0x8a, 0x2e, 0x03, 0x70, 0x73, 0x34}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = FastIPv6ToString(ip)
+	}
+}
+
+func Benchmark_WriteIP_IPv4(b *testing.B) {
+	ip := []byte{192, 168, 1, 100}
+	var buf bytes.Buffer
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		WriteIP(&buf, ip)
+	}
+}
+
+func Benchmark_WriteIP_IPv6(b *testing.B) {
+	ip := []byte{0x20, 0x01, 0x0d, 0xb8, 0x85, 0xa3, 0, 0, 0, 0, 0x8a, 0x2e, 0x03, 0x70, 0x73, 0x34}
+	var buf bytes.Buffer
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		WriteIP(&buf, ip)
 	}
 }
 

--- a/dnsutils/dns_parser_test.go
+++ b/dnsutils/dns_parser_test.go
@@ -155,3 +155,42 @@ func TestWriteIP(t *testing.T) {
 		})
 	}
 }
+
+func TestFastIPv6ToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"Loopback", "::1", "::1"},
+		{"All zeros", "::", "::"},
+		{"Google DNS", "2001:4860:4860::8888", "2001:4860:4860::8888"},
+		{"Cloudflare DNS", "2606:4700:4700::1111", "2606:4700:4700::1111"},
+		{"Link local", "fe80::1", "fe80::1"},
+		{"Complex", "2001:db8:85a3::8a2e:370:7334", "2001:db8:85a3::8a2e:370:7334"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.input).To16()
+			got := FastIPv6ToString(ip)
+			if got != tt.expected {
+				t.Errorf("FastIPv6ToString(%s) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFastIPToString(t *testing.T) {
+	// IPv4
+	ipv4 := []byte{192, 168, 1, 1}
+	if got := FastIPToString(ipv4); got != "192.168.1.1" {
+		t.Errorf("FastIPToString(IPv4) = %q, want %q", got, "192.168.1.1")
+	}
+
+	// IPv6
+	ipv6 := net.ParseIP("2001:4860:4860::8888").To16()
+	if got := FastIPToString(ipv6); got != "2001:4860:4860::8888" {
+		t.Errorf("FastIPToString(IPv6) = %q, want %q", got, "2001:4860:4860::8888")
+	}
+}

--- a/dnsutils/dnsmessage.go
+++ b/dnsutils/dnsmessage.go
@@ -51,14 +51,14 @@ type DNSNetInfo struct {
 
 func (net *DNSNetInfo) GetQueryIP() string {
 	if net.QueryIP == "-" && net.QueryIPLen > 0 {
-		net.QueryIP = FastIPv4ToString(net.QueryIPBuf[:net.QueryIPLen])
+		net.QueryIP = FastIPToString(net.QueryIPBuf[:net.QueryIPLen])
 	}
 	return net.QueryIP
 }
 
 func (net *DNSNetInfo) GetResponseIP() string {
 	if net.ResponseIP == "-" && net.ResponseIPLen > 0 {
-		net.ResponseIP = FastIPv4ToString(net.ResponseIPBuf[:net.ResponseIPLen])
+		net.ResponseIP = FastIPToString(net.ResponseIPBuf[:net.ResponseIPLen])
 	}
 	return net.ResponseIP
 }

--- a/dnsutils/dnsmessage_dnstap.go
+++ b/dnsutils/dnsmessage_dnstap.go
@@ -2,7 +2,7 @@ package dnsutils
 
 import (
 	"errors"
-	"net"
+	"net/netip"
 	"strconv"
 
 	dnstap "github.com/dmachard/go-dnstap-protobuf"
@@ -58,14 +58,20 @@ func (dm *DNSMessage) ToDNSTap(extended bool) ([]byte, error) {
 	msg.SocketFamily = &sf
 	msg.SocketProtocol = &sp
 
+	var reqIP4, rspIP4 [4]byte
+	var reqIP16, rspIP16 [16]byte
+
 	if dm.NetworkInfo.QueryIPLen > 0 {
 		msg.QueryAddress = dm.NetworkInfo.QueryIPBuf[:dm.NetworkInfo.QueryIPLen]
 	} else if dm.NetworkInfo.QueryIP != "-" {
-		reqIP := net.ParseIP(dm.NetworkInfo.GetQueryIP())
-		if dm.NetworkInfo.Family == netutils.ProtoIPv4 {
-			msg.QueryAddress = reqIP.To4()
-		} else {
-			msg.QueryAddress = reqIP.To16()
+		if addr, err := netip.ParseAddr(dm.NetworkInfo.GetQueryIP()); err == nil {
+			if addr.Is4() {
+				reqIP4 = addr.As4()
+				msg.QueryAddress = reqIP4[:]
+			} else {
+				reqIP16 = addr.As16()
+				msg.QueryAddress = reqIP16[:]
+			}
 		}
 	}
 	msg.QueryPort = &qport
@@ -73,11 +79,14 @@ func (dm *DNSMessage) ToDNSTap(extended bool) ([]byte, error) {
 	if dm.NetworkInfo.ResponseIPLen > 0 {
 		msg.ResponseAddress = dm.NetworkInfo.ResponseIPBuf[:dm.NetworkInfo.ResponseIPLen]
 	} else if dm.NetworkInfo.ResponseIP != "-" {
-		rspIP := net.ParseIP(dm.NetworkInfo.GetResponseIP())
-		if dm.NetworkInfo.Family == netutils.ProtoIPv4 {
-			msg.ResponseAddress = rspIP.To4()
-		} else {
-			msg.ResponseAddress = rspIP.To16()
+		if addr, err := netip.ParseAddr(dm.NetworkInfo.GetResponseIP()); err == nil {
+			if addr.Is4() {
+				rspIP4 = addr.As4()
+				msg.ResponseAddress = rspIP4[:]
+			} else {
+				rspIP16 = addr.As16()
+				msg.ResponseAddress = rspIP16[:]
+			}
 		}
 	}
 	msg.ResponsePort = &rport

--- a/dnsutils/dnsmessage_pcap.go
+++ b/dnsutils/dnsmessage_pcap.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math"
 	"net"
+	"net/netip"
 
 	"github.com/dmachard/go-netutils"
 	"github.com/google/gopacket"
@@ -46,15 +47,11 @@ func parseIPv4Bytes(s string, dst *[4]byte) bool {
 }
 
 func parseIPv6Bytes(s string, dst *[16]byte) bool {
-	ip := net.ParseIP(s)
-	if ip == nil {
+	addr, err := netip.ParseAddr(s)
+	if err != nil || !addr.Is6() {
 		return false
 	}
-	ip6 := ip.To16()
-	if ip6 == nil {
-		return false
-	}
-	copy(dst[:], ip6)
+	*dst = addr.As16()
 	return true
 }
 
@@ -141,18 +138,18 @@ func (dm *DNSMessage) EncodeToPacketBytes(dst []byte, overwritePort bool) ([]byt
 
 	if isIPv4 {
 		if !parseIPv4Bytes(srcIPStr, &srcIP4) {
-			ip := net.ParseIP(srcIPStr).To4()
-			if ip == nil {
+			addr, err := netip.ParseAddr(srcIPStr)
+			if err != nil || !addr.Is4() {
 				return dst, errInvalidIPAddress
 			}
-			copy(srcIP4[:], ip)
+			srcIP4 = addr.As4()
 		}
 		if !parseIPv4Bytes(dstIPStr, &dstIP4) {
-			ip := net.ParseIP(dstIPStr).To4()
-			if ip == nil {
+			addr, err := netip.ParseAddr(dstIPStr)
+			if err != nil || !addr.Is4() {
 				return dst, errInvalidIPAddress
 			}
-			copy(dstIP4[:], ip)
+			dstIP4 = addr.As4()
 		}
 	} else {
 		if !parseIPv6Bytes(srcIPStr, &srcIP6) {


### PR DESCRIPTION
This PR replaces residual `net.ParseIP()` calls with zero-allocation `netip.ParseAddr()` stack-based parsing in `dnsutils/dnsmessage_pcap.go` and `dnsutils/dnsmessage_dnstap.go`.
