### PR TITLE
fix(workers): resolve missing IPs and timestamps in JSON mode (#1362)

### DIFF
--- a/workers/logfile_test.go
+++ b/workers/logfile_test.go
@@ -348,4 +348,3 @@ func Test_LogFile_JSON_DNSTap_Fields(t *testing.T) {
 		t.Errorf("expected RFC3339 timestamp, got: %s", contentStr)
 	}
 }
-

--- a/workers/stdout_test.go
+++ b/workers/stdout_test.go
@@ -338,4 +338,3 @@ func Test_Stdout_JSON_DNSTap_Fields(t *testing.T) {
 		t.Errorf("expected RFC3339 timestamp, got: %s", contentStr)
 	}
 }
-


### PR DESCRIPTION
Fixes #1362 where `network.query-ip`, `network.response-ip`, and `dnstap.timestamp-rfc3339ns` were emitted as `"-"` in nested `mode: json`.

Regression because of  zero-allocation IP decoding and lazy timestamp formatting.
