### PR TITLE
fix(docker): set root workdir and copy passwd/group to fix permission denied

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,14 @@ FROM gcr.io/distroless/static-debian13:nonroot
 # Runtime directories
 COPY --from=builder --chown=1000:1000 /rootfs/etc/dnscollector /etc/dnscollector
 COPY --from=builder --chown=1000:1000 /rootfs/var/dnscollector /var/dnscollector
+COPY --from=builder /rootfs/etc/passwd /etc/passwd
+COPY --from=builder /rootfs/etc/group /etc/group
 
 # Binary and default config
 COPY --from=builder /build/dnscollector /bin/dnscollector
 COPY --from=builder /build/docker-config.yml /etc/dnscollector/config.yml
+
+WORKDIR /
 
 USER 1000
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -32,5 +32,45 @@ docker compose up -d
 Docker run with a custom configuration:
 
 ```bash
-docker run -d dmachard/dnscollector -v $(pwd)/config.yml:/etc/dnscollector/config.yml
+docker run -d -v $(pwd)/config.yml:/etc/dnscollector/config.yml dmachard/dnscollector
 ```
+
+## Running with Podman (Rootless)
+
+The official container image runs as a non-root user (`UID 1000` / `GID 1000`).
+
+### Volume Permissions
+
+In rootless Podman, your host user is mapped to container `UID 0` by default, while container `UID 1000` maps to a subordinate UID (`subuid`). To ensure the container can read and write mounted volumes, use `--userns=keep-id`:
+
+```bash
+podman run -d \
+  --userns=keep-id:uid=1000,gid=1000 \
+  -v $(pwd)/config.yml:/etc/dnscollector/config.yml:ro,z \
+  -v ./data:/var/dnscollector:z \
+  dmachard/dnscollector
+```
+
+> **Note:** The `:z` flag configures SELinux volume relabeling when running on distributions like Fedora, RHEL, or Rocky Linux.
+
+### User Namespaces Range (`--userns=auto`)
+
+When using automatic user namespaces (`--userns=auto`), ensure that the allocated namespace size is at least **1024** so that `UID 1000` is mapped inside the container:
+
+```bash
+podman run -d --userns=auto:size=1024 dmachard/dnscollector
+```
+
+### Privileged Ports (< 1024)
+
+In rootless environments, binding directly to privileged ports (such as DNS port `53`) requires kernel permission. You can either:
+
+- Allow unprivileged binding on the host:
+  ```bash
+  sudo sysctl -w net.ipv4.ip_unprivileged_port_start=53
+  ```
+- Or map an unprivileged host port to the container port:
+  ```bash
+  podman run -d -p 5353:53/udp -p 5353:53/tcp dmachard/dnscollector
+  ```
+


### PR DESCRIPTION
Fixes #1353

Set `WORKDIR /` in the runtime stage to avoid inheriting distroless's default `/home/nonroot`, which causes OCI permission denied errors when running under restricted user namespaces (e.g. Podman `--userns=auto:size=1024`).

