### PR TITLE
chore(build): add Go 1.27 support and update CI matrix (#1364)

### DIFF
--- a/.github/workflows/bench-go.yml
+++ b/.github/workflows/bench-go.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os-version: [ 'ubuntu-26.04' ]
-        go-version: ['1.26'  ]
+        go-version: ['1.26', '1.27']
     runs-on: ${{ matrix.os-version }}
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     
     strategy:
       matrix:
-        go-version: ['1.26']
+        go-version: ['1.26', '1.27']
 
     steps:
       - uses: actions/checkout@v7
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-26.04, macos-latest, windows-latest]
-        go-version: ['1.26']
+        go-version: ['1.26', '1.27']
         goos: [linux, freebsd, darwin, windows]
         exclude:
           - { os: macos-latest, goos: linux }

--- a/.github/workflows/testing-go.yml
+++ b/.github/workflows/testing-go.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         os-version: [ 'ubuntu-26.04' ]
-        go-version: [ '1.26' ] 
+        go-version: [ '1.26', '1.27' ] 
         package:
           - '.'
           - 'pkg/config'


### PR DESCRIPTION
Adds Go 1.27 to the CI test and build matrices alongside Go 1.26, ensuring compatibility with the latest Go release while maintaining baseline support for Go 1.26.