### PR TITLE
Close gzip writer when bulk compression fails

### DIFF
--- a/workers/elasticsearch.go
+++ b/workers/elasticsearch.go
@@ -281,6 +281,7 @@ func (w *ElasticSearchClient) sendCompressedBulk(bulk []byte) error {
 	gzipWriter := gzip.NewWriter(&compressedBulk)
 	_, err := gzipWriter.Write(bulk)
 	if err != nil {
+		gzipWriter.Close()
 		return err
 	}
 	err = gzipWriter.Close()

--- a/workers/elasticsearch.go
+++ b/workers/elasticsearch.go
@@ -281,7 +281,7 @@ func (w *ElasticSearchClient) sendCompressedBulk(bulk []byte) error {
 	gzipWriter := gzip.NewWriter(&compressedBulk)
 	_, err := gzipWriter.Write(bulk)
 	if err != nil {
-		gzipWriter.Close()
+		_ = gzipWriter.Close()
 		return err
 	}
 	err = gzipWriter.Close()


### PR DESCRIPTION
The gzip writer in `sendCompressedBulk` is abandoned without being closed when the write fails. This PR closes it on that error path.

Testing: `go test -race ./workers -run '^Test_ElasticSearchClient'` passes.

I found this issue through a static analysis tool I'm developing called [gohawk](https://github.com/kojah/gohawk). If you're interested, let me know and I can open a separate PR to add gohawk to your linter configuration :) You can view more comprehensive information about the project on the documentation website: [https://gohawk.dev](https://gohawk.dev)